### PR TITLE
Add High DPI text rendering support for Mac OSX.

### DIFF
--- a/src/app.plist
+++ b/src/app.plist
@@ -55,5 +55,9 @@
 	<string>SqLB</string>
 	<key>CFBundleVersion</key>
 	<string>3.1</string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
For text render, adding 'NSHighResolutionCapable' key into plist fixes
high-dpi display
