### PR TITLE
Fixed a problem with the import of .csv-files

### DIFF
--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -898,16 +898,18 @@ QStringList DBBrowserDB::decodeCSV(const QString & csvfilename, char sep, char q
                     result << current;
                     current = "";
                 }
-            } else if (c==10) {
+            } else if (c==10 || c==13) {
                 if (inquotemode){
-                    //add the newline
+                    //add the newline/carrier return
                     current.append(c);
                 }
-            } else if (c==13) {
-                if (inquotemode){
-                    //add the carrier return if in quote mode only
-                    current.append(c);
-                }
+            } else if (c==32) {
+              
+              // Only append blanks if we are inside of quotes
+              if (inquotemode) {
+                current.append(c);
+              }
+
             } else {//another character type
                 current.append(c);
             }


### PR DESCRIPTION
Up until now, the DBBrowserDB:decodeCSV used to load the csv-file character by character using the getChar() method of the QFile-class.
Unfortunatelly, this approach caused multibyte-chars as used for UTF-8 encoding to be split and displayed incorrectly.

The fix uses the QTextStream-class to load the file line by line.
Every line is then again iterated character by character, before the old algorithm is applied. Using this approach, the characters are loaded and encoded properly. Splitting multibyte-chars is thus prevented.
