### PR TITLE
Update BUILDING.md by specifing path for cmake

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -11,7 +11,7 @@ depending on the current Qt configuration on the building machine.
 
 Provided you have Qt and cmake installed and configured, simply run
 
-    $ cmake
+    $ cmake .
 
 followed by
 


### PR DESCRIPTION
Being in the root directory cmake needed a path for the CMakeLists.txt - otherwise cmake won't run

(Tested on my ubuntu 14.04)
