### PR TITLE
Test fixes

### DIFF
--- a/src/tests/testsqlobjects.cpp
+++ b/src/tests/testsqlobjects.cpp
@@ -87,7 +87,7 @@ void TestTable::parseSQL()
     Table tab = Table::parseSQL(sSQL).first;
 
     QVERIFY(tab.name() == "hero");
-    QVERIFY(tab.rowidColumn() == "rowid");
+    QVERIFY(tab.rowidColumn() == "_rowid_");
     QVERIFY(tab.fields().at(0)->name() == "id");
     QVERIFY(tab.fields().at(1)->name() == "name");
     QVERIFY(tab.fields().at(2)->name() == "info");


### PR DESCRIPTION
First commit fixes the test file failing to compile (cannot assign `QPair<Table,bool>` to `Table`).

Second commit updates the test for commit 55678bb9450a0546835b2d86f5124e7efb0a1109

There is still one failing test:

```
FAIL!  : TestTable::createTableWithNotLikeConstraint() 'tab.fields().at(0)->check() == "value NOT LIKE 'prefix%'"' returned FALSE. ()
Loc: [/builddir/build/BUILD/sqlitebrowser-3.3.0/src/tests/testsqlobjects.cpp(244)]
```
