### PR TITLE
Install icon to hicolor directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ install(TARGETS ${PROJECT_NAME}
 	
 if(UNIX AND NOT APPLE)
 install(FILES src/icons/${PROJECT_NAME}.png
-	DESTINATION share/pixmaps/)
+	DESTINATION share/icons/hicolor/256x256/apps/)
 	
 install(FILES distri/${PROJECT_NAME}.desktop
 	DESTINATION share/applications/)


### PR DESCRIPTION
Trivial patch: Application icons should be installed inside the `hicolor/<size>/apps` folder, see [1].

[1] http://standards.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#install_icons
