### PR TITLE
tests: fix QCoreApplication parameters

### DIFF
--- a/src/tests/TestImport.cpp
+++ b/src/tests/TestImport.cpp
@@ -14,9 +14,9 @@ TestImport::TestImport()
     // Init basic application
     // The app needs to be initialized for the utf8 test
     // to work
-    int argcount = 1;
-    const char* appname = "sqlb-unittests";
-    app = new QCoreApplication(argcount, const_cast<char**>(&appname));
+    argcount = 1;
+    args[0] = "sqlb-unittests";
+    app = new QCoreApplication(argcount, args);
 }
 
 TestImport::~TestImport()

--- a/src/tests/TestImport.h
+++ b/src/tests/TestImport.h
@@ -13,6 +13,8 @@ public:
     ~TestImport();
 
 private:
+    int argcount;
+    char *args[1]; // the size must match what 'argcount' is set to
     QCoreApplication* app;
 
 private slots:


### PR DESCRIPTION
The argument count (first parameter) is a reference, and thus must be kept alive for the whole lifetime of the QCoreApplication instance, as also the Qt apidocs say.

Also properly create a "string array" for the actual args, instead of badly casting a string to that.

This fixes sporadic crashes in this test, for example as seen for some architectures in the Debian build of 3.4.0: https://buildd.debian.org/status/logs.php?pkg=sqlitebrowser&ver=3.4.0-1 & http://buildd.debian-ports.org/status/logs.php?pkg=sqlitebrowser&ver=3.4.0-1 (click on texts in the "Result" column to see the logs).