### PR TITLE
Sqlitebrowser entry not listing in desktop menus

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,13 +248,13 @@ install(TARGETS ${PROJECT_NAME}
 	
 if(UNIX AND NOT APPLE)
 install(FILES src/icons/${PROJECT_NAME}.png
-	DESTINATION share/icons/hicolor/256x256/apps/)
+	DESTINATION /usr/share/icons/hicolor/256x256/apps/)
 	
 install(FILES distri/${PROJECT_NAME}.desktop
-	DESTINATION share/applications/)
+	DESTINATION /usr/share/applications/)
 
 install(FILES distri/${PROJECT_NAME}.desktop.appdata.xml
-	DESTINATION share/appdata/)
+	DESTINATION /usr/share/appdata/)
 endif(UNIX AND NOT APPLE)
 
 #cpack


### PR DESCRIPTION
Desktop shortcuts were being copy to /usr/local/share/ instead of /usr/share/. According to the FreeDesktop.org specification (see http://standards.freedesktop.org/menu-spec/latest/ar01s02.html) it should not be a problem since it uses $XDG_DATA_DIRS environment variable, but it does not really work in GNOME. In their help files (see https://developer.gnome.org/integration-guide/stable/desktop-files.html.en) they guide developers to drop desktop files in /usr/share/ or ~/.local/share/.