### PR TITLE
exportsql: issue #242

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,7 @@ set(SQLB_MOC_HDR
 	src/DbStructureModel.h
 	src/Application.h
 	src/CipherDialog.h
+	src/ExportSqlDialog.h
 )
 
 set(SQLB_SRC
@@ -83,6 +84,7 @@ set(SQLB_SRC
 	src/main.cpp
 	src/Application.cpp
 	src/CipherDialog.cpp
+	src/ExportSqlDialog.cpp
 )
 
 set(SQLB_FORMS
@@ -97,6 +99,7 @@ set(SQLB_FORMS
 	src/SqlExecutionArea.ui
 	src/VacuumDialog.ui
 	src/CipherDialog.ui
+	src/ExportSqlDialog.ui
 )
 
 set(SQLB_RESOURCES

--- a/src/ExportSqlDialog.cpp
+++ b/src/ExportSqlDialog.cpp
@@ -1,0 +1,95 @@
+#include "ExportSqlDialog.h"
+#include "ui_ExportSqlDialog.h"
+#include "sqlitedb.h"
+#include "PreferencesDialog.h"
+#include "sqlitetablemodel.h"
+#include "sqlite.h"
+
+#include <QFile>
+#include <QMessageBox>
+#include <QFileDialog>
+#include <QSettings>
+
+static QString sSettingsGroup("exportsql");
+static QString sSettingsInsertColNames("insertcolnames");
+static QString sSettingsInsertMultiply("insertmultiply");
+
+ExportSqlDialog::ExportSqlDialog(DBBrowserDB* db, QWidget* parent, const QString& selection)
+    : QDialog(parent),
+      ui(new Ui::ExportSqlDialog),
+      pdb(db)
+{
+    // Create UI
+    ui->setupUi(this);
+
+    QSettings settings(QApplication::organizationName(), QApplication::organizationName());
+    settings.beginGroup(sSettingsGroup);
+    ui->checkColNames->setChecked(settings.value(sSettingsInsertColNames, false).toBool());
+    ui->checkMultiply->setChecked(settings.value(sSettingsInsertMultiply, false).toBool());
+
+    // Get list of tables to export
+    objectMap objects = pdb->getBrowsableObjects();
+    for(objectMap::ConstIterator i=objects.begin();i!=objects.end();++i) {
+        ui->listTables->addItem(new QListWidgetItem(QIcon(QString(":icons/%1").arg(i.value().gettype())), i.value().getname()));
+    }
+
+    // Sort list of tables and select the table specified in the
+    // selection parameter or all tables if table not specifed
+    ui->listTables->model()->sort(0);
+    if(selection.isEmpty())
+    {
+        for (int i = 0; i < ui->listTables->count(); ++i)
+            ui->listTables->item(i)->setSelected(true);
+    }
+    else
+    {
+        QList<QListWidgetItem*> items = ui->listTables->findItems(selection, Qt::MatchExactly);
+        ui->listTables->setCurrentItem(items.at(0));
+    }
+    ui->listTables->setFocus();
+}
+
+ExportSqlDialog::~ExportSqlDialog()
+{
+    delete ui;
+}
+
+void ExportSqlDialog::accept()
+{
+    if(ui->listTables->selectedItems().isEmpty())
+    {
+        QMessageBox::warning(this, QApplication::applicationName(),
+                             tr("Please select at least 1 table."));
+        return;
+    }
+    QString fileName = QFileDialog::getSaveFileName(
+                this,
+                tr("Choose a filename to export"),
+                PreferencesDialog::getSettingsValue("db", "defaultlocation").toString(),
+                tr("Text files(*.sql *.txt)"));
+
+    if(fileName.isEmpty())
+        return;
+
+    // save settings
+    QSettings settings(QApplication::organizationName(), QApplication::organizationName());
+    settings.beginGroup(sSettingsGroup);
+    settings.setValue(sSettingsInsertColNames, ui->checkColNames->isChecked());
+    settings.setValue(sSettingsInsertMultiply, ui->checkMultiply->isChecked());
+    settings.endGroup();
+
+    QStringList tables;
+    foreach (const QListWidgetItem * item, ui->listTables->selectedItems())
+        tables.push_back(item->text());
+
+    bool dumpOk = pdb->dump(fileName,
+                            tables,
+                            ui->checkColNames->isChecked(),
+                            ui->checkMultiply->isChecked());
+    if (dumpOk)
+        QMessageBox::information(this, QApplication::applicationName(), tr("Export completed."));
+    else
+        QMessageBox::warning(this, QApplication::applicationName(), tr("Export cancelled or failed."));
+
+    QDialog::accept();
+}

--- a/src/ExportSqlDialog.h
+++ b/src/ExportSqlDialog.h
@@ -1,0 +1,28 @@
+#ifndef ExportSqlDialog_H
+#define ExportSqlDialog_H
+
+#include <QDialog>
+
+class DBBrowserDB;
+
+namespace Ui {
+class ExportSqlDialog;
+}
+
+class ExportSqlDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit ExportSqlDialog(DBBrowserDB* db, QWidget* parent = 0, const QString& selection = "");
+    ~ExportSqlDialog();
+
+private slots:
+    virtual void accept();
+
+private:
+    Ui::ExportSqlDialog* ui;
+    DBBrowserDB* pdb;
+};
+
+#endif

--- a/src/ExportSqlDialog.ui
+++ b/src/ExportSqlDialog.ui
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ExportSqlDialog</class>
+ <widget class="QDialog" name="ExportSqlDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>497</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Export SQL...</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+     </property>
+     <item row="0" column="0">
+      <widget class="QLabel" name="labelTable">
+       <property name="text">
+        <string>&amp;Table(s)</string>
+       </property>
+       <property name="buddy">
+        <cstring>listTables</cstring>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QListWidget" name="listTables">
+       <property name="selectionMode">
+        <enum>QAbstractItemView::MultiSelection</enum>
+       </property>
+       <property name="sortingEnabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>&amp;Options</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="checkColNames">
+          <property name="text">
+           <string>Keep column names in INSERT INTO</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QCheckBox" name="checkMultiply">
+          <property name="text">
+           <string>New INSERT INTO syntax (multiply rows in VALUES)</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>listTables</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ExportSqlDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>252</x>
+     <y>136</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>140</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ExportSqlDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>320</x>
+     <y>136</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>140</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <slots>
+  <slot>showCustomCharEdits()</slot>
+ </slots>
+</ui>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -17,6 +17,7 @@
 #include "gen_version.h"
 #include "sqlite.h"
 #include "CipherDialog.h"
+#include "ExportSqlDialog.h"
 
 #include <QFileDialog>
 #include <QFile>
@@ -897,19 +898,12 @@ void MainWindow::fileRevert()
 
 void MainWindow::exportDatabaseToSQL()
 {
-    QString fileName = QFileDialog::getSaveFileName(
-                this,
-                tr("Choose a filename to export"),
-                PreferencesDialog::getSettingsValue("db", "defaultlocation").toString(),
-                tr("Text files(*.sql *.txt)"));
+    QString current_table;
+    if(ui->mainTab->currentIndex() == 1)
+        current_table = ui->comboBrowseTable->currentText();
 
-    if(fileName.size())
-    {
-        if(!db.dump(fileName))
-            QMessageBox::warning(this, QApplication::applicationName(), tr("Export cancelled or failed."));
-        else
-            QMessageBox::information(this, QApplication::applicationName(), tr("Export completed."));
-    }
+    ExportSqlDialog dialog(&db, this, current_table);
+    dialog.exec();
 }
 
 void MainWindow::importDatabaseFromSQL()

--- a/src/sqlitedb.h
+++ b/src/sqlitedb.h
@@ -54,9 +54,11 @@ public:
     bool revert (const QString& pointname = "RESTOREPOINT");
     bool saveAll();
     bool revertAll();
-    bool dump( const QString & filename);
+    bool dump(const QString & filename, const QStringList &tablesToDump, bool insertColNames, bool insertNew);
     bool executeSQL ( const QString & statement, bool dirtyDB=true, bool logsql=true);
     bool executeMultiSQL(const QString& statement, bool dirty = true, bool log = false);
+
+    QStringList tableColumns(const QString& tableName);
 
     /**
      * @brief getRow Executes a sqlite statement to get the rowdata(columns)

--- a/src/src.pro
+++ b/src/src.pro
@@ -49,7 +49,8 @@ HEADERS += \
     DbStructureModel.h \
     Application.h \
     sqlite.h \
-    CipherDialog.h
+    CipherDialog.h \
+    ExportSqlDialog.h
 
 SOURCES += \
     sqlitedb.cpp \
@@ -74,7 +75,8 @@ SOURCES += \
     VacuumDialog.cpp \
     DbStructureModel.cpp \
     Application.cpp \
-    CipherDialog.cpp
+    CipherDialog.cpp \
+    ExportSqlDialog.cpp
 
 RESOURCES += icons/icons.qrc \
              translations/flags/flags.qrc
@@ -90,7 +92,8 @@ FORMS += \
     ImportCsvDialog.ui \
     SqlExecutionArea.ui \
     VacuumDialog.ui \
-    CipherDialog.ui
+    CipherDialog.ui \
+    ExportSqlDialog.ui
 
 TRANSLATIONS += \
     translations/sqlb_zh.ts \


### PR DESCRIPTION
ADD:
- export SQL options dialog (referenced in issue #242);
- option: Keep column names in INSERT INTO (false by default, store in settings);
- option: New INSERT INTO SQLite 3.7.11 syntax (false by default, store in settings);
- select table(s) to export.

FIX:
- Export sql doesn't name insert columns #242.