### PR TITLE
fix: type of imported BLOB data #239

### DIFF
--- a/src/sqlitedb.h
+++ b/src/sqlitedb.h
@@ -88,7 +88,7 @@ public:
      */
     QString emptyInsertStmt(const sqlb::Table& t, qint64 pk_value = -1) const;
     bool deleteRecord(const QString& table, qint64 rowid);
-    bool updateRecord(const QString& table, const QString& column, qint64 row, const QByteArray& value);
+    bool updateRecord(const QString& table, const QString& column, qint64 row, const QByteArray& value, bool itsBlob);
 
     bool createTable(const QString& name, const sqlb::FieldVector& structure);
     bool renameTable(const QString& from_table, const QString& to_table);

--- a/src/sqlitetablemodel.h
+++ b/src/sqlitetablemodel.h
@@ -3,6 +3,7 @@
 
 #include <QAbstractTableModel>
 #include <QStringList>
+#include <QVector>
 
 class DBBrowserDB;
 
@@ -50,7 +51,7 @@ private:
     void clearCache();
 
     void buildQuery();
-    QStringList getColumns(const QString sQuery);
+    QStringList getColumns(const QString& sQuery, QVector<int>& fieldsTypes);
     int getQueryRowCount();
 
     DBBrowserDB* m_db;
@@ -64,6 +65,7 @@ private:
     int m_iSortColumn;
     QString m_sSortOrder;
     QMap<int, QString> m_mWhere;
+    QVector<int> m_vDataTypes;
 
     /**
      * @brief m_chunkSize Size of the next chunk fetch more will try to fetch.


### PR DESCRIPTION
in SqliteTableModel when setTable() is called need to fetch and store data types of each field of DB.
next, in DBbrowserDB::updateRecord() append argument - bool isBlob.
and then in code this function:

    //...

    if (isBlob) {
        sqlite3_bind_blob(...)
    } else {
        sqlite3_bind_text(...)
    }

    //...

and we can rewrite "Cheap BLOB test here..." function to:

    bool SqliteTableModel::isBinary(const QModelIndex& index) const
    {
        return m_vDataTypes.at(index.column()) == SQLITE_BLOB;
    }

PS: this solution will be work incorrect if need DB with values of multiple data types in one field.