### PR TITLE
set selected data type on Edit database cell dialog

### DIFF
--- a/src/EditDialog.cpp
+++ b/src/EditDialog.cpp
@@ -163,7 +163,11 @@ void EditDialog::accept()
     // Don't update if the data hasn't changed
     // To differentiate NULL and empty byte arrays, we also compare the NULL flag
     if(hexEdit->data() != oldData || hexEdit->data().isNull() != oldData.isNull())
-        emit updateRecordText(curRow, curCol, hexEdit->data());
+    {
+        const QString dataType = ui->comboEditor->currentText();
+        bool isBlob = dataType == tr("Binary") || !ui->comboEditor->isVisible();
+        emit updateRecordText(curRow, curCol, isBlob, hexEdit->data());
+    }
     emit goingAway();
 }
 

--- a/src/EditDialog.h
+++ b/src/EditDialog.h
@@ -43,7 +43,7 @@ private slots:
 
 signals:
     void goingAway();
-    void updateRecordText(int, int, const QByteArray&);
+    void updateRecordText(int row, int col, bool isBlob, const QByteArray& data);
 
 private:
     Ui::EditDialog* ui;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -182,7 +182,7 @@ void MainWindow::init()
     connect(ui->dataTable->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(setRecordsetLabel()));
     connect(ui->dataTable->horizontalHeader(), SIGNAL(sectionResized(int,int,int)), this, SLOT(updateBrowseDataColumnWidth(int,int,int)));
     connect(editWin, SIGNAL(goingAway()), this, SLOT(editWinAway()));
-    connect(editWin, SIGNAL(updateRecordText(int, int, QByteArray)), this, SLOT(updateRecordText(int, int, QByteArray)));
+    connect(editWin, SIGNAL(updateRecordText(int, int, bool, QByteArray)), this, SLOT(updateRecordText(int, int, bool, QByteArray)));
     connect(editDock, SIGNAL(goingAway()), this, SLOT(editWinAway()));
     connect(editDock, SIGNAL(updateRecordText(int, int, QByteArray)), this, SLOT(updateRecordText(int, int, QByteArray)));
     connect(ui->dbTreeWidget->selectionModel(), SIGNAL(currentChanged(QModelIndex,QModelIndex)), this, SLOT(changeTreeSelection()));
@@ -746,9 +746,9 @@ void MainWindow::helpAbout()
     dialog.exec();
 }
 
-void MainWindow::updateRecordText(int row, int col, const QByteArray& newtext)
+void MainWindow::updateRecordText(int row, int col, bool isBlob, const QByteArray& newtext)
 {
-    m_browseTableModel->setData(m_browseTableModel->index(row, col), newtext);
+    m_browseTableModel->setTypedData(m_browseTableModel->index(row, col), isBlob, newtext);
 }
 
 void MainWindow::editWinAway()

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -176,7 +176,7 @@ private slots:
     void editTable();
     void helpWhatsThis();
     void helpAbout();
-    void updateRecordText(int row, int col, const QByteArray& newtext);
+    void updateRecordText(int row, int col, bool type, const QByteArray& newtext);
     void editWinAway();
     void dataTableSelectionChanged(const QModelIndex& index);
     void doubleClickTable(const QModelIndex& index);

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -296,6 +296,13 @@ sqlb::ForeignKeyClause SqliteTableModel::getForeignKeyClause(int column) const
 
 bool SqliteTableModel::setData(const QModelIndex& index, const QVariant& value, int role)
 {
+    // This function is for in-place editing.
+    // So, BLOB flag is false every times.
+    return setTypedData(index, false, value, role);
+}
+
+bool SqliteTableModel::setTypedData(const QModelIndex& index, bool isBlob, const QVariant& value, int role)
+{
     if(index.isValid() && role == Qt::EditRole)
     {
         QByteArray newValue = encode(value.toByteArray());
@@ -306,7 +313,7 @@ bool SqliteTableModel::setData(const QModelIndex& index, const QVariant& value, 
         if(oldValue == newValue && oldValue.isNull() == newValue.isNull())
             return true;
 
-        if(m_db->updateRecord(m_sTable, m_headers.at(index.column()), m_data[index.row()].at(0), newValue, isBinary(index)))
+        if(m_db->updateRecord(m_sTable, m_headers.at(index.column()), m_data[index.row()].at(0), newValue, isBlob))
         {
             // Only update the cache if this row has already been read, if not there's no need to do any changes to the cache
             if(index.row() < m_data.size())

--- a/src/sqlitetablemodel.h
+++ b/src/sqlitetablemodel.h
@@ -21,6 +21,7 @@ public:
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
+    bool setTypedData(const QModelIndex& index, bool isBlob, const QVariant& value, int role = Qt::EditRole);
     bool canFetchMore(const QModelIndex &parent = QModelIndex()) const;
     void fetchMore(const QModelIndex &parent = QModelIndex());
     size_t queryMore(size_t offset);


### PR DESCRIPTION
Data type isn't decided by column type, but user's decision on 'Edit database cell' dialog.
Note : This topic is discussed on issue #239.