### PR TITLE
cmake: use an external antlr2 if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 before_install:
   - sudo add-apt-repository ppa:likemartinma/devel -y
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libqt4-dev libsqlite3-dev libsqlcipher-dev
+  - sudo apt-get install -qq libqt4-dev libsqlite3-dev libsqlcipher-dev libantlr-dev
 
 script:
   - mkdir build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 project(sqlitebrowser)
 cmake_minimum_required(VERSION 2.8.7)
 
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}")
+
 OPTION(USE_QT5 FALSE "Build with qt5")
 OPTION(ENABLE_TESTING FALSE "Enable the unit tests")
 
@@ -22,12 +24,16 @@ if(WIN32 AND MSVC)
 	set(CMAKE_PREFIX_PATH "${QT5_PATH};${SQLITE3_PATH}")
 endif()
 
-set(ANTLR_DIR libs/antlr-2.7.7)
+find_package(Antlr2)
+
 set(QHEXEDIT_DIR libs/qhexedit)
 set(QCUSTOMPLOT_DIR libs/qcustomplot-source)
 set(QSCINTILLA_DIR libs/qscintilla/Qt4Qt5)
 
-add_subdirectory(${ANTLR_DIR})
+if(NOT ANTLR2_FOUND)
+    set(ANTLR_DIR libs/antlr-2.7.7)
+    add_subdirectory(${ANTLR_DIR})
+endif()
 add_subdirectory(${QHEXEDIT_DIR})
 add_subdirectory(${QCUSTOMPLOT_DIR})
 add_subdirectory(${QSCINTILLA_DIR})
@@ -214,12 +220,16 @@ endif()
 
 include_directories(
 		"${CMAKE_CURRENT_BINARY_DIR}"
-		${ANTLR_DIR}
 		${QHEXEDIT_DIR}
 		${QCUSTOMPLOT_DIR}
 		${QSCINTILLA_DIR}
 		${ADDITIONAL_INCLUDE_PATHS}
 		src)
+if(ANTLR2_FOUND)
+    include_directories(${ANTLR2_INCLUDE_DIRS})
+else()
+    include_directories(${ANTLR_DIR})
+endif()
 
 add_executable(${PROJECT_NAME}
 		${SQLB_HDR}
@@ -234,16 +244,21 @@ if(USE_QT5)
     qt5_use_modules(${PROJECT_NAME} Gui Widgets Network Test PrintSupport)
     set(QT_LIBRARIES "")
 endif()
-add_dependencies(${PROJECT_NAME} antlr qhexedit qcustomplot qscintilla2)
+add_dependencies(${PROJECT_NAME} qhexedit qcustomplot qscintilla2)
+if(NOT ANTLR2_FOUND)
+    add_dependencies(${PROJECT_NAME} antlr)
+endif()
 
 link_directories(
 		"${CMAKE_CURRENT_BINARY_DIR}/${ANTLR_DIR}"
 		"${CMAKE_CURRENT_BINARY_DIR}/${QHEXEDIT_DIR}"
 		"${CMAKE_CURRENT_BINARY_DIR}/${QCUSTOMPLOT_DIR}"
 		"${CMAKE_CURRENT_BINARY_DIR}/${QSCINTILLA_DIR}")
+if(NOT ANTLR2_FOUND)
+    link_directories("${CMAKE_CURRENT_BINARY_DIR}/${ANTLR_DIR}")
+endif()
 
 target_link_libraries(${PROJECT_NAME}
-		antlr
 		qhexedit
 		qcustomplot
 		qscintilla2
@@ -251,6 +266,11 @@ target_link_libraries(${PROJECT_NAME}
 		${WIN32_STATIC_LINK}
 		${LIBSQLITE}
 		${ADDITIONAL_LIBS})
+if(ANTLR2_FOUND)
+    target_link_libraries(${PROJECT_NAME} ${ANTLR2_LIBRARIES})
+else()
+    target_link_libraries(${PROJECT_NAME} antlr)
+endif()
 
 if(WIN32 AND MSVC)
 	set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS_DEBUG "/SUBSYSTEM:CONSOLE")

--- a/cmake/FindAntlr2.cmake
+++ b/cmake/FindAntlr2.cmake
@@ -1,0 +1,50 @@
+# - try to find Antlr v2
+# Once done this will define:
+#
+#  ANTLR2_FOUND - system has antlr2
+#  ANTLR2_INCLUDE_DIRS - the include directories for antlr2
+#  ANTLR2_LIBRARIES - Link these to use antl2
+#  ANTLR2_EXECUTABLE - The 'antlr' or 'runantlr' executable
+
+# Copyright (C) 2015, Pino Toscano, <toscano.pino@tiscali.it>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+find_library(ANTLR2_LIBRARY antlr)
+set(ANTLR2_LIBRARIES "${ANTLR2_LIBRARY}")
+
+find_path(ANTLR2_INCLUDE_DIR antlr/AST.hpp)
+set(ANTLR2_INCLUDE_DIRS "${ANTLR2_INCLUDE_DIR}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Antlr2 DEFAULT_MSG ANTLR2_LIBRARIES ANTLR2_INCLUDE_DIRS)
+
+find_program(ANTLR2_EXECUTABLE NAMES runantlr runantlr2 antlr)
+
+mark_as_advanced(
+  ANTLR2_INCLUDE_DIRS
+  ANTLR2_LIBRARIES
+  ANTLR2_EXECUTABLE
+)

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
     add_definitions(${QT_DEFINITIONS})
 endif()
 
-include_directories("${CMAKE_CURRENT_BINARY_DIR}" "${ANTLR_DIR}" ..)
+include_directories("${CMAKE_CURRENT_BINARY_DIR}" ..)
 
 # test-sqlobjects
 
@@ -58,8 +58,15 @@ if(USE_QT5)
     set(QT_LIBRARIES "")
 endif()
 
-add_dependencies(test-sqlobjects antlr)
-target_link_libraries(test-sqlobjects antlr ${QT_LIBRARIES} ${LIBSQLITE})
+if(NOT ANTLR2_FOUND)
+    add_dependencies(test-sqlobjects antlr)
+endif()
+target_link_libraries(test-sqlobjects ${QT_LIBRARIES} ${LIBSQLITE})
+if(ANTLR2_FOUND)
+    target_link_libraries(test-sqlobjects ${ANTLR2_LIBRARIES})
+else()
+    target_link_libraries(test-sqlobjects antlr)
+endif()
 add_test(test-sqlobjects test-sqlobjects)
 
 # test-import


### PR DESCRIPTION
Look for an installed antlr v2, and if available use it instead of its embedded copy.