### PR TITLE
fix: translations are not being installed via make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ set(SQLB_FORMS
 set(SQLB_RESOURCES
 	src/icons/icons.qrc
 	src/translations/flags/flags.qrc
+	src/translations/translations.qrc
 )
 
 set(SQLB_MISC
@@ -144,25 +145,25 @@ set(SQLB_TSS
 
 if(USE_QT5)
     qt5_wrap_ui(SQLB_FORM_HDR ${SQLB_FORMS})
-    qt5_add_resources(SQLB_RESOURCES_RCC ${SQLB_RESOURCES})
     if(SQLB_TSS)
         # add translations
         foreach(SQLB_TS ${SQLB_TSS})
-            SET_SOURCE_FILES_PROPERTIES("${SQLB_TS}" PROPERTIES OUTPUT_LOCATION "${CMAKE_BINARY_DIR}/translations")
+            SET_SOURCE_FILES_PROPERTIES("${SQLB_TS}" PROPERTIES OUTPUT_LOCATION "${CMAKE_SOURCE_DIR}/src/translations")
         endforeach(SQLB_TS ${SQLB_TSS})
         qt5_add_translation(SQLB_QMS ${SQLB_TSS})
     endif(SQLB_TSS)
+    qt5_add_resources(SQLB_RESOURCES_RCC ${SQLB_RESOURCES})
 else()
     QT4_WRAP_CPP(SQLB_MOC ${SQLB_MOC_HDR})
     QT4_WRAP_UI(SQLB_FORM_HDR ${SQLB_FORMS})
-    QT4_ADD_RESOURCES(SQLB_RESOURCES_RCC ${SQLB_RESOURCES})
     if(SQLB_TSS)
         # add translations
         foreach(SQLB_TS ${SQLB_TSS})
-            SET_SOURCE_FILES_PROPERTIES("${SQLB_TS}" PROPERTIES OUTPUT_LOCATION "${CMAKE_BINARY_DIR}/translations")
+            SET_SOURCE_FILES_PROPERTIES("${SQLB_TS}" PROPERTIES OUTPUT_LOCATION "${CMAKE_SOURCE_DIR}/src/translations")
         endforeach(SQLB_TS ${SQLB_TSS})
         QT4_ADD_TRANSLATION(SQLB_QMS ${SQLB_TSS})
     endif(SQLB_TSS)
+    QT4_ADD_RESOURCES(SQLB_RESOURCES_RCC ${SQLB_RESOURCES})
 endif()
 
 
@@ -227,8 +228,7 @@ add_executable(${PROJECT_NAME}
 		${SQLB_FORM_HDR}
 		${SQLB_MOC}
 		${SQLB_RESOURCES_RCC}
-                ${SQLB_QMS}
-                ${SQLB_MISC})
+		${SQLB_MISC})
 
 if(USE_QT5)
     qt5_use_modules(${PROJECT_NAME} Gui Widgets Network Test PrintSupport)

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -32,6 +32,10 @@ Application::Application(int& argc, char** argv) :
     m_translatorApp = new QTranslator(this);
     ok = m_translatorApp->load("sqlb_" + name,
                                QCoreApplication::applicationDirPath() + "/translations");
+    // If failed then try to load .qm file from resources
+    if (ok == false) {
+        ok = m_translatorApp->load("sqlb_" + name, ":/translations");
+    }
 
     if (ok == true) {
         PreferencesDialog::setSettingsValue("General", "language", name);

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -394,12 +394,35 @@ void PreferencesDialog::fillLanguageBox()
                                       "en_US");
     }
 
+    // append availeble *.qm files from translation dir near executable
     foreach(const QFileInfo &file, translationsDir.entryInfoList())
     {
         QLocale locale(file.baseName().remove("sqlb_"));
 
         // Skip invalid locales
         if(locale.name() == "C")
+            continue;
+
+        QString language = QLocale::languageToString(locale.language()) + " (" +
+                           QLocale::countryToString(locale.country()) + ")";
+
+        if (locale == systemLocale)
+            language += " [System language]";
+
+        ui->languageComboBox->addItem(QIcon(":/flags/" + locale.name()), language, locale.name());
+    }
+
+    // append *.qm files from resources
+    foreach (const QFileInfo &file, QDir(":/translations").entryInfoList())
+    {
+        QLocale locale(file.baseName().remove("sqlb_"));
+
+        // Skip invalid locales
+        if(locale.name() == "C")
+            continue;
+
+        // Translation for this locale already loaded in previous foreach
+        if (ui->languageComboBox->findData(locale.name(), Qt::UserRole, Qt::MatchExactly) != -1)
             continue;
 
         QString language = QLocale::languageToString(locale.language()) + " (" +

--- a/src/src.pro
+++ b/src/src.pro
@@ -81,7 +81,8 @@ SOURCES += \
     FileDialog.cpp
 
 RESOURCES += icons/icons.qrc \
-             translations/flags/flags.qrc
+             translations/flags/flags.qrc \
+             translations/translations.qrc
 
 FORMS += \
     MainWindow.ui \

--- a/src/translations/translations.qrc
+++ b/src/translations/translations.qrc
@@ -1,0 +1,8 @@
+<RCC>
+    <qresource prefix="/translations">
+        <file alias="sqlb_ru">sqlb_ru.qm</file>
+        <file alias="sqlb_de">sqlb_de.qm</file>
+        <file alias="sqlb_fr">sqlb_fr.qm</file>
+        <file alias="sqlb_zh">sqlb_zh.qm</file>
+    </qresource>
+</RCC>


### PR DESCRIPTION
#304

- translation files (.qm) moved into Qt resources;
- still can put the .qm file in /translations directory next to the executable file and this translation will have a higher priority than .qm file from resources for the same locale.

@rp-, please review (not sure about CMake).