### PR TITLE
qscintilla: get rid 'Not relevant classes found' messages from build log

### DIFF
--- a/libs/qscintilla/Qt4Qt5/CMakeLists.txt
+++ b/libs/qscintilla/Qt4Qt5/CMakeLists.txt
@@ -75,27 +75,15 @@ set(QSCINTILLA_SRC
 )
 
 set(QSCINTILLA_HDR
-)
-
-set(QSCINTILLA_MOC_HDR
 	./Qsci/qsciglobal.h
-	./Qsci/qsciscintilla.h
-	./Qsci/qsciscintillabase.h
-	./Qsci/qsciabstractapis.h
-	./Qsci/qsciapis.h
 	./Qsci/qscicommand.h
 	./Qsci/qscicommandset.h
 	./Qsci/qscidocument.h
-	./Qsci/qscilexer.h
-	./Qsci/qscilexersql.h
-	./Qsci/qscimacro.h
 	./Qsci/qsciprinter.h
 	./Qsci/qscistyle.h
 	./Qsci/qscistyledtext.h
 	ListBoxQt.h
-	SciClasses.h
 	SciNamespace.h
-	ScintillaQt.h
 	../include/ILexer.h
 	../include/Platform.h
 	../include/SciLexer.h
@@ -143,6 +131,18 @@ set(QSCINTILLA_MOC_HDR
 	../src/UniConversion.h
 	../src/ViewStyle.h
 	../src/XPM.h
+)
+
+set(QSCINTILLA_MOC_HDR
+	./Qsci/qsciscintilla.h
+	./Qsci/qsciscintillabase.h
+	./Qsci/qsciabstractapis.h
+	./Qsci/qsciapis.h
+	./Qsci/qscilexer.h
+	./Qsci/qscilexersql.h
+	./Qsci/qscimacro.h
+	SciClasses.h
+	ScintillaQt.h
 )
 
 if(NOT USE_QT5)


### PR DESCRIPTION
While building of qscintilla library using CMake in build log there are many notes, something like:

    [  1%] Generating __/src/moc_XPM.cxx
    /home/jsbot/src/github/sqlitebrowser/libs/qscintilla/src/XPM.h:0: Note: No relevant classes found. No output generated.

That's because XPM class, for example, not inherited from QObject and does not require processing with Qt Meta Object Compiler.

Possible solution is to move these classes from QSCINTILLA_MOC_HDR into QSCINTILLA_HDR in file CMakeLists.txt

@MKleusberg, what you think about this?