### PR TITLE
fix: UTF-8 characters (when out of comments or quotes) are drawn with different font

### DIFF
--- a/src/sqltextedit.cpp
+++ b/src/sqltextedit.cpp
@@ -104,10 +104,10 @@ void SqlTextEdit::reloadKeywords()
 void SqlTextEdit::reloadSettings()
 {
     // Set syntax highlighting settings
-    sqlLexer->setDefaultColor(Qt::black);
     QFont defaultfont(PreferencesDialog::getSettingsValue("editor", "font").toString());
     defaultfont.setStyleHint(QFont::TypeWriter);
     defaultfont.setPointSize(PreferencesDialog::getSettingsValue("editor", "fontsize").toInt());
+    sqlLexer->setColor(Qt::black, QsciLexerSQL::Default);
     sqlLexer->setFont(defaultfont);
     setupSyntaxHighlightingFormat("comment", QsciLexerSQL::Comment);
     setupSyntaxHighlightingFormat("comment", QsciLexerSQL::CommentLine);

--- a/src/sqltextedit.cpp
+++ b/src/sqltextedit.cpp
@@ -108,7 +108,7 @@ void SqlTextEdit::reloadSettings()
     QFont defaultfont(PreferencesDialog::getSettingsValue("editor", "font").toString());
     defaultfont.setStyleHint(QFont::TypeWriter);
     defaultfont.setPointSize(PreferencesDialog::getSettingsValue("editor", "fontsize").toInt());
-    sqlLexer->setDefaultFont(defaultfont);
+    sqlLexer->setFont(defaultfont);
     setupSyntaxHighlightingFormat("comment", QsciLexerSQL::Comment);
     setupSyntaxHighlightingFormat("comment", QsciLexerSQL::CommentLine);
     setupSyntaxHighlightingFormat("comment", QsciLexerSQL::CommentDoc);

--- a/src/sqltextedit.cpp
+++ b/src/sqltextedit.cpp
@@ -63,7 +63,7 @@ void SqlTextEdit::updateLineNumberAreaWidth()
 
     // Calculate the width of this number if it was all zeros (this is because a 1 might require less space than a 0 and this could
     // cause some flickering depending on the font) and set the new margin width.
-    QFont font = lexer()->defaultFont(QsciLexerSQL::Default);
+    QFont font = lexer()->font(QsciLexerSQL::Default);
     setMarginWidth(0, QFontMetrics(font).width(QString("0").repeated(digits)) + 5);
 }
 


### PR DESCRIPTION
Function ```setFont()```, without params, sets font for all lexems types. .
To set default font color to black I used ```sqlLexer->setColor(Qt::black, QsciLexerSQL::Default)```.
That's also keeps numbers color with aquablue color

And it doesn't  looks very clever now, it thinks that every not special english SQL word is table or column name.

I compared it with old (before Scintilla) appearance:

![workspace 1_065](https://cloud.githubusercontent.com/assets/5500999/8290579/2dca5b18-194e-11e5-93aa-478376843c6e.png)
