### PR TITLE
Fix sqlcipher and OSX 10.10 build.

### DIFF
--- a/libs/qscintilla/Qt4Qt5/CMakeLists.txt
+++ b/libs/qscintilla/Qt4Qt5/CMakeLists.txt
@@ -10,6 +10,10 @@ else()
     add_definitions(${QT_DEFINITIONS})
 endif()
 
+if(APPLE AND USE_QT5)
+    find_package(Qt5MacExtras)
+endif()
+
 add_definitions(-DSCINTILLA_QT)
 add_definitions(-DSCI_LEXER)
 
@@ -154,5 +158,9 @@ include_directories(. ../include ../lexlib ../src)
 add_library(qscintilla2 ${QSCINTILLA_SRC} ${QSCINTILLA_HDR} ${QSCINTILLA_MOC_HDR} ${QSCINTILLA_MOC})
 
 if(USE_QT5)
-    qt5_use_modules(qscintilla2 Widgets PrintSupport)
+    if (APPLE)
+        qt5_use_modules(qscintilla2 Widgets PrintSupport MacExtras)
+    else()
+        qt5_use_modules(qscintilla2 Widgets PrintSupport)
+    endif()
 endif()

--- a/src/src.pro
+++ b/src/src.pro
@@ -142,8 +142,9 @@ win32 {
 }
 mac {
     RC_FILE = macapp.icns
-    INCLUDEPATH += -I/usr/local/include \
-                   -I/usr/local/opt/sqlite/include
+    QT+= macextras
+    INCLUDEPATH += /usr/local/include \
+                   /usr/local/opt/sqlite/include
     LIBS += -L/usr/local/lib \
             -L/usr/local/opt/sqlite/lib \
             -framework Carbon


### PR DESCRIPTION
Building under Mac OS X 10.10 was broken using QT SDK 5.4. Add
missing macextras.

To be able to build against sqlcipher fix INCLUDEPATH for mac by removing the -I from PATH.
