### PR TITLE
Fix stack overflow due to signal infinite loop

### DIFF
--- a/src/EditDialog.cpp
+++ b/src/EditDialog.cpp
@@ -132,7 +132,9 @@ void EditDialog::editTextChanged()
 {
     if(ui->editorText->hasFocus())
     {
+        hexEdit->blockSignals(true);
         hexEdit->setData(ui->editorText->toPlainText().toUtf8());
+        hexEdit->blockSignals(false);
         checkDataType();
     }
 }
@@ -140,7 +142,9 @@ void EditDialog::editTextChanged()
 void EditDialog::hexDataChanged()
 {
     // Update the text editor accordingly
+    ui->editorText->blockSignals(true);
     ui->editorText->setPlainText(QString::fromUtf8(hexEdit->data().constData(), hexEdit->data().size()));
+    ui->editorText->blockSignals(false);
 }
 
 void EditDialog::checkDataType()


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1282792 :

"In the browse data tab, add new row, then double click a field. The popup window appeared to edit the field, and it froze."

Problem is that during synchronization of the plaintextedit and hexedit, the updated editor emits the changed signal which then triggers another syncronization, and so on, resulting in a stack overflow due to infinite recursion:

    [...]
    #42 0x00005555555a169f in EditDialog::editTextChanged() (this=0x55555598b510) at /usr/src/debug/sqlitebrowser-3.7.0/src/EditDialog.cpp:140
    #43 0x00007ffff55012ca in QMetaObject::activate(QObject*, int, int, void**) () at /lib64/libQt5Core.so.5
    #44 0x00007ffff636ba75 in QTextEdit::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) () at /lib64/libQt5Widgets.so.5
    #45 0x00007ffff55012ca in QMetaObject::activate(QObject*, int, int, void**) () at /lib64/libQt5Core.so.5
    #46 0x00007ffff63853ff in QWidgetTextControlPrivate::setContent(Qt::TextFormat, QString const&, QTextDocument*) () at /lib64/libQt5Widgets.so.5
    #47 0x00007ffff63679a1 in QTextEdit::setPlainText(QString const&) () at /lib64/libQt5Widgets.so.5
    #48 0x00005555555a17d9 in EditDialog::hexDataChanged() (this=0x55555598b510) at /usr/src/debug/sqlitebrowser-3.7.0/src/EditDialog.cpp:148
    #49 0x00007ffff55012ca in QMetaObject::activate(QObject*, int, int, void**) () at /lib64/libQt5Core.so.5
    #50 0x00007ffff73d47c9 in QHexEdit::setData(QIODevice&) (this=0x5555559e14d0, iODevice=...) at ../src/qhexedit.cpp:247
    #51 0x00007ffff73d4817 in QHexEdit::setData(QByteArray const&) (this=<optimized out>, ba=...) at ../src/qhexedit.cpp:178
    #52 0x00005555555a169f in EditDialog::editTextChanged() (this=0x55555598b510) at /usr/src/debug/sqlitebrowser-3.7.0/src/EditDialog.cpp:140
    #53 0x00007ffff55012ca in QMetaObject::activate(QObject*, int, int, void**) () at /lib64/libQt5Core.so.5
    #54 0x00007ffff636ba75 in QTextEdit::qt_static_metacall(QObject*, QMetaObject::Call, int, void**) () at /lib64/libQt5Widgets.so.5
    #55 0x00007ffff55012ca in QMetaObject::activate(QObject*, int, int, void**) () at /lib64/libQt5Core.so.5
    #56 0x00007ffff63853ff in QWidgetTextControlPrivate::setContent(Qt::TextFormat, QString const&, QTextDocument*) () at /lib64/libQt5Widgets.so.5
    #57 0x00007ffff63679a1 in QTextEdit::setPlainText(QString const&) () at /lib64/libQt5Widgets.so.5
    #58 0x00005555555a17d9 in EditDialog::hexDataChanged() (this=0x55555598b510) at /usr/src/debug/sqlitebrowser-3.7.0/src/EditDialog.cpp:148
    #59 0x00007ffff55012ca in QMetaObject::activate(QObject*, int, int, void**) () at /lib64/libQt5Core.so.5
[...]
