### PR TITLE
Paste and erase in Browse Data table

### DIFF
--- a/src/ExtendedTableWidget.h
+++ b/src/ExtendedTableWidget.h
@@ -24,6 +24,7 @@ signals:
 
 private:
     void copy();
+    void paste();
     int numVisibleRows();
 
 private slots:


### PR DESCRIPTION
Hi.
I added paste (Ctrl+V) and erase (Delete) functionality for cells in Browse Data table (ExtendedTableWidget).
I add it for my convenience, please consider to merge it if you think that is usefull.