### PR TITLE
Unquoting text pasted from clipboard in Browse Data table.

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -158,7 +158,15 @@ void ExtendedTableWidget::paste()
         int column = firstColumn;
         foreach(const QString& cell, clipboardRow)
         {
-            m->setData(m->index(row, column), cell);
+            if(cell.startsWith('"') && cell.endsWith('"'))
+            {
+                QString unquatedCell = cell.mid(1, cell.length()-2);
+                m->setData(m->index(row, column), unquatedCell);
+            }
+            else
+            {
+                m->setData(m->index(row, column), cell);
+            }
 
             column++;
             if(column> lastColumn)


### PR DESCRIPTION
Corrected overlooked problem suggested by @tonypdmtr on issue [#453](https://github.com/sqlitebrowser/sqlitebrowser/pull/453). I make new issue because [#453](https://github.com/sqlitebrowser/sqlitebrowser/pull/453) is already merged.