### PR TITLE
Adding Fedora 22/23 instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -49,6 +49,11 @@ Done. :)
 
 ### CentOS / Fedora Linux
 
+For Fedora 22 and 23 the RPM is available via DNF. 
+```
+$ sudo dnf install sqlitebrowser
+```
+
 **1**. Make sure the `qt-devel`, `ant-antlr`, and `antlr-C++` packages are installed.<br />
 ```
 $ sudo yum install qt-devel ant-antlr antlr-C++


### PR DESCRIPTION
Sqlitebrowser is actually being compiled and provided in Fedora 22/23 so it's much easier to get it running.