### PR TITLE
- Add Select-All and Deselect-All options to ExportSQL dialog menu

### DIFF
--- a/src/ExportSqlDialog.cpp
+++ b/src/ExportSqlDialog.cpp
@@ -54,6 +54,18 @@ ExportSqlDialog::~ExportSqlDialog()
     delete ui;
 }
 
+void ExportSqlDialog::doSelectAll()
+{
+	for (int i = 0; i < ui->listTables->count(); ++i)
+		ui->listTables->item(i)->setSelected(true);
+}
+
+void ExportSqlDialog::doDeselectAll()
+{
+	for (int i = 0; i < ui->listTables->count(); ++i)
+		ui->listTables->item(i)->setSelected(false);
+}
+
 void ExportSqlDialog::accept()
 {
     QList<QListWidgetItem*> selectedItems = ui->listTables->selectedItems();
@@ -102,3 +114,6 @@ void ExportSqlDialog::accept()
 
     QDialog::accept();
 }
+
+
+

--- a/src/ExportSqlDialog.h
+++ b/src/ExportSqlDialog.h
@@ -19,6 +19,8 @@ public:
 
 private slots:
     virtual void accept();
+    void doSelectAll();
+    void doDeselectAll();
 
 private:
     Ui::ExportSqlDialog* ui;

--- a/src/ExportSqlDialog.ui
+++ b/src/ExportSqlDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>497</width>
-    <height>300</height>
+    <height>338</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -49,7 +49,31 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0" colspan="2">
+     <item row="1" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="sizeConstraint">
+        <enum>QLayout::SetFixedSize</enum>
+       </property>
+       <property name="topMargin">
+        <number>10</number>
+       </property>
+       <item>
+        <widget class="QPushButton" name="buttonSelectAll">
+         <property name="text">
+          <string>Select All</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="buttonDeselectAll">
+         <property name="text">
+          <string>Deselect All</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="2" column="0" colspan="2">
       <widget class="QGroupBox" name="groupBox">
        <property name="title">
         <string>&amp;Options</string>
@@ -121,18 +145,34 @@
    </hints>
   </connection>
   <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
+   <sender>buttonDeselectAll</sender>
+   <signal>clicked()</signal>
    <receiver>ExportSqlDialog</receiver>
-   <slot>reject()</slot>
+   <slot>doDeselectAll()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>320</x>
-     <y>136</y>
+     <x>20</x>
+     <y>20</y>
     </hint>
     <hint type="destinationlabel">
-     <x>286</x>
-     <y>140</y>
+     <x>20</x>
+     <y>20</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonSelectAll</sender>
+   <signal>clicked()</signal>
+   <receiver>ExportSqlDialog</receiver>
+   <slot>doSelectAll()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>20</x>
+     <y>20</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>20</x>
+     <y>20</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
The export SQL dialog has no option to select or de-select all. I ran into this issue when I wanted to export a subset of a very large database of about 70 tables, so I've added the two self-explanatory buttons.

I think another good improvement would be support for shift-clicking to select a range of tables, which I can also implement.