### PR TITLE
Allow viewing via the EditDialog for executed sql statements

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -270,8 +270,7 @@ QSet<int> ExtendedTableWidget::selectedCols()
 void ExtendedTableWidget::cellClicked(const QModelIndex& index)
 {
     // If Alt key is pressed try to jump to the row referenced by the foreign key of the clicked cell
-    if(qApp->keyboardModifiers().testFlag(Qt::ControlModifier) && qApp->keyboardModifiers().testFlag(Qt::ShiftModifier)
-       && model())
+    if(qApp->keyboardModifiers().testFlag(Qt::ControlModifier) && qApp->keyboardModifiers().testFlag(Qt::ShiftModifier) && model())
     {
         SqliteTableModel* m = qobject_cast<SqliteTableModel*>(model());
         sqlb::ForeignKeyClause fk = m->getForeignKeyClause(index.column()-1);

--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -271,13 +271,13 @@ void ExtendedTableWidget::cellClicked(const QModelIndex& index)
 {
     // If Alt key is pressed try to jump to the row referenced by the foreign key of the clicked cell
     if(qApp->keyboardModifiers().testFlag(Qt::ControlModifier) && qApp->keyboardModifiers().testFlag(Qt::ShiftModifier)
-	   && model())
+       && model())
     {
-		SqliteTableModel* m = qobject_cast<SqliteTableModel*>(model());
-		sqlb::ForeignKeyClause fk = m->getForeignKeyClause(index.column()-1);
+        SqliteTableModel* m = qobject_cast<SqliteTableModel*>(model());
+        sqlb::ForeignKeyClause fk = m->getForeignKeyClause(index.column()-1);
 
-		if(fk.isSet())
-			emit foreignKeyClicked(fk.table(), fk.columns().size() ? fk.columns().at(0) : "", m->data(index, Qt::EditRole).toByteArray());
+        if(fk.isSet())
+            emit foreignKeyClicked(fk.table(), fk.columns().size() ? fk.columns().at(0) : "", m->data(index, Qt::EditRole).toByteArray());
     }
 }
 

--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -270,13 +270,14 @@ QSet<int> ExtendedTableWidget::selectedCols()
 void ExtendedTableWidget::cellClicked(const QModelIndex& index)
 {
     // If Alt key is pressed try to jump to the row referenced by the foreign key of the clicked cell
-    if(qApp->keyboardModifiers().testFlag(Qt::ControlModifier) && qApp->keyboardModifiers().testFlag(Qt::ShiftModifier) && model())
+    if(qApp->keyboardModifiers().testFlag(Qt::ControlModifier) && qApp->keyboardModifiers().testFlag(Qt::ShiftModifier)
+	   && model())
     {
-        SqliteTableModel* m = qobject_cast<SqliteTableModel*>(model());
-        sqlb::ForeignKeyClause fk = m->getForeignKeyClause(index.column()-1);
+		SqliteTableModel* m = qobject_cast<SqliteTableModel*>(model());
+		sqlb::ForeignKeyClause fk = m->getForeignKeyClause(index.column()-1);
 
-        if(fk.isSet())
-            emit foreignKeyClicked(fk.table(), fk.columns().size() ? fk.columns().at(0) : "", m->data(index, Qt::EditRole).toByteArray());
+		if(fk.isSet())
+			emit foreignKeyClicked(fk.table(), fk.columns().size() ? fk.columns().at(0) : "", m->data(index, Qt::EditRole).toByteArray());
     }
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -51,6 +51,7 @@ MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent),
       ui(new Ui::MainWindow),
       m_browseTableModel(new SqliteTableModel(this, &db, PreferencesDialog::getSettingsValue("db", "prefetchsize").toInt())),
+      m_currentTabTableModel(m_browseTableModel),
       editWin(new EditDialog(this)),
       editDock(new EditDialog(this, true)),
       gotoValidator(new QIntValidator(0, 0, this))
@@ -770,7 +771,7 @@ void MainWindow::helpAbout()
 
 void MainWindow::updateRecordText(int row, int col, bool isBlob, const QByteArray& newtext)
 {
-    m_browseTableModel->setTypedData(m_browseTableModel->index(row, col), isBlob, newtext);
+    m_currentTabTableModel->setTypedData(m_currentTabTableModel->index(row, col), isBlob, newtext);
 }
 
 void MainWindow::editWinAway()
@@ -816,8 +817,11 @@ void MainWindow::dataTableSelectionChanged(const QModelIndex& index)
     if(!index.isValid())
         return;
 
+	bool edit = (m_currentTabTableModel == m_browseTableModel) &&
+	(db.getObjectByName(ui->comboBrowseTable->currentText()).gettype() == "table");
+
     // Don't allow editing of other objects than tables
-    editDock->allowEditing(db.getObjectByName(ui->comboBrowseTable->currentText()).gettype() == "table");
+    editDock->allowEditing(edit);
 
     // Load the current value into the edit dock only
     editDock->loadText(index.data(Qt::EditRole).toByteArray(), index.row(), index.column());
@@ -963,21 +967,30 @@ void MainWindow::executeQuery()
     sqlWidget->finishExecution(statusMessage);
     updatePlot(sqlWidget->getModel());
 
+    connect(sqlWidget->getTableResult(), SIGNAL(clicked(QModelIndex)), this, SLOT(dataTableSelectionChanged(QModelIndex)));
+
     if(!modified && !wasdirty)
         db.revertToSavepoint(); // better rollback, if the logic is not enough we can tune it.
 }
 
 void MainWindow::mainTabSelected(int tabindex)
 {
-    if(tabindex == 0)
+	editDock->allowEditing(false);
+
+	if(tabindex == 0)
     {
         populateStructure();
     } else if(tabindex == 1) {
+		m_currentTabTableModel = m_browseTableModel;
         populateStructure();
         resetBrowser();
     } else if(tabindex == 2) {
         loadPragmas();
-    }
+	} else if(tabindex == 3) {
+		SqlExecutionArea* sqlWidget = qobject_cast<SqlExecutionArea*>(ui->tabSqlAreas->currentWidget());
+
+		m_currentTabTableModel = sqlWidget->getModel();
+	}
 }
 
 void MainWindow::importTableFromCSV()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -796,7 +796,7 @@ void MainWindow::doubleClickTable(const QModelIndex& index)
 
 	// Don't allow editing of other objects than tables (on the browse table)
 
-	bool allowEditing = (m_currentTabTableModel == m_browseTableModel) && (db.getObjectByName(ui->comboBrowseTable->currentText()).gettype() == "table");
+    bool allowEditing = (m_currentTabTableModel == m_browseTableModel) && (db.getObjectByName(ui->comboBrowseTable->currentText()).gettype() == "table");
 
     editDock->allowEditing(allowEditing);
     editWin->allowEditing(allowEditing);
@@ -971,8 +971,7 @@ void MainWindow::executeQuery()
 
     connect(sqlWidget->getTableResult(), SIGNAL(clicked(QModelIndex)), this, SLOT(dataTableSelectionChanged(QModelIndex)));
 
-	connect(sqlWidget->getTableResult(), SIGNAL(doubleClicked(QModelIndex)), this,
-			SLOT(doubleClickTable(QModelIndex)));
+    connect(sqlWidget->getTableResult(), SIGNAL(doubleClicked(QModelIndex)), this, SLOT(doubleClickTable(QModelIndex)));
 
     if(!modified && !wasdirty)
         db.revertToSavepoint(); // better rollback, if the logic is not enough we can tune it.
@@ -994,8 +993,11 @@ void MainWindow::mainTabSelected(int tabindex)
     } else if(tabindex == 3) {
         SqlExecutionArea* sqlWidget = qobject_cast<SqlExecutionArea*>(ui->tabSqlAreas->currentWidget());
 
-        if (sqlWidget)
+        if (sqlWidget) {
             m_currentTabTableModel = sqlWidget->getModel();
+
+            dataTableSelectionChanged(sqlWidget->getTableResult()->currentIndex());
+        }
     }
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -817,8 +817,8 @@ void MainWindow::dataTableSelectionChanged(const QModelIndex& index)
     if(!index.isValid())
         return;
 
-	bool edit = (m_currentTabTableModel == m_browseTableModel) &&
-	(db.getObjectByName(ui->comboBrowseTable->currentText()).gettype() == "table");
+    bool edit = (m_currentTabTableModel == m_browseTableModel) &&
+    (db.getObjectByName(ui->comboBrowseTable->currentText()).gettype() == "table");
 
     // Don't allow editing of other objects than tables
     editDock->allowEditing(edit);
@@ -975,22 +975,22 @@ void MainWindow::executeQuery()
 
 void MainWindow::mainTabSelected(int tabindex)
 {
-	editDock->allowEditing(false);
+    editDock->allowEditing(false);
 
-	if(tabindex == 0)
+    if(tabindex == 0)
     {
         populateStructure();
     } else if(tabindex == 1) {
-		m_currentTabTableModel = m_browseTableModel;
+        m_currentTabTableModel = m_browseTableModel;
         populateStructure();
         resetBrowser();
     } else if(tabindex == 2) {
         loadPragmas();
-	} else if(tabindex == 3) {
-		SqlExecutionArea* sqlWidget = qobject_cast<SqlExecutionArea*>(ui->tabSqlAreas->currentWidget());
+    } else if(tabindex == 3) {
+        SqlExecutionArea* sqlWidget = qobject_cast<SqlExecutionArea*>(ui->tabSqlAreas->currentWidget());
 
-		m_currentTabTableModel = sqlWidget->getModel();
-	}
+        m_currentTabTableModel = sqlWidget->getModel();
+    }
 }
 
 void MainWindow::importTableFromCSV()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -989,7 +989,8 @@ void MainWindow::mainTabSelected(int tabindex)
     } else if(tabindex == 3) {
         SqlExecutionArea* sqlWidget = qobject_cast<SqlExecutionArea*>(ui->tabSqlAreas->currentWidget());
 
-        m_currentTabTableModel = sqlWidget->getModel();
+        if (sqlWidget)
+            m_currentTabTableModel = sqlWidget->getModel();
     }
 }
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -794,8 +794,10 @@ void MainWindow::doubleClickTable(const QModelIndex& index)
     if(!index.isValid())
         return;
 
-    // Don't allow editing of other objects than tables
-    bool allowEditing = db.getObjectByName(ui->comboBrowseTable->currentText()).gettype() == "table";
+	// Don't allow editing of other objects than tables (on the browse table)
+
+	bool allowEditing = (m_currentTabTableModel == m_browseTableModel) && (db.getObjectByName(ui->comboBrowseTable->currentText()).gettype() == "table");
+
     editDock->allowEditing(allowEditing);
     editWin->allowEditing(allowEditing);
 
@@ -968,6 +970,9 @@ void MainWindow::executeQuery()
     updatePlot(sqlWidget->getModel());
 
     connect(sqlWidget->getTableResult(), SIGNAL(clicked(QModelIndex)), this, SLOT(dataTableSelectionChanged(QModelIndex)));
+
+	connect(sqlWidget->getTableResult(), SIGNAL(doubleClicked(QModelIndex)), this,
+			SLOT(doubleClickTable(QModelIndex)));
 
     if(!modified && !wasdirty)
         db.revertToSavepoint(); // better rollback, if the logic is not enough we can tune it.

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -103,7 +103,7 @@ private:
     Ui::MainWindow* ui;
 
     SqliteTableModel* m_browseTableModel;
-	SqliteTableModel* m_currentTabTableModel;
+    SqliteTableModel* m_currentTabTableModel;
     SqliteTableModel* m_currentPlotModel;
     QMenu *popupTableMenu;
     QMenu *recentFilesMenu;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -103,6 +103,7 @@ private:
     Ui::MainWindow* ui;
 
     SqliteTableModel* m_browseTableModel;
+	SqliteTableModel* m_currentTabTableModel;
     SqliteTableModel* m_currentPlotModel;
     QMenu *popupTableMenu;
     QMenu *recentFilesMenu;

--- a/src/SqlExecutionArea.cpp
+++ b/src/SqlExecutionArea.cpp
@@ -68,7 +68,7 @@ SqlTextEdit *SqlExecutionArea::getEditor()
 
 ExtendedTableWidget *SqlExecutionArea::getTableResult()
 {
-	return ui->tableResult;
+    return ui->tableResult;
 }
 
 

--- a/src/SqlExecutionArea.cpp
+++ b/src/SqlExecutionArea.cpp
@@ -66,6 +66,12 @@ SqlTextEdit *SqlExecutionArea::getEditor()
     return ui->editEditor;
 }
 
+ExtendedTableWidget *SqlExecutionArea::getTableResult()
+{
+	return ui->tableResult;
+}
+
+
 QTextEdit* SqlExecutionArea::getResultView()
 {
     return ui->editErrors;

--- a/src/SqlExecutionArea.h
+++ b/src/SqlExecutionArea.h
@@ -5,6 +5,8 @@
 
 #include <QWidget>
 
+#include "ExtendedTableWidget.h"
+
 class SqlTextEdit;
 class SqliteTableModel;
 class DBBrowserDB;
@@ -32,7 +34,8 @@ public:
     SqliteTableModel* getModel() { return model; }
     QTextEdit* getResultView();
     SqlTextEdit* getEditor();
-
+	ExtendedTableWidget *getTableResult();
+	
 public slots:
     virtual void finishExecution(const QString& result);
     virtual void enableSaveButton(bool enable);

--- a/src/SqlExecutionArea.h
+++ b/src/SqlExecutionArea.h
@@ -34,8 +34,8 @@ public:
     SqliteTableModel* getModel() { return model; }
     QTextEdit* getResultView();
     SqlTextEdit* getEditor();
-	ExtendedTableWidget *getTableResult();
-	
+    ExtendedTableWidget *getTableResult();
+    
 public slots:
     virtual void finishExecution(const QString& result);
     virtual void enableSaveButton(bool enable);


### PR DESCRIPTION
This patch allows to view result data from the _Execute SQL_ tab in the EditDialog.

This patch is lightweight and already useful to me - and hopefully other people

Ideally, I'd like to be able to edit the data too, but I couldn't get it to work, because when the user enters freeform SQL, it is nontrivial to determine what the underlying table is (see http://www.sqlite.org/sessions/lang_select.html).