### PR TITLE
package sqlite-devel required for CentOS

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -49,9 +49,9 @@ Done. :)
 
 ### CentOS / Fedora Linux
 
-**1**. Make sure the `qt-devel`, `ant-antlr`, and `antlr-C++` packages are installed.<br />
+**1**. Make sure the `qt-devel`, `ant-antlr`, `sqlite-devel`, and `antlr-C++` packages are installed.<br />
 ```
-$ sudo yum install qt-devel ant-antlr antlr-C++
+$ sudo yum install qt-devel ant-antlr sqlite-devel antlr-C++
 ```
 **2**. Download the DB Browser for SQLite source code.<br />
 **3**. Open a terminal in the source code directory.<br />


### PR DESCRIPTION
Added package `sqlite-devel` as a requirement for CentOS, because when I was building sqlitebrowser-3.8.0 from source on my Centos 7, command `cmake .` throwed error: 
```
CMake Error: The following variables are used in this project, but they are set to NOTFOUND.
Please set them or make sure they are set and tested correctly in the CMake files:
LIBSQLITE
    linked by target "sqlitebrowser" in directory /home/maxim/software/sqlitebrowser-3.8.0
```
Installing `sqlite-devel` from `base` repo fixed the problem.