### PR TITLE
Disabled bufferedDraw for smooth fonts on Retina and high DPI displays

### DIFF
--- a/libs/qscintilla/src/EditView.cpp
+++ b/libs/qscintilla/src/EditView.cpp
@@ -175,7 +175,7 @@ EditView::EditView() {
 	ldTabstops = NULL;
 	hideSelection = false;
 	drawOverstrikeCaret = true;
-	bufferedDraw = true;
+	bufferedDraw = false;
 	phasesDraw = phasesTwo;
 	lineWidthMaxSeen = 0;
 	additionalCaretsBlink = true;


### PR DESCRIPTION
A proposed fix for this issue
https://github.com/sqlitebrowser/sqlitebrowser/issues/498#issuecomment-214718575