### PR TITLE
RFC: Add SQLCipher version to the About dialog

### DIFF
--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -2,21 +2,27 @@
 #include "ui_AboutDialog.h"
 #include "version.h"
 #include "sqlite.h"
+#include "sqlitedb.h"
 
-AboutDialog::AboutDialog(QWidget *parent) :
+AboutDialog::AboutDialog(DBBrowserDB* _db, QWidget *parent) :
     QDialog(parent),
-    ui(new Ui::AboutDialog)
+    ui(new Ui::AboutDialog),
+    db(_db)
 {
+#ifdef ENABLE_SQLCIPHER
+    // Retrieve the SQLCipher version
+    QString sqlcipher_version = db->getPragma("cipher_version");
+#endif
+
+    // Display the About dialog
     ui->setupUi(this);
     this->setFixedSize(this->width(), this->height());
-
     ui->label_version->setText(tr("Version ") + APP_VERSION + "\n\n" +
                                tr("Qt Version ") + QT_VERSION_STR + "\n\n" +
 #ifdef ENABLE_SQLCIPHER
-                               tr("SQLCipher Version ") + SQLITE_VERSION
-#else
-                               tr("SQLite Version ") + SQLITE_VERSION
+                               tr("SQLCipher Version ") + sqlcipher_version + "\n\n" +
 #endif
+                               tr("SQLite Version ") + SQLITE_VERSION
                                );
 }
 

--- a/src/AboutDialog.h
+++ b/src/AboutDialog.h
@@ -7,16 +7,19 @@ namespace Ui {
 class AboutDialog;
 }
 
+class DBBrowserDB;
+
 class AboutDialog : public QDialog
 {
     Q_OBJECT
 
 public:
-    explicit AboutDialog(QWidget *parent = 0);
+    explicit AboutDialog(DBBrowserDB* _db, QWidget *parent = 0);
     ~AboutDialog();
 
 private:
     Ui::AboutDialog *ui;
+    DBBrowserDB* db;
 };
 
 #endif

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -765,7 +765,7 @@ void MainWindow::helpWhatsThis()
 
 void MainWindow::helpAbout()
 {
-    AboutDialog dialog(this);
+    AboutDialog dialog(&db, this);
     dialog.exec();
 }
 


### PR DESCRIPTION
Note - this is just for discussion at this point, don't merge it yet.

This commit adds the SQLCipher version number to the About dialog.

Weirdly, retrieving the SQLCipher version number appears to need an open database connection.  So, without an open database the field is left blank.

Updating this commit to cleanly handle both situations is required before merging this.

Btw - unsure if the requirement for an open database connection is something caused by our code, or a requirement from the underlying SQLCipher library itself.  The SQLCipher version seems like it should be available at compile time, not just at runtime.