### PR TITLE
Prevent crash when removing records

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -577,6 +577,10 @@ void MainWindow::deleteRecord()
 {
     if(ui->dataTable->selectionModel()->hasSelection())
     {
+        // If only filter header is selected
+        if(ui->dataTable->selectionModel()->selectedIndexes().isEmpty())
+            return;
+
         int old_row = ui->dataTable->currentIndex().row();
         while(ui->dataTable->selectionModel()->hasSelection())
         {


### PR DESCRIPTION
Steps to reproduce this issue:
1. Open table with no records at all (or remove them all)
2. Press Ctrl+A
3. Press "Delete record"
4. Watch the world burn

```
ASSERT: "!isEmpty()" in file /usr/include/qt/QtCore/qlist.h, line 335
The program has unexpectedly finished.
```