### PR TITLE
Add duplicate record option

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -22,6 +22,8 @@ ExtendedTableWidget::ExtendedTableWidget(QWidget* parent) :
     // Set up filter row
     m_tableHeader = new FilterTableHeader(this);
     setHorizontalHeader(m_tableHeader);
+
+    verticalHeader()->setContextMenuPolicy(Qt::CustomContextMenu);
 }
 
 void ExtendedTableWidget::copy()

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -135,6 +135,11 @@ void MainWindow::init()
     popupBrowseDataHeaderMenu->addSeparator();
     popupBrowseDataHeaderMenu->addAction(ui->actionSetAllTablesEncoding);
 
+    popupRecordMenu = new QMenu(this);
+    popupRecordMenu->addAction(ui->actionDittoRecord);
+    QShortcut* dittoRecordShortcut = new QShortcut(QKeySequence("Ctrl+\""), this);
+    connect(dittoRecordShortcut, SIGNAL(activated()), this, SLOT(dittoRecord()));
+
     // Add menu item for log dock
     ui->viewMenu->insertAction(ui->viewDBToolbarAction, ui->dockLog->toggleViewAction());
     ui->viewMenu->actions().at(0)->setShortcut(QKeySequence(tr("Ctrl+L")));
@@ -188,6 +193,7 @@ void MainWindow::init()
     connect(editDock, SIGNAL(updateRecordText(int, int, bool, QByteArray)), this, SLOT(updateRecordText(int, int, bool, QByteArray)));
     connect(ui->dbTreeWidget->selectionModel(), SIGNAL(currentChanged(QModelIndex,QModelIndex)), this, SLOT(changeTreeSelection()));
     connect(ui->dataTable->horizontalHeader(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showDataColumnPopupMenu(QPoint)));
+    connect(ui->dataTable->verticalHeader(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showRecordPopupMenu(QPoint)));
 
     // Load window settings
     tabifyDockWidget(ui->dockLog, ui->dockPlot);
@@ -597,6 +603,26 @@ void MainWindow::deleteRecord()
     } else {
         QMessageBox::information( this, QApplication::applicationName(), tr("Please select a record first"));
     }
+}
+
+void MainWindow::dittoRecord()
+{
+    const QString sCurrentTable = ui->comboBrowseTable->currentText();
+    if (!(db.getObjectByName(sCurrentTable).gettype() == "table" && !db.readOnly()))
+        return;
+
+    int row;
+    if (qobject_cast<QShortcut*>(sender()))
+        row = ui->dataTable->currentIndex().row();
+    else
+        row = ui->actionDittoRecord->property("current_row").toInt();
+
+    if (row == -1)
+        return;
+
+    addRecord();
+    QModelIndex idx = m_browseTableModel->dittoRecord(row);
+    ui->dataTable->setCurrentIndex(idx);
 }
 
 void MainWindow::selectTableLine(int lineToSelect)
@@ -2391,6 +2417,20 @@ void MainWindow::showDataColumnPopupMenu(const QPoint& pos)
 
     // Calculate the proper position for the context menu and display it
     popupBrowseDataHeaderMenu->exec(ui->dataTable->horizontalHeader()->mapToGlobal(pos));
+}
+
+void MainWindow::showRecordPopupMenu(const QPoint& pos)
+{
+    const QString sCurrentTable = ui->comboBrowseTable->currentText();
+    if (!(db.getObjectByName(sCurrentTable).gettype() == "table" && !db.readOnly()))
+        return;
+
+    int row = ui->dataTable->verticalHeader()->logicalIndexAt(pos);
+    if (row == -1)
+        return;
+
+    ui->actionDittoRecord->setProperty("current_row", row);
+    popupRecordMenu->exec(ui->dataTable->verticalHeader()->mapToGlobal(pos));
 }
 
 void MainWindow::editDataColumnDisplayFormat()

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -109,6 +109,7 @@ private:
     QMenu *recentFilesMenu;
     QMenu *popupSaveSqlFileMenu;
     QMenu* popupBrowseDataHeaderMenu;
+    QMenu* popupRecordMenu;
 
     QLabel* statusEncodingLabel;
     QLabel* statusEncryptionLabel;
@@ -164,6 +165,7 @@ private slots:
     bool fileClose();
     void addRecord();
     void deleteRecord();
+    void dittoRecord();
     void selectTableLine( int lineToSelect );
     void navigatePrevious();
     void navigateNext();
@@ -222,6 +224,7 @@ private slots:
     void on_comboLineType_currentIndexChanged(int index);
     void on_comboPointShape_currentIndexChanged(int index);
     void showDataColumnPopupMenu(const QPoint& pos);
+    void showRecordPopupMenu(const QPoint& pos);
     void editDataColumnDisplayFormat();
     void showRowidColumn(bool show);
     void browseDataSetTableEncoding(bool forAllTables = false);

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1824,6 +1824,14 @@
     <string>Change the default encoding assumed for all tables in the database</string>
    </property>
   </action>
+  <action name="actionDittoRecord">
+   <property name="text">
+    <string>Duplicate record</string>
+   </property>
+   <property name="toolTip">
+    <string>Duplicate record</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -2837,6 +2845,22 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionDittoRecord</sender>
+   <signal>triggered()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>dittoRecord()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>518</x>
+     <y>314</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>fileOpen()</slot>
@@ -2898,5 +2922,6 @@
   <slot>browseDataSetTableEncoding()</slot>
   <slot>browseDataSetDefaultTableEncoding()</slot>
   <slot>browseDataFetchAllData()</slot>
+  <slot>dittoRecord()</slot>
  </slots>
 </ui>

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -432,6 +432,26 @@ bool SqliteTableModel::removeRows(int row, int count, const QModelIndex& parent)
     return true;
 }
 
+QModelIndex SqliteTableModel::dittoRecord(int old_row)
+{
+    int firstEditedColumn = 0;
+    int new_row = rowCount() - 1;
+
+    sqlb::Table t = sqlb::Table::parseSQL(m_db->getObjectByName(m_sTable).getsql()).first;
+
+    for (int col = 0; col < t.fields().size(); ++col) {
+        if (!t.fields().at(col)->primaryKey()) {
+            if (!firstEditedColumn)
+                firstEditedColumn = col + 1;
+
+            QVariant value = data(index(old_row, col + 1), Qt::EditRole);
+            setData(index(new_row, col + 1), value);
+        }
+    }
+
+    return index(new_row, firstEditedColumn);
+}
+
 void SqliteTableModel::fetchData(unsigned int from, unsigned to)
 {
     int currentsize = m_data.size();

--- a/src/sqlitetablemodel.h
+++ b/src/sqlitetablemodel.h
@@ -29,6 +29,8 @@ public:
     bool insertRows(int row, int count, const QModelIndex& parent = QModelIndex());
     bool removeRows(int row, int count, const QModelIndex& parent = QModelIndex());
 
+    QModelIndex dittoRecord(int old_row);
+
     void setQuery(const QString& sQuery, bool dontClearHeaders = false);
     QString query() const { return m_sQuery; }
     void setTable(const QString& table, const QVector<QString> &display_format = QVector<QString>());


### PR DESCRIPTION
Summary about this patch:

1. One can duplicate record via:
  * context popup menu over the record in table 
  * shortcut Ctrl-" 
2. The very first *copied* value in new row is focused. Primary keys are ignored.
3. Copied alues aren't written to db instantly until "Write changes"

In #577 there was suggestion to provide "duplicate field". I find this feature ambiguous tho, *especially* for user. So much depends on which row is currently selected, which row should be copied where and so on. I guess, in this case one should really just Ctrl-C Ctrl-V. 
So, since original feature request was about duplicating *records*, this closes #577 . We can discuss better design for ditto field separately.