### PR TITLE
Fix database toolbar actions not updating after deleting a table

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -734,6 +734,7 @@ void MainWindow::deleteObject()
         } else {
             populateStructure();
             resetBrowser();
+            changeTreeSelection();
         }
     }
 }


### PR DESCRIPTION
After deleting a table, the `Delete Table` button remained active and if pressed, it tried to delete table `''`.