### PR TITLE
Update buttons in removal message boxes

### DIFF
--- a/src/EditTableDialog.cpp
+++ b/src/EditTableDialog.cpp
@@ -498,7 +498,7 @@ void EditTableDialog::removeField()
 
         // Ask user whether he really wants to delete that column
         QString msg = tr("Are you sure you want to delete the field '%1'?\nAll data currently stored in this field will be lost.").arg(ui->treeWidget->currentItem()->text(0));
-        if(QMessageBox::warning(this, QApplication::applicationName(), msg, QMessageBox::Yes | QMessageBox::Default, QMessageBox::No | QMessageBox::Escape) == QMessageBox::Yes)
+        if(QMessageBox::warning(this, QApplication::applicationName(), msg, QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes)
         {
             if(!pdb->renameColumn(curTable, ui->treeWidget->currentItem()->text(0), sqlb::FieldPtr()))
             {

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -754,7 +754,7 @@ void MainWindow::deleteObject()
 
     // Ask user if he really wants to delete that table
     if(QMessageBox::warning(this, QApplication::applicationName(), tr("Are you sure you want to delete the %1 '%2'?\nAll data associated with the %1 will be lost.").arg(type).arg(table),
-                            QMessageBox::Yes, QMessageBox::No | QMessageBox::Default | QMessageBox::Escape) == QMessageBox::Yes)
+                            QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::Yes)
     {
         // Delete the table
         QString statement = QString("DROP %1 %2;").arg(type.toUpper()).arg(sqlb::escapeIdentifier(table));


### PR DESCRIPTION
Fixes #616 plus table removal dialog.
You might notice, that QMessageBox::Default and QMessageBox::Escape are removed. That's for a reason, those are obsolete for a long time. Default button is listed in the last parameter.
What about QMessageBox::Escape, we don't need setEscapeButton here, since it's straightforward and redundant. Closed dialog means declined removal operation.

And of course, "No" is our default button now.