### PR TITLE
Add SQLCipher saved passwords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 before_install:
   - sudo add-apt-repository ppa:likemartinma/devel -y
   - sudo apt-get update -qq
-  - sudo apt-get install -qq libqt4-dev libsqlite3-dev libsqlcipher-dev libantlr-dev
+  - sudo apt-get --force-yes install -qq libqt4-dev libsqlite3-dev libsqlcipher-dev libantlr-dev
 
 script:
   - mkdir build

--- a/src/CipherDialog.cpp
+++ b/src/CipherDialog.cpp
@@ -51,6 +51,11 @@ int CipherDialog::pageSize() const
     return ui->spinPageSize->value();
 }
 
+bool CipherDialog::isSavePasswordEnabled() const
+{
+    return ui->savePasswordCheckBox->isChecked();
+}
+
 void CipherDialog::checkInputFields()
 {
     bool valid = true;

--- a/src/CipherDialog.cpp
+++ b/src/CipherDialog.cpp
@@ -10,6 +10,8 @@ CipherDialog::CipherDialog(QWidget* parent, bool encrypt) :
 {
     ui->setupUi(this);
 
+    savedPageSize = 0;
+
     if(encrypt)
     {
         ui->labelDialogDescription->setText(tr("Please set a key to encrypt the database.\nNote that if you change any of the other, optional, settings you'll need "
@@ -31,11 +33,21 @@ CipherDialog::~CipherDialog()
 
 QString CipherDialog::password() const
 {
+    if (savedPassword != NULL)
+    {
+        return savedPassword;
+    }
+
     return ui->editPassword->text();
 }
 
 int CipherDialog::pageSize() const
 {
+    if (savedPageSize > 0)
+    {
+        return savedPageSize;
+    }
+
     return ui->spinPageSize->value();
 }
 

--- a/src/CipherDialog.h
+++ b/src/CipherDialog.h
@@ -24,6 +24,7 @@ public:
     // Allow read access to the input fields
     QString password() const;
     int pageSize() const;
+    bool isSavePasswordEnabled() const;
 
 private:
     Ui::CipherDialog* ui;

--- a/src/CipherDialog.h
+++ b/src/CipherDialog.h
@@ -17,6 +17,10 @@ public:
     explicit CipherDialog(QWidget* parent, bool encrypt);
     ~CipherDialog();
 
+    // Set these to the values from the preferences settings
+    QString savedPassword;
+    int savedPageSize;
+
     // Allow read access to the input fields
     QString password() const;
     int pageSize() const;

--- a/src/CipherDialog.ui
+++ b/src/CipherDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>712</width>
-    <height>147</height>
+    <height>202</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -78,6 +78,16 @@
         <number>1024</number>
        </property>
       </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="savePasswordLabel">
+       <property name="text">
+        <string>Save password</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QCheckBox" name="savePasswordCheckBox"/>
      </item>
     </layout>
    </item>

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -65,7 +65,7 @@ void PreferencesDialog::loadSettings()
     ui->spinPrefetchSize->setValue(getSettingsValue("db", "prefetchsize").toInt());
     ui->editDatabaseDefaultSqlText->setText(getSettingsValue("db", "defaultsqltext").toString());
 
-    QMap<QString, QVariant> databasePasswords = getSettingsValue("db", "databasepasswords").toMap();
+    DatabasePasswordsMap databasePasswords = getSettingsValue("db", "databasepasswords").toMap();
     QMapIterator<QString, QVariant> databasePasswordsIterator(databasePasswords);
 
     while (databasePasswordsIterator.hasNext())
@@ -144,7 +144,7 @@ void PreferencesDialog::saveSettings()
 
     ui->tableWidgetDatabasePasswords->setCurrentIndex(QModelIndex()); // saves the current editing QTableWidgetItem
 
-    QMap<QString, QVariant> databasePasswords;
+    DatabasePasswordsMap databasePasswords;
 
     for(int rowIndex = 0; rowIndex < ui->tableWidgetDatabasePasswords->rowCount(); ++rowIndex)
     {

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -73,7 +73,9 @@ void PreferencesDialog::loadSettings()
         databasePasswordsIterator.next();
 
         QString fileName = databasePasswordsIterator.key();
+
         QVariantList value = databasePasswordsIterator.value().toList();
+
         QString password = value.at(0).toString();
         int pageSize = value.at(1).toInt();
 
@@ -150,15 +152,18 @@ void PreferencesDialog::saveSettings()
         QTableWidgetItem *passwordItem = ui->tableWidgetDatabasePasswords->item(rowIndex, 1);
         QTableWidgetItem *pageSizeItem = ui->tableWidgetDatabasePasswords->item(rowIndex, 2);
 
-        if (!fileNameItem) {
+        if (!fileNameItem)
+        {
             continue;
         }
 
-        if (!passwordItem) {
+        if (!passwordItem)
+        {
             continue;
         }
 
-        if (!pageSizeItem) {
+        if (!pageSizeItem)
+        {
             continue;
         }
 
@@ -166,11 +171,13 @@ void PreferencesDialog::saveSettings()
         QString password = passwordItem->text();
         int pageSize = pageSizeItem->text().toInt();
 
-        if (fileName == NULL || fileName.isEmpty()) {
+        if (fileName == NULL || fileName.isEmpty())
+        {
             continue;
         }
 
-        if (password == NULL || password.isEmpty()) {
+        if (password == NULL || password.isEmpty())
+        {
             continue;
         }
 

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -525,6 +525,22 @@ void PreferencesDialog::on_buttonAddPassword_clicked()
     QTableWidgetItem *defaultPageSizeItem = new QTableWidgetItem("1024");
 
     ui->tableWidgetDatabasePasswords->setItem(newRowIndex, 2, defaultPageSizeItem);
+
+    QString filePath = FileDialog::getOpenFileName(
+                this,
+                tr("Choose a database file")
+#ifndef Q_OS_MAC // Filters on OS X are buggy
+                , FileDialog::getSqlDatabaseFileFilter()
+#endif
+                );
+
+    QFile databaseFile(filePath);
+    QFileInfo databaseFileInfo(databaseFile);
+    QString databaseFileName(databaseFileInfo.fileName());
+
+    QTableWidgetItem *databaseFileNameItem = new QTableWidgetItem(databaseFileName);
+
+    ui->tableWidgetDatabasePasswords->setItem(newRowIndex, 0, databaseFileNameItem);
 }
 
 void PreferencesDialog::on_buttonDeletePassword_clicked()

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -5,6 +5,9 @@
 #include <QVariant>
 #include <QHash>
 
+typedef QMultiMap<QString, QVariant> DatabasePasswordsMap;
+Q_DECLARE_METATYPE(DatabasePasswordsMap)
+
 class QTreeWidgetItem;
 class QFrame;
 

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -33,6 +33,9 @@ private slots:
     virtual void addExtension();
     virtual void removeExtension();
 
+    virtual void on_buttonAddPassword_clicked();
+    virtual void on_buttonDeletePassword_clicked();
+
 private:
     Ui::PreferencesDialog *ui;
 

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>590</width>
-    <height>555</height>
+    <width>651</width>
+    <height>597</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
    <item>
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="tab_4">
       <attribute name="title">
@@ -145,57 +145,11 @@
       <attribute name="title">
        <string>&amp;Database</string>
       </attribute>
-      <layout class="QFormLayout" name="formLayout">
-       <property name="fieldGrowthPolicy">
-        <enum>QFormLayout::FieldsStayAtSizeHint</enum>
-       </property>
-       <property name="labelAlignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="formAlignment">
-        <set>Qt::AlignHCenter|Qt::AlignTop</set>
-       </property>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label">
+      <layout class="QGridLayout" name="gridLayout_5">
+       <item row="8" column="0">
+        <widget class="QLabel" name="label_21">
          <property name="text">
-          <string>Database &amp;encoding</string>
-         </property>
-         <property name="buddy">
-          <cstring>encodingComboBox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="encodingComboBox">
-         <item>
-          <property name="text">
-           <string notr="true">UTF-8</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string notr="true">UTF-16</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="label_5">
-         <property name="toolTip">
-          <string>Open databases with foreign keys enabled.</string>
-         </property>
-         <property name="text">
-          <string>&amp;Foreign keys</string>
-         </property>
-         <property name="buddy">
-          <cstring>foreignKeysCheckBox</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QCheckBox" name="foreignKeysCheckBox">
-         <property name="text">
-          <string>enabled</string>
+          <string>Password to use for crypted databases</string>
          </property>
         </widget>
        </item>
@@ -212,15 +166,109 @@
        <item row="2" column="1">
         <widget class="QCheckBox" name="checkHideSchemaLinebreaks"/>
        </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label_2">
+       <item row="0" column="1">
+        <widget class="QComboBox" name="encodingComboBox">
+         <item>
+          <property name="text">
+           <string notr="true">UTF-8</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string notr="true">UTF-16</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QPushButton" name="buttonDatabaseAdvanced">
          <property name="text">
-          <string>Prefetch block si&amp;ze</string>
+          <string>Advanced</string>
          </property>
-         <property name="buddy">
-          <cstring>spinPrefetchSize</cstring>
+         <property name="icon">
+          <iconset resource="icons/icons.qrc">
+           <normaloff>:/icons/down</normaloff>:/icons/down</iconset>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
          </property>
         </widget>
+       </item>
+       <item row="8" column="1">
+        <layout class="QVBoxLayout" name="verticalLayout_7">
+         <item>
+          <widget class="QTableWidget" name="tableWidgetDatabasePasswords">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="horizontalScrollMode">
+            <enum>QAbstractItemView::ScrollPerPixel</enum>
+           </property>
+           <column>
+            <property name="text">
+             <string>File name</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Password</string>
+            </property>
+           </column>
+           <column>
+            <property name="text">
+             <string>Page size</string>
+            </property>
+           </column>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <item>
+            <widget class="QPushButton" name="buttonAddPassword">
+             <property name="text">
+              <string>Add password</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="buttonDeletePassword">
+             <property name="text">
+              <string>Delete password</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_3">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </item>
+       <item row="9" column="1">
+        <spacer name="horizontalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>180</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
        </item>
        <item row="3" column="1">
         <widget class="QSpinBox" name="spinPrefetchSize">
@@ -232,17 +280,53 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
-        <widget class="QPushButton" name="buttonDatabaseAdvanced">
+       <item row="0" column="0">
+        <widget class="QLabel" name="label">
          <property name="text">
-          <string>Advanced</string>
+          <string>Database &amp;encoding</string>
          </property>
-         <property name="icon">
-          <iconset resource="icons/icons.qrc">
-           <normaloff>:/icons/down</normaloff>:/icons/down</iconset>
+         <property name="buddy">
+          <cstring>encodingComboBox</cstring>
          </property>
-         <property name="checkable">
-          <bool>true</bool>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="toolTip">
+          <string>Open databases with foreign keys enabled.</string>
+         </property>
+         <property name="text">
+          <string>&amp;Foreign keys</string>
+         </property>
+         <property name="buddy">
+          <cstring>foreignKeysCheckBox</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Prefetch block si&amp;ze</string>
+         </property>
+         <property name="buddy">
+          <cstring>spinPrefetchSize</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="foreignKeysCheckBox">
+         <property name="text">
+          <string>enabled</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0">
+        <widget class="QLabel" name="labelDatabaseDefaultSqlText">
+         <property name="text">
+          <string>SQL to execute after opening database</string>
+         </property>
+         <property name="buddy">
+          <cstring>editDatabaseDefaultSqlText</cstring>
          </property>
         </widget>
        </item>
@@ -259,69 +343,6 @@
            <width>16777215</width>
            <height>200</height>
           </size>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0">
-        <widget class="QLabel" name="labelDatabaseDefaultSqlText">
-         <property name="text">
-          <string>SQL to execute after opening database</string>
-         </property>
-         <property name="buddy">
-          <cstring>editDatabaseDefaultSqlText</cstring>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>180</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="label_21">
-         <property name="text">
-          <string>Password to use for crypted databases</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="1">
-        <widget class="QTableWidget" name="tableWidgetDatabasePasswords">
-         <column>
-          <property name="text">
-           <string>File name</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Password</string>
-          </property>
-         </column>
-         <column>
-          <property name="text">
-           <string>Page size</string>
-          </property>
-         </column>
-        </widget>
-       </item>
-       <item row="8" column="1">
-        <widget class="QPushButton" name="buttonAddPassword">
-         <property name="text">
-          <string>Add password</string>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QPushButton" name="buttonDeletePassword">
-         <property name="text">
-          <string>Delete password</string>
          </property>
         </widget>
        </item>
@@ -988,6 +1009,19 @@
       </layout>
      </widget>
     </widget>
+   </item>
+   <item>
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>590</width>
-    <height>532</height>
+    <height>555</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -272,7 +272,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="10" column="1">
         <spacer name="horizontalSpacer_2">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -284,6 +284,46 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="label_21">
+         <property name="text">
+          <string>Password to use for crypted databases</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="1">
+        <widget class="QTableWidget" name="tableWidgetDatabasePasswords">
+         <column>
+          <property name="text">
+           <string>File name</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Password</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Page size</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+       <item row="8" column="1">
+        <widget class="QPushButton" name="buttonAddPassword">
+         <property name="text">
+          <string>Add password</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="1">
+        <widget class="QPushButton" name="buttonDeletePassword">
+         <property name="text">
+          <string>Delete password</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -259,7 +259,8 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
 
                         // Set key and, if it differs from the default value, the page size
                         sqlite3_key(dbHandle, password.toUtf8(), password.toUtf8().length());
-                        if(pageSize != 1024) {
+                        if(pageSize != 1024)
+                        {
                             sqlite3_exec(dbHandle, QString("PRAGMA cipher_page_size = %1;").arg(pageSize).toUtf8(), NULL, NULL, NULL);
                         }
 
@@ -294,7 +295,9 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                 // Set key and, if it differs from the default value, the page size
                 sqlite3_key(dbHandle, cipherSettings->password().toUtf8(), cipherSettings->password().toUtf8().length());
                 if(cipherSettings->pageSize() != 1024)
+                {
                     sqlite3_exec(dbHandle, QString("PRAGMA cipher_page_size = %1;").arg(cipherSettings->pageSize()).toUtf8(), NULL, NULL, NULL);
+                }
 
                 *encrypted = true;
             } else {

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -213,7 +213,11 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
         return false;
 
     // Try reading from database
+
+#ifdef ENABLE_SQLCIPHER
     bool isDatabasePasswordChecked = false;
+#endif
+
     *encrypted = false;
     cipherSettings = 0;
 

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -241,7 +241,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                 {
                     QFile databaseFile(filePath);
                     QFileInfo databaseFileInfo(databaseFile);
-                    QString databaseFileName(databaseFileInfo.baseName());
+                    QString databaseFileName(databaseFileInfo.fileName());
 
                     if (databasePasswords.contains(databaseFileName))
                     {
@@ -327,7 +327,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
 
                 QFile databaseFile(filePath);
                 QFileInfo databaseFileInfo(databaseFile);
-                QString databaseFileName(databaseFileInfo.baseName());
+                QString databaseFileName(databaseFileInfo.fileName());
 
                 QVariantList value;
 

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -321,6 +321,24 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
             return false;
 #endif
         } else {
+            if (cipherSettings->isSavePasswordEnabled())
+            {
+                DatabasePasswordsMap databasePasswords = PreferencesDialog::getSettingsValue("db", "databasepasswords").toMap();
+
+                QFile databaseFile(filePath);
+                QFileInfo databaseFileInfo(databaseFile);
+                QString databaseFileName(databaseFileInfo.baseName());
+
+                QVariantList value;
+
+                value.append(QVariant(cipherSettings->password()));
+                value.append(QVariant(cipherSettings->pageSize()));
+
+                databasePasswords.insert(databaseFileName, value);
+
+                PreferencesDialog::setSettingsValue("db", "databasepasswords", databasePasswords);
+            }
+
             sqlite3_finalize(vm);
             sqlite3_close(dbHandle);
             return true;

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -321,6 +321,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
             return false;
 #endif
         } else {
+#ifdef ENABLE_SQLCIPHER
             if (cipherSettings->isSavePasswordEnabled())
             {
                 DatabasePasswordsMap databasePasswords = PreferencesDialog::getSettingsValue("db", "databasepasswords").toMap();
@@ -338,6 +339,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
 
                 PreferencesDialog::setSettingsValue("db", "databasepasswords", databasePasswords);
             }
+#endif
 
             sqlite3_finalize(vm);
             sqlite3_close(dbHandle);

--- a/src/sqlitedb.h
+++ b/src/sqlitedb.h
@@ -136,7 +136,7 @@ private:
     bool isEncrypted;
     bool isReadOnly;
 
-    bool tryEncryptionSettings(const QString& filename, bool* encrypted, CipherDialog*& cipherSettings);
+    bool tryEncryptionSettings(const QString& filePath, bool* encrypted, CipherDialog*& cipherSettings);
 };
 
 #endif


### PR DESCRIPTION
This PR adds the option to save a password per database file name and upon trying to open an encrypted database for which the password was saved in the Preferences, it opens up automatically, without the need for user input.

Fixed #486.