### PR TITLE
Fix for unquoted path vulnerability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -375,8 +375,8 @@ if(WIN32 AND NOT UNIX)
 
 	# VS redist
 	list(APPEND CPACK_NSIS_EXTRA_INSTALL_COMMANDS "
-               ExecWait '$INSTDIR\\\\tmp\\\\${VSREDIST} /install /passive /quiet'
-               Delete '$INSTDIR\\\\tmp\\\\${VSREDIST}'
+               ExecWait '\\\"$INSTDIR\\\\tmp\\\\${VSREDIST}\\\" /install /passive /quiet'
+               Delete '\\\"$INSTDIR\\\\tmp\\\\${VSREDIST}\\\"'
                ")
 else(WIN32 AND NOT UNIX)
 	set(CPACK_STRIP_FILES "bin/sqlitebrowser")


### PR DESCRIPTION
See issue #621 for details.

I built a new installation package and during installation on Windows 7
I could  see that the previously unquoted path is now quoted.