### PR TITLE
Rationalise the Edit Cell dock and Windows code into one

### DIFF
--- a/src/EditDialog.cpp
+++ b/src/EditDialog.cpp
@@ -8,14 +8,13 @@
 #include <QKeySequence>
 #include <QShortcut>
 
-EditDialog::EditDialog(QWidget* parent, bool forUseInDockWidget)
+EditDialog::EditDialog(QWidget* parent)
     : QDialog(parent),
-      ui(new Ui::EditDialog),
-      useInDock(forUseInDockWidget)
+      ui(new Ui::EditDialog)
 {
     ui->setupUi(this);
     ui->buttonBox->button(QDialogButtonBox::Ok)->setShortcut(QKeySequence(Qt::CTRL + Qt::Key_Return));
-    ui->buttonBox->button(QDialogButtonBox::Cancel)->setVisible(!forUseInDockWidget);
+    ui->buttonBox->button(QDialogButtonBox::Cancel)->setVisible(true);
 
     QHBoxLayout* hexLayout = new QHBoxLayout(ui->editorBinary);
     hexEdit = new QHexEdit(this);
@@ -66,15 +65,9 @@ void EditDialog::reject()
 {
     // This is called when pressing the cancel button or hitting the escape key
 
-    // If we're in dock mode, reset all fields and move the cursor back to the table view.
-    // If we're in window mode, call the default implementation to just close the window normally.
-    if(useInDock)
-    {
-        loadText(oldData, curRow, curCol);
-        emit goingAway();
-    } else {
-        QDialog::reject();
-    }
+    // Reset all fields and move the cursor back to the table view
+    loadText(oldData, curRow, curCol);
+    emit goingAway();
 }
 
 void EditDialog::loadText(const QByteArray& data, int row, int col)
@@ -238,16 +231,16 @@ void EditDialog::setFocus()
 {
     QDialog::setFocus();
 
-    // When in dock mode set the focus to the editor widget. The idea here is that setting focus to the
-    // dock itself doesn't make much sense as it's just a frame; you'd have to tab to the editor which is what you
-    // most likely want to use. So in order to save the user from doing this we explicitly set the focus to the editor.
-    if(useInDock)
-    {
-        ui->editorText->setFocus();
-        ui->editorText->selectAll();
-    }
+    // Set the focus to the editor widget. The idea here is that setting focus
+    // to the dock itself doesn't make much sense as it's just a frame; you'd
+    // have to tab to the editor which is what you most likely want to use. So
+    // in order to save the user from doing this we explicitly set the focus
+    // to the editor.
+    ui->editorText->setFocus();
+    ui->editorText->selectAll();
 }
 
+// Enables or disables the OK/Clear/Import buttons in the Edit Cell dock
 void EditDialog::allowEditing(bool on)
 {
     ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(on);

--- a/src/EditDialog.h
+++ b/src/EditDialog.h
@@ -14,7 +14,7 @@ class EditDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit EditDialog(QWidget* parent = 0, bool forUseInDockWidget = false);
+    explicit EditDialog(QWidget* parent = 0);
     ~EditDialog();
 
     int getCurrentCol() { return curCol; }
@@ -47,7 +47,6 @@ signals:
 
 private:
     Ui::EditDialog* ui;
-    bool useInDock;
     QHexEdit* hexEdit;
     QByteArray oldData;
     int curCol;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -71,6 +71,16 @@ MainWindow::~MainWindow()
 
 void MainWindow::init()
 {
+    // Load window settings
+    tabifyDockWidget(ui->dockLog, ui->dockPlot);
+    tabifyDockWidget(ui->dockLog, ui->dockSchema);
+    restoreGeometry(PreferencesDialog::getSettingsValue("MainWindow", "geometry").toByteArray());
+    restoreState(PreferencesDialog::getSettingsValue("MainWindow", "windowState").toByteArray());
+    ui->comboLogSubmittedBy->setCurrentIndex(ui->comboLogSubmittedBy->findText(PreferencesDialog::getSettingsValue("SQLLogDock", "Log").toString()));
+    ui->splitterForPlot->restoreState(PreferencesDialog::getSettingsValue("PlotDock", "splitterSize").toByteArray());
+    ui->comboLineType->setCurrentIndex(PreferencesDialog::getSettingsValue("PlotDock", "lineType").toInt());
+    ui->comboPointShape->setCurrentIndex(PreferencesDialog::getSettingsValue("PlotDock", "pointShape").toInt());
+
     // Connect SQL logging and database state setting to main window
     connect(&db, SIGNAL(dbChanged(bool)), this, SLOT(dbState(bool)));
     connect(&db, SIGNAL(sqlExecuted(QString, int)), this, SLOT(logSql(QString,int)));
@@ -197,16 +207,6 @@ void MainWindow::init()
     connect(ui->dbTreeWidget->selectionModel(), SIGNAL(currentChanged(QModelIndex,QModelIndex)), this, SLOT(changeTreeSelection()));
     connect(ui->dataTable->horizontalHeader(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showDataColumnPopupMenu(QPoint)));
     connect(ui->dataTable->verticalHeader(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showRecordPopupMenu(QPoint)));
-
-    // Load window settings
-    tabifyDockWidget(ui->dockLog, ui->dockPlot);
-    tabifyDockWidget(ui->dockLog, ui->dockSchema);
-    restoreGeometry(PreferencesDialog::getSettingsValue("MainWindow", "geometry").toByteArray());
-    restoreState(PreferencesDialog::getSettingsValue("MainWindow", "windowState").toByteArray());
-    ui->comboLogSubmittedBy->setCurrentIndex(ui->comboLogSubmittedBy->findText(PreferencesDialog::getSettingsValue("SQLLogDock", "Log").toString()));
-    ui->splitterForPlot->restoreState(PreferencesDialog::getSettingsValue("PlotDock", "splitterSize").toByteArray());
-    ui->comboLineType->setCurrentIndex(PreferencesDialog::getSettingsValue("PlotDock", "lineType").toInt());
-    ui->comboPointShape->setCurrentIndex(PreferencesDialog::getSettingsValue("PlotDock", "pointShape").toInt());
 
     // plot widgets
     ui->treePlotColumns->setSelectionMode(QAbstractItemView::NoSelection);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -123,7 +123,6 @@ private:
 
     QMap<QString, BrowseDataTableSettings> browseTableSettings;
 
-    EditDialog* editWin;
     EditDialog* editDock;
     QIntValidator* gotoValidator;
 
@@ -181,7 +180,7 @@ private slots:
     void helpWhatsThis();
     void helpAbout();
     void updateRecordText(int row, int col, bool type, const QByteArray& newtext);
-    void editWinAway();
+    void editDockAway();
     void dataTableSelectionChanged(const QModelIndex& index);
     void doubleClickTable(const QModelIndex& index);
     void executeQuery();

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1274,7 +1274,7 @@
   </widget>
   <widget class="QDockWidget" name="dockSchema">
    <property name="windowTitle">
-    <string>DB Sche&amp;ma</string>
+    <string>DB Schema</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>2</number>
@@ -1297,9 +1297,9 @@
     </layout>
    </widget>
   </widget>
-  <widget class="QDockWidget" name="dockEditWindow">
+  <widget class="QDockWidget" name="dockEdit">
    <property name="windowTitle">
-    <string>Edit &amp;cell</string>
+    <string>Edit Database Cell</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>8</number>


### PR DESCRIPTION
Prior to this PR, we've had the Edit Cell be available both in a "dock" and "window"
mode, both at the same time. (!)

The "dock" mode already had tear off window functionality and was more
complete, whereas the "window" mode was buggy and didn't really add
anything new.

This PR removes the "window" version of the dock, and cleans up the handling of
"dock" mode, so there's just one Edit Cell dock now.  It can be torn off and used
as a window, docked to the main UI (by double clicking its title bar), and toggled
on/off with Ctrl-E (Cmd-E on OSX).