### PR TITLE
Fix Filter Input Row in RTL Locales

### DIFF
--- a/src/FilterTableHeader.cpp
+++ b/src/FilterTableHeader.cpp
@@ -76,7 +76,10 @@ void FilterTableHeader::adjustPositions()
     {
         // Get the current widget, move it and resize it
         QWidget* w = filterWidgets.at(i);
-        w->move(sectionPosition(i) - offset(), w->sizeHint().height() + 2);   // The two adds some extra space between the header label and the input widget
+        if (layoutDirection() == Qt::RightToLeft)
+            w->move(width() - (sectionPosition(i) + sectionSize(i) - offset()), w->sizeHint().height() + 2);   // The two adds some extra space between the header label and the input widget
+        else
+            w->move(sectionPosition(i) - offset(), w->sizeHint().height() + 2);   // The two adds some extra space between the header label and the input widget
         w->resize(sectionSize(i), w->sizeHint().height());
     }
 }


### PR DESCRIPTION
The filter input row isn't mirrored in RTL locales.
That is because Qt draws from left to right, and the painting wasn't recognizing RTL locales.
This fix does change the position of the inputs to be drawn from right to left (Using `width() - ..`).

According to Qt documentation:
> The position is measured in pixels from the first visible item's top-left corner to the top-left corner of the item with logicalIndex.

For that the size of the column is added to the postion so that it's measured from the top-right corner to the top-right corner.

Fixes #631