### PR TITLE
Add Backspace and Alt+Backspace key support

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -195,7 +195,7 @@ void ExtendedTableWidget::keyPressEvent(QKeyEvent* event)
               selectedIndexes().at(0).row() == model()->rowCount()-1 && selectedIndexes().at(0).column() == model()->columnCount()-1) {
         // If the Tab key was pressed while the focus was on the last cell of the last row insert a new row automatically
         model()->insertRow(model()->rowCount());
-    } else if(event->key() == Qt::Key_Delete) {
+    } else if ((event->key() == Qt::Key_Delete) || (event->key() == Qt::Key_Backspace)) {
         if(event->modifiers().testFlag(Qt::AltModifier))
         {
             // When pressing Alt+Delete set the value to NULL


### PR DESCRIPTION
They now perform the same functions as Delete, and Alt+Delete.

This is useful for people using keyboards without a dedicated
Delete key. For example at least some Apple laptops.