### PR TITLE
Fix Binary In-Place Editable Cell

### DIFF
--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -623,7 +623,7 @@ void SqliteTableModel::clearCache()
 
 bool SqliteTableModel::isBinary(const QModelIndex& index) const
 {
-    return m_vDataTypes.at(index.column()) == SQLITE_BLOB;
+    return m_data.at(index.row()).at(index.column()).left(1024).contains('\0');
 }
 
 QByteArray SqliteTableModel::encode(const QByteArray& str) const


### PR DESCRIPTION
Instead of checking the column datatype, this will check the cell datatype.
Copied from the same file in the `data` method: https://github.com/sqlitebrowser/sqlitebrowser/blob/master/src/sqlitetablemodel.cpp#L223

Fixes #674 