### PR TITLE
Improved copy/pasting in ExtendedTableWidget

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -96,28 +96,6 @@ void ExtendedTableWidget::copy()
         }
     }
 
-    // Check whether selection is rectangular
-    QItemSelection rect(indices.first(), indices.last());
-    bool correct = true;
-
-    foreach (const QModelIndex& index, indices)
-        if (!rect.contains(index)) {
-            correct = false;
-            break;
-        }
-
-    foreach (const QModelIndex& index, rect.indexes())
-        if (!indices.contains(index)) {
-            correct = false;
-            break;
-        }
-
-    if (!correct) {
-        QMessageBox::warning(this, QApplication::applicationName(),
-                             tr("This function cannot be used with multiple independent selections."));
-        return;
-    }
-
     m_buffer.clear();
 
     // If any of the cells contain binary data - we use inner buffer

--- a/src/ExtendedTableWidget.h
+++ b/src/ExtendedTableWidget.h
@@ -27,6 +27,9 @@ private:
     void paste();
     int numVisibleRows();
 
+    typedef QList<QByteArray> QByteArrayList;
+    QList<QByteArrayList> m_buffer;
+
 private slots:
     void vscrollbarChanged(int value);
     void cellClicked(const QModelIndex& index);

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -198,6 +198,9 @@
           <property name="defaultDropAction">
            <enum>Qt::CopyAction</enum>
           </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::ContiguousSelection</enum>
+          </property>
           <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
            <bool>true</bool>
           </attribute>


### PR DESCRIPTION
* NULLs are now copied and pasted correctly
* Ctrl+C allows only rectangular selections (multi-selections should be provided later with Ctrl+Shift+C and not use clipboard)

Testing is much appreciated.

NB. return in 199L is workaround, because  of mess with keyPressEvent in 226L.