### PR TITLE
Indicate when display strings are being truncated

### DIFF
--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -361,7 +361,7 @@
                </sizepolicy>
               </property>
               <property name="minimum">
-               <number>1000</number>
+               <number>1</number>
               </property>
               <property name="maximum">
                <number>20000</number>

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -227,7 +227,13 @@ QVariant SqliteTableModel::data(const QModelIndex &index, int role) const
             return "BLOB";
         } else if(role == Qt::DisplayRole) {
             int limit = Settings::getSettingsValue("databrowser", "symbol_limit").toInt();
-            return decode(m_data.at(index.row()).at(index.column()).left(limit));
+            QByteArray displayText = m_data.at(index.row()).at(index.column());
+            if (displayText.length() > limit) {
+                // Add "..." to the end of truncated strings
+                return decode(displayText.left(limit).append(" ..."));
+            } else {
+                return decode(displayText);
+            }
         } else {
             return decode(m_data.at(index.row()).at(index.column()));
         }


### PR DESCRIPTION
Also reduce the minimum length to 1, just in case it's useful for
people.

For #761.