### PR TITLE
Fixed executing current SQL line not working for multiple lines SQLs

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -865,13 +865,13 @@ void MainWindow::executeQuery()
         int position = editor->positionFromLineIndex(cursor_line, cursor_index);
 
         QString entireSQL = editor->text();
-        QString firstPartEntireSQL = entireSQL.left(position);
-        QString secondPartEntireSQL = entireSQL.right(entireSQL.length() - position);
+        QStringRef firstPartEntireSQL = entireSQL.leftRef(position);
+        QStringRef secondPartEntireSQL = entireSQL.rightRef(entireSQL.length() - position);
 
-        QString firstPartSQL = firstPartEntireSQL.split(";").last();
-        QString lastPartSQL = secondPartEntireSQL.split(";").first();
+        QStringRef firstPartSQL = firstPartEntireSQL.split(";").last();
+        QStringRef lastPartSQL = secondPartEntireSQL.split(";").first();
 
-        query = firstPartSQL + lastPartSQL;
+        query = firstPartSQL.toString() + lastPartSQL.toString();
     } else {
         // if a part of the query is selected, we will only execute this part
         query = sqlWidget->getSelectedSql();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -865,13 +865,13 @@ void MainWindow::executeQuery()
         int position = editor->positionFromLineIndex(cursor_line, cursor_index);
 
         QString entireSQL = editor->text();
-        QStringRef firstPartEntireSQL = entireSQL.leftRef(position);
-        QStringRef secondPartEntireSQL = entireSQL.rightRef(entireSQL.length() - position);
+        QString firstPartEntireSQL = entireSQL.leftRef(position);
+        QString secondPartEntireSQL = entireSQL.rightRef(entireSQL.length() - position);
 
-        QStringRef firstPartSQL = firstPartEntireSQL.split(";").last();
-        QStringRef lastPartSQL = secondPartEntireSQL.split(";").first();
+        QString firstPartSQL = firstPartEntireSQL.split(";").last();
+        QString lastPartSQL = secondPartEntireSQL.split(";").first();
 
-        query = firstPartSQL.toString() + lastPartSQL.toString();
+        query = firstPartSQL + lastPartSQL;
     } else {
         // if a part of the query is selected, we will only execute this part
         query = sqlWidget->getSelectedSql();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -851,18 +851,27 @@ void MainWindow::executeQuery()
 
     // Get SQL code to execute. This depends on the button that's been pressed
     QString query;
-    bool singleStep = false;
     int execution_start_line = 0;
     int execution_start_index = 0;
     if(sender()->objectName() == "actionSqlExecuteLine")
     {
         int cursor_line, cursor_index;
-        sqlWidget->getEditor()->getCursorPosition(&cursor_line, &cursor_index);
+        SqlTextEdit *editor = sqlWidget->getEditor();
+
+        editor->getCursorPosition(&cursor_line, &cursor_index);
+
         execution_start_line = cursor_line;
 
-        query = sqlWidget->getEditor()->text(cursor_line);
+        int position = editor->positionFromLineIndex(cursor_line, cursor_index);
 
-        singleStep = true;
+        QString entireSQL = editor->text();
+        QString firstPartEntireSQL = entireSQL.left(position);
+        QString secondPartEntireSQL = entireSQL.right(entireSQL.length() - position);
+
+        QString firstPartSQL = firstPartEntireSQL.split(";").last();
+        QString lastPartSQL = secondPartEntireSQL.split(";").first();
+
+        query = firstPartSQL + lastPartSQL;
     } else {
         // if a part of the query is selected, we will only execute this part
         query = sqlWidget->getSelectedSql();
@@ -975,10 +984,6 @@ void MainWindow::executeQuery()
                 break;
             }
             timer.restart();
-
-            // Stop after the first full statement if we're in single step mode
-            if(singleStep)
-                break;
         } else {
             statusMessage = QString::fromUtf8((const char*)sqlite3_errmsg(db._db)) +
                     ": " + queryPart;


### PR DESCRIPTION
This PR selects the text from the last semicolon (or the start) found before the cursor and up to the first semicolon (or the end) found after the cursor and executes it.

Examples:

    SELECT *
    FROM table| a; SELECT *
    FROM table b

runs the first query.

    SELECT *
    FROM table a; |SELECT *
    FROM table b

runs the second query.

    SELECT *|
    FROM table a; SELECT *
    FROM table b

runs the first query.

    SELECT *
    FROM table a; SELE|CT *
    FROM table b

runs the second query.