### PR TITLE
Fix incorrect scrollbar size on macOS with Qt5

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -64,6 +64,7 @@ ExtendedTableWidget::ExtendedTableWidget(QWidget* parent) :
     QTableView(parent)
 {
     setHorizontalScrollMode(ExtendedTableWidget::ScrollPerPixel);
+    setVerticalScrollMode(ExtendedTableWidget::ScrollPerItem);
 
     connect(verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(vscrollbarChanged(int)));
     connect(this, SIGNAL(clicked(QModelIndex)), this, SLOT(cellClicked(QModelIndex)));


### PR DESCRIPTION
Building the project with Qt5 on macOS and browsing a huge table, the
scrollbar height was smaller than necessary. Scrolling to the end, some
rows were not showing up.

This was caused by the default vertical scroll mode, which is set to
ScrollPerPixel on macOS, and ScrollPerItem on other systems.

Hope I was clear enough 😄

Related to #750.