### PR TITLE
Fix multiple commented out lines not being ignored

### DIFF
--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -102,7 +102,7 @@ void SqliteTableModel::setQuery(const QString& sQuery, bool dontClearHeaders)
 
     m_sQuery = sQuery.trimmed();
 
-    m_sQuery.remove(QRegExp("(?=\\s*[-]{2})[^'\"\n]*($|\\n)"));
+    m_sQuery.remove(QRegExp("(?=\\s*[-]{2})((?!\\n|$).)*"));
 
     // do a count query to get the full row count in a fast manner
     m_rowCount = getQueryRowCount();

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -102,7 +102,7 @@ void SqliteTableModel::setQuery(const QString& sQuery, bool dontClearHeaders)
 
     m_sQuery = sQuery.trimmed();
 
-    m_sQuery.remove(QRegExp("\s*--[^\n]+"));
+    m_sQuery.remove(QRegExp("\\s*--[^\\n]+"));
 
     // do a count query to get the full row count in a fast manner
     m_rowCount = getQueryRowCount();

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -102,7 +102,7 @@ void SqliteTableModel::setQuery(const QString& sQuery, bool dontClearHeaders)
 
     m_sQuery = sQuery.trimmed();
 
-    m_sQuery.remove(QRegExp("(?=\\s*[-]{2})((?!\\n|$).)*"));
+    m_sQuery.remove(QRegExp("\s*--[^\n]+"));
 
     // do a count query to get the full row count in a fast manner
     m_rowCount = getQueryRowCount();


### PR DESCRIPTION
This was supposed to be fixed by 842aec8, but it wasn't. It now removes
all the lines that optionally start with any number of spaces which are
followed by 2 consecutive dashes.

Could I get some help with intensive testing?