### PR TITLE
grammar: Add support for row values

### DIFF
--- a/src/grammar/Sqlite3Parser.cpp
+++ b/src/grammar/Sqlite3Parser.cpp
@@ -2600,84 +2600,179 @@ void Sqlite3Parser::expr() {
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
 	ANTLR_USE_NAMESPACE(antlr)RefAST expr_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	
-	subexpr();
-	if (inputState->guessing==0) {
-		astFactory->addASTChild( currentAST, returnAST );
-	}
-	{ // ( ... )*
-	for (;;) {
-		if ((_tokenSet_9.member(LA(1))) && (_tokenSet_10.member(LA(2)))) {
-			{
-			switch ( LA(1)) {
-			case GLOB:
-			case LIKE:
-			case IS:
-			case MATCH:
-			case REGEXP:
-			case PLUS:
-			case MINUS:
-			case STAR:
-			case AMPERSAND:
-			case BITOR:
-			case OROP:
-			case EQUAL:
-			case EQUAL2:
-			case GREATER:
-			case GREATEREQUAL:
-			case LOWER:
-			case LOWEREQUAL:
-			case UNEQUAL:
-			case UNEQUAL2:
-			case BITWISELEFT:
-			case BITWISERIGHT:
-			case SLASH:
-			case PERCENT:
-			{
-				binaryoperator();
-				if (inputState->guessing==0) {
-					astFactory->addASTChild( currentAST, returnAST );
-				}
-				break;
-			}
-			case AND:
-			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp155_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
-				if ( inputState->guessing == 0 ) {
-					tmp155_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp155_AST);
-				}
-				match(AND);
-				break;
-			}
-			case OR:
-			{
+	if ((LA(1) == LPAREN) && (_tokenSet_9.member(LA(2)))) {
+		{
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp155_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		if ( inputState->guessing == 0 ) {
+			tmp155_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp155_AST);
+		}
+		match(LPAREN);
+		subexpr();
+		if (inputState->guessing==0) {
+			astFactory->addASTChild( currentAST, returnAST );
+		}
+		{ // ( ... )+
+		int _cnt160=0;
+		for (;;) {
+			if ((LA(1) == COMMA)) {
 				ANTLR_USE_NAMESPACE(antlr)RefAST tmp156_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
 					tmp156_AST = astFactory->create(LT(1));
 					astFactory->addASTChild(currentAST, tmp156_AST);
 				}
-				match(OR);
-				break;
+				match(COMMA);
+				subexpr();
+				if (inputState->guessing==0) {
+					astFactory->addASTChild( currentAST, returnAST );
+				}
 			}
-			default:
-			{
-				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
+			else {
+				if ( _cnt160>=1 ) { goto _loop160; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());}
 			}
-			}
-			}
-			subexpr();
-			if (inputState->guessing==0) {
-				astFactory->addASTChild( currentAST, returnAST );
-			}
+			
+			_cnt160++;
 		}
-		else {
-			goto _loop160;
+		_loop160:;
+		}  // ( ... )+
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp157_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		if ( inputState->guessing == 0 ) {
+			tmp157_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp157_AST);
 		}
-		
+		match(RPAREN);
+		binaryoperator();
+		if (inputState->guessing==0) {
+			astFactory->addASTChild( currentAST, returnAST );
+		}
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp158_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		if ( inputState->guessing == 0 ) {
+			tmp158_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp158_AST);
+		}
+		match(LPAREN);
+		subexpr();
+		if (inputState->guessing==0) {
+			astFactory->addASTChild( currentAST, returnAST );
+		}
+		{ // ( ... )+
+		int _cnt162=0;
+		for (;;) {
+			if ((LA(1) == COMMA)) {
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp159_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				if ( inputState->guessing == 0 ) {
+					tmp159_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp159_AST);
+				}
+				match(COMMA);
+				subexpr();
+				if (inputState->guessing==0) {
+					astFactory->addASTChild( currentAST, returnAST );
+				}
+			}
+			else {
+				if ( _cnt162>=1 ) { goto _loop162; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());}
+			}
+			
+			_cnt162++;
+		}
+		_loop162:;
+		}  // ( ... )+
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp160_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		if ( inputState->guessing == 0 ) {
+			tmp160_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp160_AST);
+		}
+		match(RPAREN);
+		}
+		expr_AST = currentAST.root;
 	}
-	_loop160:;
-	} // ( ... )*
-	expr_AST = currentAST.root;
+	else if ((_tokenSet_9.member(LA(1))) && (_tokenSet_10.member(LA(2)))) {
+		{
+		subexpr();
+		if (inputState->guessing==0) {
+			astFactory->addASTChild( currentAST, returnAST );
+		}
+		{ // ( ... )*
+		for (;;) {
+			if ((_tokenSet_11.member(LA(1))) && (_tokenSet_9.member(LA(2)))) {
+				{
+				switch ( LA(1)) {
+				case GLOB:
+				case LIKE:
+				case IS:
+				case MATCH:
+				case REGEXP:
+				case PLUS:
+				case MINUS:
+				case STAR:
+				case AMPERSAND:
+				case BITOR:
+				case OROP:
+				case EQUAL:
+				case EQUAL2:
+				case GREATER:
+				case GREATEREQUAL:
+				case LOWER:
+				case LOWEREQUAL:
+				case UNEQUAL:
+				case UNEQUAL2:
+				case BITWISELEFT:
+				case BITWISERIGHT:
+				case SLASH:
+				case PERCENT:
+				{
+					binaryoperator();
+					if (inputState->guessing==0) {
+						astFactory->addASTChild( currentAST, returnAST );
+					}
+					break;
+				}
+				case AND:
+				{
+					ANTLR_USE_NAMESPACE(antlr)RefAST tmp161_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+					if ( inputState->guessing == 0 ) {
+						tmp161_AST = astFactory->create(LT(1));
+						astFactory->addASTChild(currentAST, tmp161_AST);
+					}
+					match(AND);
+					break;
+				}
+				case OR:
+				{
+					ANTLR_USE_NAMESPACE(antlr)RefAST tmp162_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+					if ( inputState->guessing == 0 ) {
+						tmp162_AST = astFactory->create(LT(1));
+						astFactory->addASTChild(currentAST, tmp162_AST);
+					}
+					match(OR);
+					break;
+				}
+				default:
+				{
+					throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
+				}
+				}
+				}
+				subexpr();
+				if (inputState->guessing==0) {
+					astFactory->addASTChild( currentAST, returnAST );
+				}
+			}
+			else {
+				goto _loop166;
+			}
+			
+		}
+		_loop166:;
+		} // ( ... )*
+		}
+		expr_AST = currentAST.root;
+	}
+	else {
+		throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
+	}
+	
 	returnAST = expr_AST;
 }
 
@@ -2689,10 +2784,10 @@ void Sqlite3Parser::literalvalue() {
 	switch ( LA(1)) {
 	case NUMERIC:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp157_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp163_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp157_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp157_AST);
+			tmp163_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp163_AST);
 		}
 		match(NUMERIC);
 		literalvalue_AST = currentAST.root;
@@ -2700,10 +2795,10 @@ void Sqlite3Parser::literalvalue() {
 	}
 	case STRINGLITERAL:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp158_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp164_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp158_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp158_AST);
+			tmp164_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp164_AST);
 		}
 		match(STRINGLITERAL);
 		literalvalue_AST = currentAST.root;
@@ -2711,10 +2806,10 @@ void Sqlite3Parser::literalvalue() {
 	}
 	case NULL_T:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp159_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp165_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp159_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp159_AST);
+			tmp165_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp165_AST);
 		}
 		match(NULL_T);
 		literalvalue_AST = currentAST.root;
@@ -2722,10 +2817,10 @@ void Sqlite3Parser::literalvalue() {
 	}
 	case CURRENT_TIME:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp160_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp166_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp160_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp160_AST);
+			tmp166_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp166_AST);
 		}
 		match(CURRENT_TIME);
 		literalvalue_AST = currentAST.root;
@@ -2733,10 +2828,10 @@ void Sqlite3Parser::literalvalue() {
 	}
 	case CURRENT_DATE:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp161_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp167_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp161_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp161_AST);
+			tmp167_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp167_AST);
 		}
 		match(CURRENT_DATE);
 		literalvalue_AST = currentAST.root;
@@ -2744,10 +2839,10 @@ void Sqlite3Parser::literalvalue() {
 	}
 	case CURRENT_TIMESTAMP:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp162_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp168_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp162_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp162_AST);
+			tmp168_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp168_AST);
 		}
 		match(CURRENT_TIMESTAMP);
 		literalvalue_AST = currentAST.root;
@@ -2766,10 +2861,10 @@ void Sqlite3Parser::foreignkeyclause() {
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
 	ANTLR_USE_NAMESPACE(antlr)RefAST foreignkeyclause_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp163_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp169_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp163_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp163_AST);
+		tmp169_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp169_AST);
 	}
 	match(REFERENCES);
 	tablename();
@@ -2780,10 +2875,10 @@ void Sqlite3Parser::foreignkeyclause() {
 	switch ( LA(1)) {
 	case LPAREN:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp164_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp170_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp164_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp164_AST);
+			tmp170_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp170_AST);
 		}
 		match(LPAREN);
 		columnname();
@@ -2793,10 +2888,10 @@ void Sqlite3Parser::foreignkeyclause() {
 		{ // ( ... )*
 		for (;;) {
 			if ((LA(1) == COMMA)) {
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp165_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp171_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp165_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp165_AST);
+					tmp171_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp171_AST);
 				}
 				match(COMMA);
 				columnname();
@@ -2811,10 +2906,10 @@ void Sqlite3Parser::foreignkeyclause() {
 		}
 		_loop142:;
 		} // ( ... )*
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp166_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp172_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp166_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp166_AST);
+			tmp172_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp172_AST);
 		}
 		match(RPAREN);
 		break;
@@ -2848,40 +2943,40 @@ void Sqlite3Parser::foreignkeyclause() {
 		switch ( LA(1)) {
 		case ON:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp167_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp173_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp167_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp167_AST);
+				tmp173_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp173_AST);
 			}
 			match(ON);
 			{
 			switch ( LA(1)) {
 			case DELETE:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp168_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp174_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp168_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp168_AST);
+					tmp174_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp174_AST);
 				}
 				match(DELETE);
 				break;
 			}
 			case UPDATE:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp169_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp175_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp169_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp169_AST);
+					tmp175_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp175_AST);
 				}
 				match(UPDATE);
 				break;
 			}
 			case INSERT:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp170_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp176_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp170_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp170_AST);
+					tmp176_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp176_AST);
 				}
 				match(INSERT);
 				break;
@@ -2896,30 +2991,30 @@ void Sqlite3Parser::foreignkeyclause() {
 			switch ( LA(1)) {
 			case SET:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp171_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp177_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp171_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp171_AST);
+					tmp177_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp177_AST);
 				}
 				match(SET);
 				{
 				switch ( LA(1)) {
 				case NULL_T:
 				{
-					ANTLR_USE_NAMESPACE(antlr)RefAST tmp172_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+					ANTLR_USE_NAMESPACE(antlr)RefAST tmp178_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 					if ( inputState->guessing == 0 ) {
-						tmp172_AST = astFactory->create(LT(1));
-						astFactory->addASTChild(currentAST, tmp172_AST);
+						tmp178_AST = astFactory->create(LT(1));
+						astFactory->addASTChild(currentAST, tmp178_AST);
 					}
 					match(NULL_T);
 					break;
 				}
 				case DEFAULT:
 				{
-					ANTLR_USE_NAMESPACE(antlr)RefAST tmp173_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+					ANTLR_USE_NAMESPACE(antlr)RefAST tmp179_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 					if ( inputState->guessing == 0 ) {
-						tmp173_AST = astFactory->create(LT(1));
-						astFactory->addASTChild(currentAST, tmp173_AST);
+						tmp179_AST = astFactory->create(LT(1));
+						astFactory->addASTChild(currentAST, tmp179_AST);
 					}
 					match(DEFAULT);
 					break;
@@ -2934,36 +3029,36 @@ void Sqlite3Parser::foreignkeyclause() {
 			}
 			case CASCADE:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp174_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp180_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp174_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp174_AST);
+					tmp180_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp180_AST);
 				}
 				match(CASCADE);
 				break;
 			}
 			case RESTRICT:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp175_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp181_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp175_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp175_AST);
+					tmp181_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp181_AST);
 				}
 				match(RESTRICT);
 				break;
 			}
 			case NO:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp176_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp182_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp176_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp176_AST);
+					tmp182_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp182_AST);
 				}
 				match(NO);
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp177_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp183_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp177_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp177_AST);
+					tmp183_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp183_AST);
 				}
 				match(ACTION);
 				break;
@@ -2978,10 +3073,10 @@ void Sqlite3Parser::foreignkeyclause() {
 		}
 		case MATCH:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp178_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp184_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp178_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp178_AST);
+				tmp184_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp184_AST);
 			}
 			match(MATCH);
 			name();
@@ -3017,46 +3112,46 @@ void Sqlite3Parser::foreignkeyclause() {
 		inputState->guessing--;
 	}
 	if ( synPredMatched150 ) {
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp179_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp185_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp179_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp179_AST);
+			tmp185_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp185_AST);
 		}
 		match(NOT);
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp180_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp186_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp180_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp180_AST);
+			tmp186_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp186_AST);
 		}
 		match(DEFERRABLE);
 		{
 		switch ( LA(1)) {
 		case INITIALLY:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp181_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp187_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp181_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp181_AST);
+				tmp187_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp187_AST);
 			}
 			match(INITIALLY);
 			{
 			switch ( LA(1)) {
 			case DEFERRED:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp182_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp188_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp182_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp182_AST);
+					tmp188_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp188_AST);
 				}
 				match(DEFERRED);
 				break;
 			}
 			case IMMEDIATE:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp183_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp189_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp183_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp183_AST);
+					tmp189_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp189_AST);
 				}
 				match(IMMEDIATE);
 				break;
@@ -3092,37 +3187,37 @@ void Sqlite3Parser::foreignkeyclause() {
 		}
 	}
 	else if ((LA(1) == DEFERRABLE)) {
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp184_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp190_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp184_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp184_AST);
+			tmp190_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp190_AST);
 		}
 		match(DEFERRABLE);
 		{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp185_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp191_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp185_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp185_AST);
+			tmp191_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp191_AST);
 		}
 		match(INITIALLY);
 		{
 		switch ( LA(1)) {
 		case DEFERRED:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp186_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp192_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp186_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp186_AST);
+				tmp192_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp192_AST);
 			}
 			match(DEFERRED);
 			break;
 		}
 		case IMMEDIATE:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp187_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp193_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp187_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp187_AST);
+				tmp193_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp193_AST);
 			}
 			match(IMMEDIATE);
 			break;
@@ -3135,7 +3230,7 @@ void Sqlite3Parser::foreignkeyclause() {
 		}
 		}
 	}
-	else if ((_tokenSet_7.member(LA(1))) && (_tokenSet_11.member(LA(2)))) {
+	else if ((_tokenSet_7.member(LA(1))) && (_tokenSet_12.member(LA(2)))) {
 	}
 	else {
 		throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
@@ -3159,10 +3254,10 @@ void Sqlite3Parser::indexedcolumn() {
 	switch ( LA(1)) {
 	case COLLATE:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp188_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp194_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp188_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp188_AST);
+			tmp194_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp194_AST);
 		}
 		match(COLLATE);
 		collationname();
@@ -3189,20 +3284,20 @@ void Sqlite3Parser::indexedcolumn() {
 	switch ( LA(1)) {
 	case ASC:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp189_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp195_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp189_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp189_AST);
+			tmp195_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp195_AST);
 		}
 		match(ASC);
 		break;
 	}
 	case DESC:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp190_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp196_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp190_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp190_AST);
+			tmp196_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp196_AST);
 		}
 		match(DESC);
 		break;
@@ -3223,10 +3318,10 @@ void Sqlite3Parser::indexedcolumn() {
 	switch ( LA(1)) {
 	case AUTOINCREMENT:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp191_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp197_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp191_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp191_AST);
+			tmp197_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp197_AST);
 		}
 		match(AUTOINCREMENT);
 		break;
@@ -3268,40 +3363,40 @@ void Sqlite3Parser::subexpr() {
 	switch ( LA(1)) {
 	case MINUS:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp192_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp198_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp192_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp192_AST);
+			tmp198_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp198_AST);
 		}
 		match(MINUS);
 		break;
 	}
 	case PLUS:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp193_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp199_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp193_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp193_AST);
+			tmp199_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp199_AST);
 		}
 		match(PLUS);
 		break;
 	}
 	case TILDE:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp194_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp200_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp194_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp194_AST);
+			tmp200_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp200_AST);
 		}
 		match(TILDE);
 		break;
 	}
 	case NOT:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp195_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp201_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp195_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp195_AST);
+			tmp201_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp201_AST);
 		}
 		match(NOT);
 		break;
@@ -3373,13 +3468,13 @@ void Sqlite3Parser::subexpr() {
 	}
 	}
 	{
-	if ((_tokenSet_8.member(LA(1))) && (_tokenSet_12.member(LA(2)))) {
+	if ((_tokenSet_8.member(LA(1))) && (_tokenSet_13.member(LA(2)))) {
 		literalvalue();
 		if (inputState->guessing==0) {
 			astFactory->addASTChild( currentAST, returnAST );
 		}
 	}
-	else if ((_tokenSet_2.member(LA(1))) && (_tokenSet_13.member(LA(2)))) {
+	else if ((_tokenSet_2.member(LA(1))) && (_tokenSet_14.member(LA(2)))) {
 		{
 		if ((_tokenSet_1.member(LA(1))) && (LA(2) == DOT)) {
 			{
@@ -3388,10 +3483,10 @@ void Sqlite3Parser::subexpr() {
 				if (inputState->guessing==0) {
 					astFactory->addASTChild( currentAST, returnAST );
 				}
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp196_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp202_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp196_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp196_AST);
+					tmp202_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp202_AST);
 				}
 				match(DOT);
 			}
@@ -3406,14 +3501,14 @@ void Sqlite3Parser::subexpr() {
 			if (inputState->guessing==0) {
 				astFactory->addASTChild( currentAST, returnAST );
 			}
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp197_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp203_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp197_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp197_AST);
+				tmp203_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp203_AST);
 			}
 			match(DOT);
 		}
-		else if ((_tokenSet_2.member(LA(1))) && (_tokenSet_12.member(LA(2)))) {
+		else if ((_tokenSet_2.member(LA(1))) && (_tokenSet_13.member(LA(2)))) {
 		}
 		else {
 			throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
@@ -3430,10 +3525,10 @@ void Sqlite3Parser::subexpr() {
 		if (inputState->guessing==0) {
 			astFactory->addASTChild( currentAST, returnAST );
 		}
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp198_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp204_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp198_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp198_AST);
+			tmp204_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp204_AST);
 		}
 		match(LPAREN);
 		{
@@ -3507,10 +3602,10 @@ void Sqlite3Parser::subexpr() {
 			{ // ( ... )*
 			for (;;) {
 				if ((LA(1) == COMMA)) {
-					ANTLR_USE_NAMESPACE(antlr)RefAST tmp199_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+					ANTLR_USE_NAMESPACE(antlr)RefAST tmp205_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 					if ( inputState->guessing == 0 ) {
-						tmp199_AST = astFactory->create(LT(1));
-						astFactory->addASTChild(currentAST, tmp199_AST);
+						tmp205_AST = astFactory->create(LT(1));
+						astFactory->addASTChild(currentAST, tmp205_AST);
 					}
 					match(COMMA);
 					expr();
@@ -3519,11 +3614,11 @@ void Sqlite3Parser::subexpr() {
 					}
 				}
 				else {
-					goto _loop168;
+					goto _loop174;
 				}
 				
 			}
-			_loop168:;
+			_loop174:;
 			} // ( ... )*
 			break;
 		}
@@ -3537,10 +3632,10 @@ void Sqlite3Parser::subexpr() {
 		}
 		}
 		}
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp200_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp206_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp200_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp200_AST);
+			tmp206_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp206_AST);
 		}
 		match(RPAREN);
 	}
@@ -3550,15 +3645,15 @@ void Sqlite3Parser::subexpr() {
 			astFactory->addASTChild( currentAST, returnAST );
 		}
 	}
-	else if ((LA(1) == EXISTS || LA(1) == LPAREN) && (_tokenSet_14.member(LA(2)))) {
+	else if ((LA(1) == EXISTS || LA(1) == LPAREN) && (_tokenSet_15.member(LA(2)))) {
 		{
 		switch ( LA(1)) {
 		case EXISTS:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp201_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp207_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp201_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp201_AST);
+				tmp207_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp207_AST);
 			}
 			match(EXISTS);
 			break;
@@ -3573,10 +3668,10 @@ void Sqlite3Parser::subexpr() {
 		}
 		}
 		}
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp202_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp208_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp202_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp202_AST);
+			tmp208_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp208_AST);
 		}
 		match(LPAREN);
 		{
@@ -3663,14 +3758,14 @@ void Sqlite3Parser::subexpr() {
 		}
 		}
 		}
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp203_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp209_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp203_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp203_AST);
+			tmp209_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp209_AST);
 		}
 		match(RPAREN);
 	}
-	else if ((LA(1) == CASE_T) && (_tokenSet_10.member(LA(2)))) {
+	else if ((LA(1) == CASE_T) && (_tokenSet_9.member(LA(2)))) {
 		caseexpr();
 		if (inputState->guessing==0) {
 			astFactory->addASTChild( currentAST, returnAST );
@@ -3688,13 +3783,13 @@ void Sqlite3Parser::subexpr() {
 	
 	}
 	{
-	if ((_tokenSet_15.member(LA(1))) && (_tokenSet_16.member(LA(2)))) {
+	if ((_tokenSet_16.member(LA(1))) && (_tokenSet_17.member(LA(2)))) {
 		suffixexpr();
 		if (inputState->guessing==0) {
 			astFactory->addASTChild( currentAST, returnAST );
 		}
 	}
-	else if ((_tokenSet_17.member(LA(1))) && (_tokenSet_18.member(LA(2)))) {
+	else if ((_tokenSet_18.member(LA(1))) && (_tokenSet_19.member(LA(2)))) {
 	}
 	else {
 		throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
@@ -3713,10 +3808,10 @@ void Sqlite3Parser::binaryoperator() {
 	switch ( LA(1)) {
 	case OROP:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp204_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp210_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp204_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp204_AST);
+			tmp210_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp210_AST);
 		}
 		match(OROP);
 		binaryoperator_AST = currentAST.root;
@@ -3724,10 +3819,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case STAR:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp205_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp211_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp205_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp205_AST);
+			tmp211_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp211_AST);
 		}
 		match(STAR);
 		binaryoperator_AST = currentAST.root;
@@ -3735,10 +3830,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case SLASH:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp206_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp212_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp206_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp206_AST);
+			tmp212_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp212_AST);
 		}
 		match(SLASH);
 		binaryoperator_AST = currentAST.root;
@@ -3746,10 +3841,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case PERCENT:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp207_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp213_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp207_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp207_AST);
+			tmp213_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp213_AST);
 		}
 		match(PERCENT);
 		binaryoperator_AST = currentAST.root;
@@ -3757,10 +3852,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case PLUS:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp208_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp214_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp208_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp208_AST);
+			tmp214_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp214_AST);
 		}
 		match(PLUS);
 		binaryoperator_AST = currentAST.root;
@@ -3768,10 +3863,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case MINUS:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp209_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp215_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp209_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp209_AST);
+			tmp215_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp215_AST);
 		}
 		match(MINUS);
 		binaryoperator_AST = currentAST.root;
@@ -3779,10 +3874,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case BITWISELEFT:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp210_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp216_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp210_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp210_AST);
+			tmp216_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp216_AST);
 		}
 		match(BITWISELEFT);
 		binaryoperator_AST = currentAST.root;
@@ -3790,10 +3885,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case BITWISERIGHT:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp211_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp217_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp211_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp211_AST);
+			tmp217_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp217_AST);
 		}
 		match(BITWISERIGHT);
 		binaryoperator_AST = currentAST.root;
@@ -3801,10 +3896,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case AMPERSAND:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp212_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp218_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp212_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp212_AST);
+			tmp218_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp218_AST);
 		}
 		match(AMPERSAND);
 		binaryoperator_AST = currentAST.root;
@@ -3812,10 +3907,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case BITOR:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp213_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp219_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp213_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp213_AST);
+			tmp219_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp219_AST);
 		}
 		match(BITOR);
 		binaryoperator_AST = currentAST.root;
@@ -3823,10 +3918,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case LOWER:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp214_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp220_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp214_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp214_AST);
+			tmp220_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp220_AST);
 		}
 		match(LOWER);
 		binaryoperator_AST = currentAST.root;
@@ -3834,10 +3929,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case LOWEREQUAL:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp215_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp221_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp215_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp215_AST);
+			tmp221_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp221_AST);
 		}
 		match(LOWEREQUAL);
 		binaryoperator_AST = currentAST.root;
@@ -3845,10 +3940,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case GREATER:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp216_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp222_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp216_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp216_AST);
+			tmp222_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp222_AST);
 		}
 		match(GREATER);
 		binaryoperator_AST = currentAST.root;
@@ -3856,10 +3951,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case GREATEREQUAL:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp217_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp223_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp217_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp217_AST);
+			tmp223_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp223_AST);
 		}
 		match(GREATEREQUAL);
 		binaryoperator_AST = currentAST.root;
@@ -3867,10 +3962,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case EQUAL:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp218_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp224_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp218_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp218_AST);
+			tmp224_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp224_AST);
 		}
 		match(EQUAL);
 		binaryoperator_AST = currentAST.root;
@@ -3878,10 +3973,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case EQUAL2:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp219_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp225_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp219_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp219_AST);
+			tmp225_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp225_AST);
 		}
 		match(EQUAL2);
 		binaryoperator_AST = currentAST.root;
@@ -3889,10 +3984,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case UNEQUAL:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp220_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp226_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp220_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp220_AST);
+			tmp226_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp226_AST);
 		}
 		match(UNEQUAL);
 		binaryoperator_AST = currentAST.root;
@@ -3900,10 +3995,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case UNEQUAL2:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp221_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp227_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp221_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp221_AST);
+			tmp227_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp227_AST);
 		}
 		match(UNEQUAL2);
 		binaryoperator_AST = currentAST.root;
@@ -3911,10 +4006,10 @@ void Sqlite3Parser::binaryoperator() {
 	}
 	case IS:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp222_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp228_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp222_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp222_AST);
+			tmp228_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp228_AST);
 		}
 		match(IS);
 		binaryoperator_AST = currentAST.root;
@@ -3945,36 +4040,36 @@ void Sqlite3Parser::castexpr() {
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
 	ANTLR_USE_NAMESPACE(antlr)RefAST castexpr_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp223_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp229_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp223_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp223_AST);
+		tmp229_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp229_AST);
 	}
 	match(CAST);
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp224_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp230_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp224_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp224_AST);
+		tmp230_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp230_AST);
 	}
 	match(LPAREN);
 	expr();
 	if (inputState->guessing==0) {
 		astFactory->addASTChild( currentAST, returnAST );
 	}
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp225_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp231_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp225_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp225_AST);
+		tmp231_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp231_AST);
 	}
 	match(AS);
 	type_name();
 	if (inputState->guessing==0) {
 		astFactory->addASTChild( currentAST, returnAST );
 	}
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp226_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp232_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp226_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp226_AST);
+		tmp232_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp232_AST);
 	}
 	match(RPAREN);
 	castexpr_AST = currentAST.root;
@@ -3986,20 +4081,20 @@ void Sqlite3Parser::caseexpr() {
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
 	ANTLR_USE_NAMESPACE(antlr)RefAST caseexpr_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp227_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp233_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp227_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp227_AST);
+		tmp233_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp233_AST);
 	}
 	match(CASE_T);
 	{
-	if ((_tokenSet_10.member(LA(1))) && (_tokenSet_19.member(LA(2)))) {
+	if ((_tokenSet_9.member(LA(1))) && (_tokenSet_20.member(LA(2)))) {
 		expr();
 		if (inputState->guessing==0) {
 			astFactory->addASTChild( currentAST, returnAST );
 		}
 	}
-	else if ((LA(1) == WHEN) && (_tokenSet_10.member(LA(2)))) {
+	else if ((LA(1) == WHEN) && (_tokenSet_9.member(LA(2)))) {
 	}
 	else {
 		throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
@@ -4007,23 +4102,23 @@ void Sqlite3Parser::caseexpr() {
 	
 	}
 	{ // ( ... )+
-	int _cnt176=0;
+	int _cnt182=0;
 	for (;;) {
 		if ((LA(1) == WHEN)) {
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp228_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp234_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp228_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp228_AST);
+				tmp234_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp234_AST);
 			}
 			match(WHEN);
 			expr();
 			if (inputState->guessing==0) {
 				astFactory->addASTChild( currentAST, returnAST );
 			}
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp229_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp235_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp229_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp229_AST);
+				tmp235_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp235_AST);
 			}
 			match(THEN);
 			expr();
@@ -4032,21 +4127,21 @@ void Sqlite3Parser::caseexpr() {
 			}
 		}
 		else {
-			if ( _cnt176>=1 ) { goto _loop176; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());}
+			if ( _cnt182>=1 ) { goto _loop182; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());}
 		}
 		
-		_cnt176++;
+		_cnt182++;
 	}
-	_loop176:;
+	_loop182:;
 	}  // ( ... )+
 	{
 	switch ( LA(1)) {
 	case ELSE_T:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp230_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp236_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp230_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp230_AST);
+			tmp236_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp236_AST);
 		}
 		match(ELSE_T);
 		expr();
@@ -4065,10 +4160,10 @@ void Sqlite3Parser::caseexpr() {
 	}
 	}
 	}
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp231_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp237_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp231_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp231_AST);
+		tmp237_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp237_AST);
 	}
 	match(END);
 	caseexpr_AST = currentAST.root;
@@ -4080,26 +4175,26 @@ void Sqlite3Parser::raisefunction() {
 	ANTLR_USE_NAMESPACE(antlr)ASTPair currentAST;
 	ANTLR_USE_NAMESPACE(antlr)RefAST raisefunction_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp232_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp238_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp232_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp232_AST);
+		tmp238_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp238_AST);
 	}
 	match(RAISE);
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp233_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp239_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp233_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp233_AST);
+		tmp239_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp239_AST);
 	}
 	match(LPAREN);
 	{
 	switch ( LA(1)) {
 	case IGNORE:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp234_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp240_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp234_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp234_AST);
+			tmp240_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp240_AST);
 		}
 		match(IGNORE);
 		break;
@@ -4112,30 +4207,30 @@ void Sqlite3Parser::raisefunction() {
 		switch ( LA(1)) {
 		case ROLLBACK:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp235_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp241_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp235_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp235_AST);
+				tmp241_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp241_AST);
 			}
 			match(ROLLBACK);
 			break;
 		}
 		case ABORT:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp236_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp242_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp236_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp236_AST);
+				tmp242_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp242_AST);
 			}
 			match(ABORT);
 			break;
 		}
 		case FAIL:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp237_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp243_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp237_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp237_AST);
+				tmp243_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp243_AST);
 			}
 			match(FAIL);
 			break;
@@ -4146,16 +4241,16 @@ void Sqlite3Parser::raisefunction() {
 		}
 		}
 		}
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp238_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp244_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp238_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp238_AST);
+			tmp244_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp244_AST);
 		}
 		match(COMMA);
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp239_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp245_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp239_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp239_AST);
+			tmp245_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp245_AST);
 		}
 		match(STRINGLITERAL);
 		break;
@@ -4166,10 +4261,10 @@ void Sqlite3Parser::raisefunction() {
 	}
 	}
 	}
-	ANTLR_USE_NAMESPACE(antlr)RefAST tmp240_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+	ANTLR_USE_NAMESPACE(antlr)RefAST tmp246_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 	if ( inputState->guessing == 0 ) {
-		tmp240_AST = astFactory->create(LT(1));
-		astFactory->addASTChild(currentAST, tmp240_AST);
+		tmp246_AST = astFactory->create(LT(1));
+		astFactory->addASTChild(currentAST, tmp246_AST);
 	}
 	match(RPAREN);
 	raisefunction_AST = currentAST.root;
@@ -4184,10 +4279,10 @@ void Sqlite3Parser::suffixexpr() {
 	switch ( LA(1)) {
 	case COLLATE:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp241_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp247_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp241_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp241_AST);
+			tmp247_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp247_AST);
 		}
 		match(COLLATE);
 		collationname();
@@ -4209,10 +4304,10 @@ void Sqlite3Parser::suffixexpr() {
 		switch ( LA(1)) {
 		case NOT:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp242_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp248_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp242_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp242_AST);
+				tmp248_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp248_AST);
 			}
 			match(NOT);
 			break;
@@ -4236,10 +4331,10 @@ void Sqlite3Parser::suffixexpr() {
 		switch ( LA(1)) {
 		case BETWEEN:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp243_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp249_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp243_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp243_AST);
+				tmp249_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp249_AST);
 			}
 			match(BETWEEN);
 			subexpr();
@@ -4248,7 +4343,7 @@ void Sqlite3Parser::suffixexpr() {
 			}
 			{ // ( ... )*
 			for (;;) {
-				if ((_tokenSet_20.member(LA(1)))) {
+				if ((_tokenSet_21.member(LA(1)))) {
 					{
 					switch ( LA(1)) {
 					case GLOB:
@@ -4283,10 +4378,10 @@ void Sqlite3Parser::suffixexpr() {
 					}
 					case OR:
 					{
-						ANTLR_USE_NAMESPACE(antlr)RefAST tmp244_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+						ANTLR_USE_NAMESPACE(antlr)RefAST tmp250_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 						if ( inputState->guessing == 0 ) {
-							tmp244_AST = astFactory->create(LT(1));
-							astFactory->addASTChild(currentAST, tmp244_AST);
+							tmp250_AST = astFactory->create(LT(1));
+							astFactory->addASTChild(currentAST, tmp250_AST);
 						}
 						match(OR);
 						break;
@@ -4303,16 +4398,16 @@ void Sqlite3Parser::suffixexpr() {
 					}
 				}
 				else {
-					goto _loop187;
+					goto _loop193;
 				}
 				
 			}
-			_loop187:;
+			_loop193:;
 			} // ( ... )*
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp245_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp251_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp245_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp245_AST);
+				tmp251_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp251_AST);
 			}
 			match(AND);
 			expr();
@@ -4323,20 +4418,20 @@ void Sqlite3Parser::suffixexpr() {
 		}
 		case IN:
 		{
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp246_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp252_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp246_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp246_AST);
+				tmp252_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp252_AST);
 			}
 			match(IN);
 			{
 			switch ( LA(1)) {
 			case LPAREN:
 			{
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp247_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp253_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp247_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp247_AST);
+					tmp253_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp253_AST);
 				}
 				match(LPAREN);
 				{
@@ -4418,10 +4513,10 @@ void Sqlite3Parser::suffixexpr() {
 					{ // ( ... )*
 					for (;;) {
 						if ((LA(1) == COMMA)) {
-							ANTLR_USE_NAMESPACE(antlr)RefAST tmp248_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+							ANTLR_USE_NAMESPACE(antlr)RefAST tmp254_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 							if ( inputState->guessing == 0 ) {
-								tmp248_AST = astFactory->create(LT(1));
-								astFactory->addASTChild(currentAST, tmp248_AST);
+								tmp254_AST = astFactory->create(LT(1));
+								astFactory->addASTChild(currentAST, tmp254_AST);
 							}
 							match(COMMA);
 							expr();
@@ -4430,11 +4525,11 @@ void Sqlite3Parser::suffixexpr() {
 							}
 						}
 						else {
-							goto _loop191;
+							goto _loop197;
 						}
 						
 					}
-					_loop191:;
+					_loop197:;
 					} // ( ... )*
 					break;
 				}
@@ -4448,10 +4543,10 @@ void Sqlite3Parser::suffixexpr() {
 				}
 				}
 				}
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp249_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp255_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp249_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp249_AST);
+					tmp255_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp255_AST);
 				}
 				match(RPAREN);
 				break;
@@ -4489,11 +4584,11 @@ void Sqlite3Parser::suffixexpr() {
 				astFactory->addASTChild( currentAST, returnAST );
 			}
 			{
-			if ((LA(1) == ESCAPE) && (_tokenSet_10.member(LA(2)))) {
-				ANTLR_USE_NAMESPACE(antlr)RefAST tmp250_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			if ((LA(1) == ESCAPE) && (_tokenSet_9.member(LA(2)))) {
+				ANTLR_USE_NAMESPACE(antlr)RefAST tmp256_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 				if ( inputState->guessing == 0 ) {
-					tmp250_AST = astFactory->create(LT(1));
-					astFactory->addASTChild(currentAST, tmp250_AST);
+					tmp256_AST = astFactory->create(LT(1));
+					astFactory->addASTChild(currentAST, tmp256_AST);
 				}
 				match(ESCAPE);
 				subexpr();
@@ -4501,7 +4596,7 @@ void Sqlite3Parser::suffixexpr() {
 					astFactory->addASTChild( currentAST, returnAST );
 				}
 			}
-			else if ((_tokenSet_17.member(LA(1))) && (_tokenSet_18.member(LA(2)))) {
+			else if ((_tokenSet_18.member(LA(1))) && (_tokenSet_19.member(LA(2)))) {
 			}
 			else {
 				throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());
@@ -4535,10 +4630,10 @@ void Sqlite3Parser::like_operator() {
 	switch ( LA(1)) {
 	case LIKE:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp251_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp257_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp251_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp251_AST);
+			tmp257_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp257_AST);
 		}
 		match(LIKE);
 		like_operator_AST = currentAST.root;
@@ -4546,10 +4641,10 @@ void Sqlite3Parser::like_operator() {
 	}
 	case GLOB:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp252_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp258_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp252_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp252_AST);
+			tmp258_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp258_AST);
 		}
 		match(GLOB);
 		like_operator_AST = currentAST.root;
@@ -4557,10 +4652,10 @@ void Sqlite3Parser::like_operator() {
 	}
 	case REGEXP:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp253_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp259_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp253_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp253_AST);
+			tmp259_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp259_AST);
 		}
 		match(REGEXP);
 		like_operator_AST = currentAST.root;
@@ -4568,10 +4663,10 @@ void Sqlite3Parser::like_operator() {
 	}
 	case MATCH:
 	{
-		ANTLR_USE_NAMESPACE(antlr)RefAST tmp254_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+		ANTLR_USE_NAMESPACE(antlr)RefAST tmp260_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 		if ( inputState->guessing == 0 ) {
-			tmp254_AST = astFactory->create(LT(1));
-			astFactory->addASTChild(currentAST, tmp254_AST);
+			tmp260_AST = astFactory->create(LT(1));
+			astFactory->addASTChild(currentAST, tmp260_AST);
 		}
 		match(MATCH);
 		like_operator_AST = currentAST.root;
@@ -4595,13 +4690,13 @@ void Sqlite3Parser::between_subexpr() {
 		astFactory->addASTChild( currentAST, returnAST );
 	}
 	{ // ( ... )+
-	int _cnt181=0;
+	int _cnt187=0;
 	for (;;) {
 		if ((LA(1) == AND)) {
-			ANTLR_USE_NAMESPACE(antlr)RefAST tmp255_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
+			ANTLR_USE_NAMESPACE(antlr)RefAST tmp261_AST = ANTLR_USE_NAMESPACE(antlr)nullAST;
 			if ( inputState->guessing == 0 ) {
-				tmp255_AST = astFactory->create(LT(1));
-				astFactory->addASTChild(currentAST, tmp255_AST);
+				tmp261_AST = astFactory->create(LT(1));
+				astFactory->addASTChild(currentAST, tmp261_AST);
 			}
 			match(AND);
 			subexpr();
@@ -4610,12 +4705,12 @@ void Sqlite3Parser::between_subexpr() {
 			}
 		}
 		else {
-			if ( _cnt181>=1 ) { goto _loop181; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());}
+			if ( _cnt187>=1 ) { goto _loop187; } else {throw ANTLR_USE_NAMESPACE(antlr)NoViableAltException(LT(1), getFilename());}
 		}
 		
-		_cnt181++;
+		_cnt187++;
 	}
-	_loop181:;
+	_loop187:;
 	}  // ( ... )+
 	between_subexpr_AST = currentAST.root;
 	returnAST = between_subexpr_AST;
@@ -4775,12 +4870,7 @@ const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_7(_tokenSet_7_da
 const unsigned long Sqlite3Parser::_tokenSet_8_data_[] = { 7340032UL, 16384UL, 278528UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // "CURRENT_TIME" "CURRENT_DATE" "CURRENT_TIMESTAMP" "NULL" NUMERIC STRINGLITERAL 
 const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_8(_tokenSet_8_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_9_data_[] = { 1536UL, 2131978UL, 4219469824UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
-// "AND" "OR" "GLOB" "LIKE" "IS" "MATCH" "REGEXP" PLUS MINUS STAR AMPERSAND 
-// BITOR OROP EQUAL EQUAL2 GREATER GREATEREQUAL LOWER LOWEREQUAL UNEQUAL 
-// UNEQUAL2 BITWISELEFT BITWISERIGHT SLASH PERCENT 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_9(_tokenSet_9_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_10_data_[] = { 4294408176UL, 3220958590UL, 93091841UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const unsigned long Sqlite3Parser::_tokenSet_9_data_[] = { 4294408176UL, 3220958590UL, 93091841UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // "ABORT" "ACTION" "AUTOINCREMENT" "AS" "ASC" "AND" "OR" "CASCADE" "CASE" 
 // "CAST" "CREATE" "COLLATE" "CONFLICT" "CURRENT_TIME" "CURRENT_DATE" "CURRENT_TIMESTAMP" 
 // "DEFAULT" "DEFERRABLE" "DEFERRED" "DELETE" "DESC" "ELSE" "END" "ESCAPE" 
@@ -4789,8 +4879,25 @@ const unsigned long Sqlite3Parser::_tokenSet_10_data_[] = { 4294408176UL, 322095
 // "REPLACE" "RESTRICT" "ROLLBACK" "ROWID" "SET" "TEMPORARY" "TEMP" "THEN" 
 // "UPDATE" "WHEN" ID QUOTEDID QUOTEDLITERAL NUMERIC STRINGLITERAL LPAREN 
 // PLUS MINUS TILDE 
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_9(_tokenSet_9_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_10_data_[] = { 4294410226UL, 3220958718UL, 4290542593UL, 2047UL, 0UL, 0UL, 0UL, 0UL };
+// EOF "ABORT" "ACTION" "AUTOINCREMENT" "AS" "ASC" "AND" "OR" "BETWEEN" 
+// "CASCADE" "CASE" "CAST" "CREATE" "COLLATE" "CONFLICT" "CURRENT_TIME" 
+// "CURRENT_DATE" "CURRENT_TIMESTAMP" "DEFAULT" "DEFERRABLE" "DEFERRED" 
+// "DELETE" "DESC" "ELSE" "END" "ESCAPE" "FAIL" "GLOB" "KEY" "LIKE" "TABLE" 
+// "IF" "IGNORE" "IN" "INITIALLY" "IMMEDIATE" "IS" "NOT" "NULL" "MATCH" 
+// "EXISTS" "ON" "RAISE" "REFERENCES" "REGEXP" "REPLACE" "RESTRICT" "ROLLBACK" 
+// "ROWID" "SET" "TEMPORARY" "TEMP" "THEN" "UPDATE" "WHEN" DOT ID QUOTEDID 
+// QUOTEDLITERAL NUMERIC STRINGLITERAL LPAREN RPAREN COMMA PLUS MINUS STAR 
+// TILDE AMPERSAND BITOR OROP EQUAL EQUAL2 GREATER GREATEREQUAL LOWER LOWEREQUAL 
+// UNEQUAL UNEQUAL2 BITWISELEFT BITWISERIGHT SELECT SLASH PERCENT 
 const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_10(_tokenSet_10_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_11_data_[] = { 4294965234UL, 4294962559UL, 33323011UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const unsigned long Sqlite3Parser::_tokenSet_11_data_[] = { 1536UL, 2131978UL, 4219469824UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
+// "AND" "OR" "GLOB" "LIKE" "IS" "MATCH" "REGEXP" PLUS MINUS STAR AMPERSAND 
+// BITOR OROP EQUAL EQUAL2 GREATER GREATEREQUAL LOWER LOWEREQUAL UNEQUAL 
+// UNEQUAL2 BITWISELEFT BITWISERIGHT SLASH PERCENT 
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_11(_tokenSet_11_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_12_data_[] = { 4294965234UL, 4294962559UL, 33323011UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // EOF "ABORT" "ACTION" "AUTOINCREMENT" "AS" "ASC" "AND" "OR" "CASCADE" 
 // "CASE" "CAST" "CHECK" "CREATE" "COLLATE" "CONFLICT" "CONSTRAINT" "CURRENT_TIME" 
 // "CURRENT_DATE" "CURRENT_TIMESTAMP" "DEFAULT" "DEFERRABLE" "DEFERRED" 
@@ -4800,20 +4907,20 @@ const unsigned long Sqlite3Parser::_tokenSet_11_data_[] = { 4294965234UL, 429496
 // "RESTRICT" "ROLLBACK" "ROWID" "SET" "TEMPORARY" "TEMP" "THEN" "UNIQUE" 
 // "UPDATE" "WHEN" "WITHOUT" ID QUOTEDID QUOTEDLITERAL NUMERIC STRINGLITERAL 
 // LPAREN RPAREN COMMA SEMI PLUS MINUS 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_11(_tokenSet_11_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_12_data_[] = { 1879182978UL, 539011210UL, 4222615553UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_12(_tokenSet_12_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_13_data_[] = { 1879182978UL, 539011210UL, 4222615553UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
 // EOF "AS" "AND" "OR" "BETWEEN" "COLLATE" "ELSE" "END" "ESCAPE" "GLOB" 
 // "LIKE" "IN" "IS" "NOT" "MATCH" "REGEXP" "THEN" "WHEN" RPAREN COMMA PLUS 
 // MINUS STAR AMPERSAND BITOR OROP EQUAL EQUAL2 GREATER GREATEREQUAL LOWER 
 // LOWEREQUAL UNEQUAL UNEQUAL2 BITWISELEFT BITWISERIGHT SLASH PERCENT 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_12(_tokenSet_12_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_13_data_[] = { 1879182978UL, 539011210UL, 4222616577UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_13(_tokenSet_13_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_14_data_[] = { 1879182978UL, 539011210UL, 4222616577UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
 // EOF "AS" "AND" "OR" "BETWEEN" "COLLATE" "ELSE" "END" "ESCAPE" "GLOB" 
 // "LIKE" "IN" "IS" "NOT" "MATCH" "REGEXP" "THEN" "WHEN" DOT RPAREN COMMA 
 // PLUS MINUS STAR AMPERSAND BITOR OROP EQUAL EQUAL2 GREATER GREATEREQUAL 
 // LOWER LOWEREQUAL UNEQUAL UNEQUAL2 BITWISELEFT BITWISERIGHT SLASH PERCENT 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_13(_tokenSet_13_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_14_data_[] = { 4294408176UL, 3220958590UL, 93091841UL, 256UL, 0UL, 0UL, 0UL, 0UL };
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_14(_tokenSet_14_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_15_data_[] = { 4294408176UL, 3220958590UL, 93091841UL, 256UL, 0UL, 0UL, 0UL, 0UL };
 // "ABORT" "ACTION" "AUTOINCREMENT" "AS" "ASC" "AND" "OR" "CASCADE" "CASE" 
 // "CAST" "CREATE" "COLLATE" "CONFLICT" "CURRENT_TIME" "CURRENT_DATE" "CURRENT_TIMESTAMP" 
 // "DEFAULT" "DEFERRABLE" "DEFERRED" "DELETE" "DESC" "ELSE" "END" "ESCAPE" 
@@ -4822,11 +4929,11 @@ const unsigned long Sqlite3Parser::_tokenSet_14_data_[] = { 4294408176UL, 322095
 // "REPLACE" "RESTRICT" "ROLLBACK" "ROWID" "SET" "TEMPORARY" "TEMP" "THEN" 
 // "UPDATE" "WHEN" ID QUOTEDID QUOTEDLITERAL NUMERIC STRINGLITERAL LPAREN 
 // PLUS MINUS TILDE SELECT 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_14(_tokenSet_14_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_15_data_[] = { 133120UL, 2138250UL, 0UL, 0UL };
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_15(_tokenSet_15_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_16_data_[] = { 133120UL, 2138250UL, 0UL, 0UL };
 // "BETWEEN" "COLLATE" "GLOB" "LIKE" "IN" "NOT" "MATCH" "REGEXP" 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_15(_tokenSet_15_data_,4);
-const unsigned long Sqlite3Parser::_tokenSet_16_data_[] = { 4294410224UL, 3220958718UL, 93091841UL, 0UL, 0UL, 0UL, 0UL, 0UL };
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_16(_tokenSet_16_data_,4);
+const unsigned long Sqlite3Parser::_tokenSet_17_data_[] = { 4294410224UL, 3220958718UL, 93091841UL, 0UL, 0UL, 0UL, 0UL, 0UL };
 // "ABORT" "ACTION" "AUTOINCREMENT" "AS" "ASC" "AND" "OR" "BETWEEN" "CASCADE" 
 // "CASE" "CAST" "CREATE" "COLLATE" "CONFLICT" "CURRENT_TIME" "CURRENT_DATE" 
 // "CURRENT_TIMESTAMP" "DEFAULT" "DEFERRABLE" "DEFERRED" "DELETE" "DESC" 
@@ -4835,14 +4942,14 @@ const unsigned long Sqlite3Parser::_tokenSet_16_data_[] = { 4294410224UL, 322095
 // "RAISE" "REFERENCES" "REGEXP" "REPLACE" "RESTRICT" "ROLLBACK" "ROWID" 
 // "SET" "TEMPORARY" "TEMP" "THEN" "UPDATE" "WHEN" ID QUOTEDID QUOTEDLITERAL 
 // NUMERIC STRINGLITERAL LPAREN PLUS MINUS TILDE 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_16(_tokenSet_16_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_17_data_[] = { 1879049858UL, 539002890UL, 4222615553UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_17(_tokenSet_17_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_18_data_[] = { 1879049858UL, 539002890UL, 4222615553UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
 // EOF "AS" "AND" "OR" "ELSE" "END" "ESCAPE" "GLOB" "LIKE" "IS" "MATCH" 
 // "REGEXP" "THEN" "WHEN" RPAREN COMMA PLUS MINUS STAR AMPERSAND BITOR 
 // OROP EQUAL EQUAL2 GREATER GREATEREQUAL LOWER LOWEREQUAL UNEQUAL UNEQUAL2 
 // BITWISELEFT BITWISERIGHT SLASH PERCENT 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_17(_tokenSet_17_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_18_data_[] = { 4294967282UL, 4294962687UL, 4290541569UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_18(_tokenSet_18_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_19_data_[] = { 4294967282UL, 4294962687UL, 4290541569UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
 // EOF "ABORT" "ACTION" "AUTOINCREMENT" "AS" "ASC" "AND" "OR" "BETWEEN" 
 // "CASCADE" "CASE" "CAST" "CHECK" "CREATE" "COLLATE" "CONFLICT" "CONSTRAINT" 
 // "CURRENT_TIME" "CURRENT_DATE" "CURRENT_TIMESTAMP" "DEFAULT" "DEFERRABLE" 
@@ -4854,8 +4961,8 @@ const unsigned long Sqlite3Parser::_tokenSet_18_data_[] = { 4294967282UL, 429496
 // LPAREN RPAREN COMMA PLUS MINUS STAR TILDE AMPERSAND BITOR OROP EQUAL 
 // EQUAL2 GREATER GREATEREQUAL LOWER LOWEREQUAL UNEQUAL UNEQUAL2 BITWISELEFT 
 // BITWISERIGHT SLASH PERCENT 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_18(_tokenSet_18_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_19_data_[] = { 4294410224UL, 3220958718UL, 4287396865UL, 2047UL, 0UL, 0UL, 0UL, 0UL };
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_19(_tokenSet_19_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_20_data_[] = { 4294410224UL, 3220958718UL, 4287396865UL, 2047UL, 0UL, 0UL, 0UL, 0UL };
 // "ABORT" "ACTION" "AUTOINCREMENT" "AS" "ASC" "AND" "OR" "BETWEEN" "CASCADE" 
 // "CASE" "CAST" "CREATE" "COLLATE" "CONFLICT" "CURRENT_TIME" "CURRENT_DATE" 
 // "CURRENT_TIMESTAMP" "DEFAULT" "DEFERRABLE" "DEFERRED" "DELETE" "DESC" 
@@ -4866,11 +4973,11 @@ const unsigned long Sqlite3Parser::_tokenSet_19_data_[] = { 4294410224UL, 322095
 // NUMERIC STRINGLITERAL LPAREN PLUS MINUS STAR TILDE AMPERSAND BITOR OROP 
 // EQUAL EQUAL2 GREATER GREATEREQUAL LOWER LOWEREQUAL UNEQUAL UNEQUAL2 
 // BITWISELEFT BITWISERIGHT SELECT SLASH PERCENT 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_19(_tokenSet_19_data_,8);
-const unsigned long Sqlite3Parser::_tokenSet_20_data_[] = { 1024UL, 2131978UL, 4219469824UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_20(_tokenSet_20_data_,8);
+const unsigned long Sqlite3Parser::_tokenSet_21_data_[] = { 1024UL, 2131978UL, 4219469824UL, 1791UL, 0UL, 0UL, 0UL, 0UL };
 // "OR" "GLOB" "LIKE" "IS" "MATCH" "REGEXP" PLUS MINUS STAR AMPERSAND BITOR 
 // OROP EQUAL EQUAL2 GREATER GREATEREQUAL LOWER LOWEREQUAL UNEQUAL UNEQUAL2 
 // BITWISELEFT BITWISERIGHT SLASH PERCENT 
-const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_20(_tokenSet_20_data_,8);
+const ANTLR_USE_NAMESPACE(antlr)BitSet Sqlite3Parser::_tokenSet_21(_tokenSet_21_data_,8);
 
 

--- a/src/grammar/Sqlite3Parser.hpp
+++ b/src/grammar/Sqlite3Parser.hpp
@@ -128,6 +128,8 @@ private:
 	static const ANTLR_USE_NAMESPACE(antlr)BitSet _tokenSet_19;
 	static const unsigned long _tokenSet_20_data_[];
 	static const ANTLR_USE_NAMESPACE(antlr)BitSet _tokenSet_20;
+	static const unsigned long _tokenSet_21_data_[];
+	static const ANTLR_USE_NAMESPACE(antlr)BitSet _tokenSet_21;
 };
 
 #endif /*INC_Sqlite3Parser_hpp_*/

--- a/src/grammar/sqlite3.g
+++ b/src/grammar/sqlite3.g
@@ -409,7 +409,8 @@ functionname
 
 expr
   :
-  subexpr ((binaryoperator | AND | OR) subexpr )*
+  ( LPAREN subexpr (COMMA subexpr)+ RPAREN binaryoperator LPAREN subexpr (COMMA subexpr)+ RPAREN )
+  | ( subexpr ((binaryoperator | AND | OR) subexpr )* )
   ;
 
 subexpr


### PR DESCRIPTION
SQLite version 3.15.0 introduced a new feature called row values. These
are basically vectors of values that can be used to simplify some
expressions.

For example instead of this
CREATE TABLE x(a int, b int, c int, CHECK(a=1 and b=2));
you could write this:
CREATE TABLE x(a int, b int, c int, CHECK((a,b) = (1,2)));

However, the new syntax wasn't supported by our grammar parser which
made it impossible to access or edit that table. This commit attempts to
fix this.