### PR TITLE
Fix hanging when deleting large number of records (#856)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,8 @@ before_install:
   - sudo add-apt-repository ppa:likemartinma/devel -y
   - sudo add-apt-repository --yes ppa:beineri/opt-qt57-trusty
   - sudo apt-get update -qq
-  - sudo apt-get --force-yes install -qq qt57-meta-full
-  - sudo apt-get --force-yes install -qq libsqlite3-dev libsqlcipher-dev libantlr-dev
+  - sudo apt-get --force-yes install qt57-meta-full
+  - sudo apt-get --force-yes install libsqlite3-dev libsqlcipher-dev libantlr-dev
   - QT_ENV_SCRIPT=$(find /opt -name 'qt*-env.sh')
   - source $QT_ENV_SCRIPT
 

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -585,8 +585,11 @@ void MainWindow::deleteRecord()
 
         int old_row = ui->dataTable->currentIndex().row();
         while(ui->dataTable->selectionModel()->hasSelection())
-        {
-            if(!m_browseTableModel->removeRow(ui->dataTable->selectionModel()->selectedIndexes().first().row()))
+	{
+	    int first_selected_row = ui->dataTable->selectionModel()->selectedIndexes().first().row();
+	    int last_selected_row = ui->dataTable->selectionModel()->selectedIndexes().last().row();
+	    int selected_rows_count = last_selected_row - first_selected_row + 1;
+	    if(!m_browseTableModel->removeRows(first_selected_row, selected_rows_count))
             {
                 QMessageBox::warning(this, QApplication::applicationName(), tr("Error deleting record:\n%1").arg(db.lastErrorMessage));
                 break;

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -865,15 +865,20 @@ QString DBBrowserDB::addRecord(const QString& sTableName)
     }
 }
 
-bool DBBrowserDB::deleteRecord(const QString& table, const QString& rowid)
+bool DBBrowserDB::deleteRecords(const QString& table, const QStringList& rowids)
 {
     if (!isOpen()) return false;
     bool ok = false;
 
-    QString statement = QString("DELETE FROM %1 WHERE %2='%3';")
+    QStringList quoted_rowids;
+    foreach(QString rowid, rowids)
+    {
+        quoted_rowids.append("'" + rowid + "'");
+    }
+    QString statement = QString("DELETE FROM %1 WHERE %2 IN (%3);")
             .arg(sqlb::escapeIdentifier(table))
             .arg(sqlb::escapeIdentifier(getObjectByName(table).table.rowidColumn()))
-            .arg(rowid);
+            .arg(quoted_rowids.join(", "));
     if(executeSQL(statement))
         ok = true;
     else

--- a/src/sqlitedb.h
+++ b/src/sqlitedb.h
@@ -85,7 +85,7 @@ public:
      * @return An sqlite conform INSERT INTO statement with empty values. (NULL,'',0)
      */
     QString emptyInsertStmt(const sqlb::Table& t, const QString& pk_value = QString()) const;
-    bool deleteRecord(const QString& table, const QString& rowid);
+    bool deleteRecords(const QString& table, const QStringList& rowids);
     bool updateRecord(const QString& table, const QString& column, const QString& rowid, const QByteArray& value, bool itsBlob);
 
     bool createTable(const QString& name, const sqlb::FieldVector& structure);

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -410,15 +410,16 @@ bool SqliteTableModel::removeRows(int row, int count, const QModelIndex& parent)
 
     bool ok = true;
 
+    QStringList rowids;
     for(int i=count-1;i>=0;i--)
     {
-        if(m_db->deleteRecord(m_sTable, m_data.at(row + i).at(0)))
-        {
-            m_data.removeAt(row + i);
-            --m_rowCount;
-        } else {
-            ok = false;
-        }
+        rowids.append(m_data.at(row + i).at(0));
+        m_data.removeAt(row + i);
+        --m_rowCount;
+    }
+    if(!m_db->deleteRecords(m_sTable, rowids))
+    {
+	ok = false;
     }
 
     endRemoveRows();


### PR DESCRIPTION
When trying to delete all records or large number of
them (~5000) (selecting them and pressing Delete Record on Data tab), it
takes too much time to execute this operation due to large number of
queries like `DELETE * FROM 'table' WHERE '_rowid_' = id`.