### PR TITLE
Support foreign key constraints referring to the same table

### DIFF
--- a/src/EditTableDialog.h
+++ b/src/EditTableDialog.h
@@ -7,6 +7,7 @@
 
 class DBBrowserDB;
 class QTreeWidgetItem;
+class ForeignKeyEditorDelegate;
 
 namespace Ui {
 class EditTableDialog;
@@ -61,6 +62,7 @@ private slots:
 private:
     Ui::EditTableDialog* ui;
     DBBrowserDB& pdb;
+    ForeignKeyEditorDelegate* m_fkEditorDelegate;
     QString curTable;
     sqlb::Table m_table;
     QStringList types;

--- a/src/ForeignKeyEditorDelegate.h
+++ b/src/ForeignKeyEditorDelegate.h
@@ -25,6 +25,8 @@ public:
     void setModelData(QWidget* editor, QAbstractItemModel* model, const QModelIndex& index) const Q_DECL_OVERRIDE;
     void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const Q_DECL_OVERRIDE;
 
+    void updateTablesList(const QString& oldTableName);
+
 private:
     const DBBrowserDB& m_db;
     sqlb::Table& m_table;


### PR DESCRIPTION
It's bugged a bit and table name in foreign key persists after pressing "Apply" button. Maybe @MKleusberg can help with it.