### PR TITLE
Create AppImage, closes #968

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,11 @@ script:
   - mkdir build
   - mkdir build_cipher
   - cd build
-  - cmake -DENABLE_TESTING=ON ..
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DENABLE_TESTING=ON ..
   - make
   - ctest -V
   - cd ../build_cipher
-  - cmake -DENABLE_TESTING=ON -Dsqlcipher=1 ..
+  - cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DENABLE_TESTING=ON -Dsqlcipher=1 ..
   - make
   - ctest -V
   - # AppImage generation

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,8 @@ script:
   - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
   - mkdir appdir ; cd appdir
   - dpkg -x ../app_1-1_amd64.deb . ; find .
-  - cp ../distri/sqlitebrowser.desktop .
-  - mkdir -p ./usr/share/{metainfo,applications}
-  - cp ../distri/sqlitebrowser.desktop ./usr/share/applications/
-  - cp ../distri/sqlitebrowser.xml ./usr/share/metainfo/
-  - cp ../images/sqlitebrowser.svg .
-  - mkdir -p ./usr/share/icons/hicolor/scalable/apps/
-  - cp ../images/sqlitebrowser.svg ./usr/share/icons/hicolor/scalable/apps/
+  - cp ./usr/local/share/applications/sqlitebrowser.desktop .
+  - cp ./usr/local/share/icons/hicolor/256x256/apps/sqlitebrowser.png .
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,26 @@ script:
   - cmake -DENABLE_TESTING=ON -Dsqlcipher=1 ..
   - make
   - ctest -V
+  - # AppImage generation
+  - cd ../build
+  - sudo apt-get -y install checkinstall
+  - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
+  - mkdir appdir ; cd appdir
+  - dpkg -x ../app_1-1_amd64.deb . ; find .
+  - cp ../distri/sqlitebrowser.desktop .
+  - mkdir -p ./usr/share/{metainfo,applications}
+  - cp ../distri/sqlitebrowser.desktop ./usr/share/applications/
+  - cp ../distri/sqlitebrowser.xml ./usr/share/metainfo/
+  - cp ../images/sqlitebrowser.svg .
+  - mkdir -p ./usr/share/icons/hicolor/scalable/apps/
+  - cp ../images/sqlitebrowser.svg ./usr/share/icons/hicolor/scalable/apps/
+  - cd .. 
+  - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
+  - chmod a+x linuxdeployqt*.AppImage
+  - unset QTDIR; unset QT_PLUGIN_PATH ; unset LD_LIBRARY_PATH
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/sqlitebrowser -bundle-non-qt-libs
+  - ./linuxdeployqt*.AppImage ./appdir/usr/bin/sqlitebrowser -appimage 
+  - curl --upload-file ./DB*.AppImage https://transfer.sh/sqlitebrowser-git.$(git rev-parse --short HEAD)-x86_64.AppImage 
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ script:
   - sudo checkinstall --pkgname=app --pkgversion="1" --pkgrelease="1" --backup=no --fstrans=no --default --deldoc 
   - mkdir appdir ; cd appdir
   - dpkg -x ../app_1-1_amd64.deb . ; find .
-  - cp ./usr/local/share/applications/sqlitebrowser.desktop .
-  - cp ./usr/local/share/icons/hicolor/256x256/apps/sqlitebrowser.png .
+  - cp ./usr/share/applications/sqlitebrowser.desktop .
+  - cp ./usr/share/icons/hicolor/256x256/apps/sqlitebrowser.png .
   - cd .. 
   - wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/3/linuxdeployqt-3-x86_64.AppImage" 
   - chmod a+x linuxdeployqt*.AppImage


### PR DESCRIPTION
This PR, when merged, will compile sqlitebrowser Travis CI upon each git push, and upload an [AppImage](http://appimage.org/) to a temporary download URL on transfer.sh (available for 14 days). The download URL is toward the end of each Travis CI build log of each build.

![screenshot from 2017-02-26 14-28-24](https://cloud.githubusercontent.com/assets/2480569/23340063/fb904556-fc2f-11e6-9c44-5a7a278e223f.png)

Providing an [AppImage](http://appimage.org/) would have, among others, these advantages:
- Works for most Linux distributions (including Ubuntu, Fedora, openSUSE, CentOS, elementaryOS, Linux Mint, and others)
- One app = one file = super simple for users: just download one AppImage file, [make it executable](http://discourse.appimage.org/t/how-to-make-an-appimage-executable/80), and run
- No unpacking or installation necessary
- No root needed
- No system libraries changed
- Just one format for all major distributions
- Works out of the box, no installation of runtimes needed
- Optional(!) desktop integration with `appimaged`
- Binary delta updates, e.g., for continuous builds (only download the binary diff) using AppImageUpdate
- Can GPG2-sign your AppImages (inside the file)

[Here is an overview](https://github.com/probonopd/AppImageKit/wiki/AppImages) of projects that are already distributing upstream-provided, official AppImages.

An example AppImage can be downloaded from here:
https://transfer.sh/UiNPi/sqlitebrowser-git.021f836-x86-64.appimage (available for 14 days)