### PR TITLE
Fix plotting with datetimes on x axis (#738)

### DIFF
--- a/src/PlotDock.cpp
+++ b/src/PlotDock.cpp
@@ -201,7 +201,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                     {
                         QString s = model->data(model->index(i, x)).toString();
                         QDateTime d = QDateTime::fromString(s, Qt::ISODate);
-                        xdata[i] = d.toTime_t();
+                        xdata[i] = d.toMSecsSinceEpoch() / 1000.0;
                     } else {
                         // Get the x value for this point. If the selected column is -1, i.e. the row number, just use the current row number from the loop
                         // instead of retrieving some value from the model.


### PR DESCRIPTION
Use QDateTime::toMSecsSinceEpoch() instead of
deprecated QDateTime::toTime_t() which does not
correctly convert datetimes which do not exist
due to switch to Daylight Saving Time