### PR TITLE
Batch import multiple CSV files at once

### DIFF
--- a/src/FileDialog.cpp
+++ b/src/FileDialog.cpp
@@ -9,6 +9,17 @@ QString FileDialog::getOpenFileName(QWidget* parent, const QString& caption, con
     return result;
 }
 
+QStringList FileDialog::getOpenFileNames(QWidget *parent, const QString &caption, const QString &filter, QString *selectedFilter, QFileDialog::Options options)
+{
+    QStringList result = QFileDialog::getOpenFileNames(parent, caption, getFileDialogPath(), filter, selectedFilter, options);
+    if(!result.isEmpty())
+    {
+        QFileInfo path = QFileInfo(result.first());
+        setFileDialogPath(path.absolutePath());
+    }
+    return result;
+}
+
 QString FileDialog::getSaveFileName(QWidget* parent, const QString& caption, const QString& filter, const QString& defaultFileName, QString* selectedFilter, Options options)
 {
     QString dir = getFileDialogPath();

--- a/src/FileDialog.h
+++ b/src/FileDialog.h
@@ -11,6 +11,9 @@ public:
     static QString getOpenFileName(QWidget* parent = 0, const QString& caption = QString(),
                                    const QString& filter = QString(), QString* selectedFilter = 0,
                                    Options options = 0);
+    static QStringList getOpenFileNames(QWidget* parent = 0, const QString& caption = QString(),
+                                        const QString& filter = QString(), QString* selectedFilter = 0,
+                                        Options options = 0);
     static QString getSaveFileName(QWidget* parent = 0, const QString& caption = QString(),
                                    const QString& filter = QString(), const QString& defaultFileName = QString(), QString* selectedFilter = 0,
                                    Options options = 0);

--- a/src/ImportCsvDialog.cpp
+++ b/src/ImportCsvDialog.cpp
@@ -43,6 +43,7 @@ ImportCsvDialog::ImportCsvDialog(const QStringList &filenames, DBBrowserDB* db, 
     QSettings settings(QApplication::organizationName(), QApplication::organizationName());
     ui->checkboxHeader->setChecked(settings.value("importcsv/firstrowheader", false).toBool());
     ui->checkBoxTrimFields->setChecked(settings.value("importcsv/trimfields", true).toBool());
+    ui->checkBoxSeparateTables->setChecked(settings.value("importcsv/separatetables", false).toBool());
     setSeparatorChar(QChar(settings.value("importcsv/separator", ',').toInt()));
     setQuoteChar(QChar(settings.value("importcsv/quotecharacter", '"').toInt()));
     setEncoding(settings.value("importcsv/encoding", "UTF-8").toString());
@@ -144,6 +145,7 @@ void ImportCsvDialog::accept()
     settings.setValue("separator", currentSeparatorChar());
     settings.setValue("quotecharacter", currentQuoteChar());
     settings.setValue("trimfields", ui->checkBoxTrimFields->isChecked());
+    settings.setValue("separatetables", ui->checkBoxSeparateTables->isChecked());
     settings.setValue("encoding", currentEncoding());
     settings.endGroup();
 

--- a/src/ImportCsvDialog.h
+++ b/src/ImportCsvDialog.h
@@ -6,6 +6,7 @@
 
 class DBBrowserDB;
 class QCompleter;
+class CSVParser;
 class QListWidgetItem;
 
 namespace Ui {
@@ -36,8 +37,10 @@ private:
     DBBrowserDB* pdb;
     QCompleter* encodingCompleter;
 
+    CSVParser parseCSV(const QString &f, qint64 count = -1);
+    sqlb::FieldVector generateFieldList(const CSVParser& parser);
+
     void importCsv(const QString& f);
-    sqlb::FieldVector fetchCsvHeader(const QString& f);
 
     void setQuoteChar(const QChar& c);
     char currentQuoteChar() const;

--- a/src/ImportCsvDialog.h
+++ b/src/ImportCsvDialog.h
@@ -40,7 +40,7 @@ private:
     CSVParser parseCSV(const QString &f, qint64 count = -1);
     sqlb::FieldVector generateFieldList(const CSVParser& parser);
 
-    void importCsv(const QString& f);
+    void importCsv(const QString& f, const QString &n = QString());
 
     void setQuoteChar(const QChar& c);
     char currentQuoteChar() const;

--- a/src/ImportCsvDialog.h
+++ b/src/ImportCsvDialog.h
@@ -1,6 +1,7 @@
 #ifndef IMPORTCSVDIALOG_H
 #define IMPORTCSVDIALOG_H
 
+#include "sqlitetypes.h"
 #include <QDialog>
 
 class DBBrowserDB;
@@ -26,6 +27,7 @@ private slots:
     void selectFiles();
     void updateSelectedFilePreview(QListWidgetItem*);
     void updateSelection(bool);
+    void matchSimilar();
 
 private:
     Ui::ImportCsvDialog* ui;
@@ -35,6 +37,7 @@ private:
     QCompleter* encodingCompleter;
 
     void importCsv(const QString& f);
+    sqlb::FieldVector fetchCsvHeader(const QString& f);
 
     void setQuoteChar(const QChar& c);
     char currentQuoteChar() const;

--- a/src/ImportCsvDialog.h
+++ b/src/ImportCsvDialog.h
@@ -5,6 +5,7 @@
 
 class DBBrowserDB;
 class QCompleter;
+class QListWidgetItem;
 
 namespace Ui {
 class ImportCsvDialog;
@@ -15,19 +16,25 @@ class ImportCsvDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit ImportCsvDialog(const QString& filename, DBBrowserDB* db, QWidget* parent = 0);
+    explicit ImportCsvDialog(const QStringList& filenames, DBBrowserDB* db, QWidget* parent = 0);
     ~ImportCsvDialog();
 
 private slots:
     virtual void accept();
     void updatePreview();
     void checkInput();
+    void selectFiles();
+    void updateSelectedFilePreview(QListWidgetItem*);
+    void updateSelection(bool);
 
 private:
     Ui::ImportCsvDialog* ui;
-    QString csvFilename;
+    QStringList csvFilenames;
+    QString selectedFile;
     DBBrowserDB* pdb;
     QCompleter* encodingCompleter;
+
+    void importCsv(const QString& f);
 
     void setQuoteChar(const QChar& c);
     char currentQuoteChar() const;

--- a/src/ImportCsvDialog.ui
+++ b/src/ImportCsvDialog.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Import CSV file</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
     <layout class="QFormLayout" name="formLayout">
      <property name="fieldGrowthPolicy">
@@ -241,7 +241,75 @@
        </property>
       </widget>
      </item>
+     <item row="7" column="0">
+      <layout class="QVBoxLayout" name="verticalLayout_2"/>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="separateTables">
+       <property name="text">
+        <string>Separate tables</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QCheckBox" name="checkBoxSeparateTables">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QWidget" name="filePickerBlock" native="true">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <layout class="QHBoxLayout" name="filePickerLayout">
+      <item>
+       <widget class="QListWidget" name="filePicker"/>
+      </item>
+      <item>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="spacing">
+         <number>7</number>
+        </property>
+        <property name="sizeConstraint">
+         <enum>QLayout::SetDefaultConstraint</enum>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <item>
+         <widget class="QPushButton" name="toggleSelected">
+          <property name="text">
+           <string>Deselect All</string>
+          </property>
+          <property name="checkable">
+           <bool>true</bool>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="verticalSpacer">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
    </item>
    <item>
     <widget class="QTableWidget" name="tablePreview"/>
@@ -273,82 +341,18 @@
  <resources/>
  <connections>
   <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>ImportCsvDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>261</x>
-     <y>480</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>ImportCsvDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>329</x>
-     <y>480</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>checkboxHeader</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>ImportCsvDialog</receiver>
-   <slot>updatePreview()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>187</x>
-     <y>46</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>354</x>
-     <y>45</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
    <sender>comboSeparator</sender>
    <signal>currentIndexChanged(int)</signal>
    <receiver>ImportCsvDialog</receiver>
    <slot>updatePreview()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>216</x>
-     <y>71</y>
+     <x>232</x>
+     <y>99</y>
     </hint>
     <hint type="destinationlabel">
      <x>445</x>
      <y>64</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>comboQuote</sender>
-   <signal>currentIndexChanged(int)</signal>
-   <receiver>ImportCsvDialog</receiver>
-   <slot>updatePreview()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>224</x>
-     <y>100</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>350</x>
-     <y>88</y>
     </hint>
    </hints>
   </connection>
@@ -375,8 +379,8 @@
    <slot>updatePreview()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>325</x>
-     <y>70</y>
+     <x>478</x>
+     <y>99</y>
     </hint>
     <hint type="destinationlabel">
      <x>577</x>
@@ -391,28 +395,12 @@
    <slot>updatePreview()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>467</x>
-     <y>101</y>
+     <x>478</x>
+     <y>132</y>
     </hint>
     <hint type="destinationlabel">
      <x>530</x>
      <y>90</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>comboEncoding</sender>
-   <signal>currentIndexChanged(int)</signal>
-   <receiver>ImportCsvDialog</receiver>
-   <slot>updatePreview()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>198</x>
-     <y>131</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>572</x>
-     <y>121</y>
     </hint>
    </hints>
   </connection>
@@ -423,8 +411,8 @@
    <slot>updatePreview()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>378</x>
-     <y>132</y>
+     <x>495</x>
+     <y>165</y>
     </hint>
     <hint type="destinationlabel">
      <x>540</x>
@@ -439,8 +427,120 @@
    <slot>updatePreview()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>191</x>
-     <y>189</y>
+     <x>184</x>
+     <y>191</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>368</x>
+     <y>244</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>comboEncoding</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>ImportCsvDialog</receiver>
+   <slot>updatePreview()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>266</x>
+     <y>165</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>572</x>
+     <y>121</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkboxHeader</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>ImportCsvDialog</receiver>
+   <slot>updatePreview()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>184</x>
+     <y>60</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>45</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>toggleSelected</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>ImportCsvDialog</receiver>
+   <slot>updateSelection(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>674</x>
+     <y>258</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>368</x>
+     <y>244</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>comboQuote</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>ImportCsvDialog</receiver>
+   <slot>updatePreview()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>232</x>
+     <y>132</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>350</x>
+     <y>88</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ImportCsvDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>272</x>
+     <y>478</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ImportCsvDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>340</x>
+     <y>478</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>checkBoxSeparateTables</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>ImportCsvDialog</receiver>
+   <slot>checkInput()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>176</x>
+     <y>216</y>
     </hint>
     <hint type="destinationlabel">
      <x>368</x>
@@ -452,5 +552,6 @@
  <slots>
   <slot>updatePreview()</slot>
   <slot>checkInput()</slot>
+  <slot>updateSelection(bool)</slot>
  </slots>
 </ui>

--- a/src/ImportCsvDialog.ui
+++ b/src/ImportCsvDialog.ui
@@ -266,6 +266,18 @@
       <bool>true</bool>
      </property>
      <layout class="QHBoxLayout" name="filePickerLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
       <item>
        <widget class="QListWidget" name="filePicker"/>
       </item>
@@ -290,6 +302,16 @@
           </property>
           <property name="checked">
            <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="matchSimilar">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Match Similar</string>
           </property>
          </widget>
         </item>
@@ -548,10 +570,27 @@
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>matchSimilar</sender>
+   <signal>pressed()</signal>
+   <receiver>ImportCsvDialog</receiver>
+   <slot>matchSimilar()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>682</x>
+     <y>279</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>368</x>
+     <y>244</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>updatePreview()</slot>
   <slot>checkInput()</slot>
   <slot>updateSelection(bool)</slot>
+  <slot>matchSimilar()</slot>
  </slots>
 </ui>

--- a/src/ImportCsvDialog.ui
+++ b/src/ImportCsvDialog.ui
@@ -358,6 +358,10 @@
   <tabstop>comboEncoding</tabstop>
   <tabstop>editCustomEncoding</tabstop>
   <tabstop>checkBoxTrimFields</tabstop>
+  <tabstop>checkBoxSeparateTables</tabstop>
+  <tabstop>filePicker</tabstop>
+  <tabstop>toggleSelected</tabstop>
+  <tabstop>matchSimilar</tabstop>
   <tabstop>tablePreview</tabstop>
  </tabstops>
  <resources/>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1094,16 +1094,20 @@ void MainWindow::mainTabSelected(int tabindex)
 
 void MainWindow::importTableFromCSV()
 {
-    QString wFile = FileDialog::getOpenFileName(
-                this,
-                tr("Choose a text file"),
-                tr("Text files(*.csv *.txt);;All files(*)"));
+    QStringList wFiles = FileDialog::getOpenFileNames(
+                            this,
+                            tr("Choose text files"),
+                            tr("Text files(*.csv *.txt);;All files(*)"));
 
-    if (QFile::exists(wFile) )
-    {
-        ImportCsvDialog dialog(wFile, &db, this);
-        if(dialog.exec())
-        {
+    QStringList validFiles;
+    foreach(auto file, wFiles) {
+        if (QFile::exists(file))
+            validFiles.append(file);
+    }
+
+    if (!validFiles.isEmpty()) {
+        ImportCsvDialog dialog(validFiles, &db, this);
+        if (dialog.exec()) {
             populateTable();
             QMessageBox::information(this, QApplication::applicationName(), tr("Import completed"));
         }


### PR DESCRIPTION
Allow for batch importing multiple CSV files at once using the import CSV dialog

- You can choose to import to separate tables using the filename
- Interactively pick which files you want to import
- Match similar files that share the same columns to import into one table

Fixes #1002 

Code could be a lot slimmer, didn't poke around as much as I could, "first timer" so a bit of reuse and ideally we should be able to fetch headers without running through the entire file (so the last commit was more of a poc) but would make for a more streamlined experience. Suggestions and improvements welcome ofc.

![](http://i.imgur.com/n8vv3hc.gif)