### PR TITLE
Change some OK buttons to Save buttons

### DIFF
--- a/src/ExportDataDialog.ui
+++ b/src/ExportDataDialog.ui
@@ -305,7 +305,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
      </property>
     </widget>
    </item>

--- a/src/ExportSqlDialog.ui
+++ b/src/ExportSqlDialog.ui
@@ -20,7 +20,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
      </property>
     </widget>
    </item>

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -1217,7 +1217,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
      </property>
     </widget>
    </item>

--- a/src/VacuumDialog.ui
+++ b/src/VacuumDialog.ui
@@ -79,7 +79,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
      </property>
     </widget>
    </item>

--- a/src/VacuumDialog.ui
+++ b/src/VacuumDialog.ui
@@ -79,7 +79,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -425,7 +425,7 @@ bool DBBrowserDB::close()
                                                                       QApplication::applicationName(),
                                                                       tr("Do you want to save the changes "
                                                                          "made to the database file %1?").arg(curDBFilename),
-                                                                      QMessageBox::Yes | QMessageBox::No | QMessageBox::Cancel);
+                                                                      QMessageBox::Save | QMessageBox::No | QMessageBox::Cancel);
 
             // If the user clicked the cancel button stop here and return false
             if(reply == QMessageBox::Cancel)


### PR DESCRIPTION
Improve UI slightly by using an actionable verb rather than a dismissive OK.

The exit confirmation dialog was bad with it’s “Yes, “No”, “Cancel” because users would have to actually read the entire dialog to understand what they were being asked. Now the button that does saving is self-explanatory as it says “Save” right on the button.