### PR TITLE
Clear column filters after table modification

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -821,8 +821,10 @@ void MainWindow::editObject()
     if(type == "table")
     {
         EditTableDialog dialog(db, name, false, this);
-        if(dialog.exec())
+        if(dialog.exec()) {
+            ui->dataTable->filterHeader()->clearFilters();
             populateTable();
+        }
     } else if(type == "index") {
         EditIndexDialog dialog(db, name, false, this);
         if(dialog.exec())


### PR DESCRIPTION
Fixes #1020. Clear values in the filter boxes
on the `Data` tab every time the table structure
changes.