### PR TITLE
Fix custom type saving when only focus changes for user-entered type

### DIFF
--- a/src/EditTableDialog.h
+++ b/src/EditTableDialog.h
@@ -51,6 +51,8 @@ private slots:
     virtual void reject();
     void checkInput();
     void itemChanged(QTreeWidgetItem* item, int column);
+    void updateTypes(QObject *object);
+    bool eventFilter(QObject *object, QEvent *event);
     void updateTypes();
     void moveUp();
     void moveDown();


### PR DESCRIPTION
At the moment when user types a custom type into the type combo box and
doesn't press enter, the entered type isn't used. This patch tries to fix
the problem by installing an event filter for the combo box and checking
when it loses focus - when it does, it performs type updates too.

On the way the patch also changes the signal used inside moveCurrentField()
from activated() to currentIndexChanged() to make it consistent with the
rest of the file.

Fixes #1144.