### PR TITLE
Fix extra spaces in type definitions with parentheses

### DIFF
--- a/src/sqlitetypes.cpp
+++ b/src/sqlitetypes.cpp
@@ -935,7 +935,28 @@ void CreateTableWalker::parsecolumn(Table* table, antlr::RefAST c)
     c = c->getNextSibling(); //type?
     if(c != antlr::nullAST && c->getType() == sqlite3TokenTypes::TYPE_NAME)
     {
-        type = concatTextAST(c->getFirstChild(), true);
+        antlr::RefAST t = c->getFirstChild();
+
+        if(t != antlr::nullAST)
+        {
+            type.clear();
+        }
+
+        while(t != antlr::nullAST)
+        {
+            int thisType = t->getType();
+            type.append(textAST(t));
+            t = t->getNextSibling();
+            if(t != antlr::nullAST)
+            {
+                int nextType = t->getType();
+                if(nextType != sqlite3TokenTypes::LPAREN && nextType != sqlite3TokenTypes::RPAREN &&
+                   thisType != sqlite3TokenTypes::LPAREN)
+                {
+                    type.append(" ");
+                }
+            }
+        }
         c = c->getNextSibling();
     }
 

--- a/src/tests/testsqlobjects.cpp
+++ b/src/tests/testsqlobjects.cpp
@@ -128,7 +128,7 @@ void TestTable::parseSQL()
 
     QVERIFY(tab.fields().at(0)->type() == "integer");
     QVERIFY(tab.fields().at(1)->type() == "text");
-    QCOMPARE(tab.fields().at(2)->type(), QString("VARCHAR ( 255 )"));
+    QCOMPARE(tab.fields().at(2)->type(), QString("VARCHAR(255)"));
 
     FieldVector pk = tab.primaryKey();
     QVERIFY(tab.fields().at(0)->autoIncrement());


### PR DESCRIPTION
At the moment space is inserted between all tokens from which a type
consists. This adds extra spaces to types like VARCHAR(5) which become
"VARCHAR ( 5 )" which causes problems in some applications.

This patch modifies the way tokens are concatenated for a type. It makes
sure that the extra space isn't inserted before "(" and ")" and also
after "(".

Fixes #1142 