### PR TITLE
Move row count query into a separate thread

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -566,9 +566,6 @@ void MainWindow::populateTable()
         ui->actionShowRowidColumn->setVisible(false);
     }
 
-    // Set the recordset label
-    setRecordsetLabel();
-
     QApplication::restoreOverrideCursor();
 }
 

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -15,7 +15,7 @@
 SqliteTableModel::SqliteTableModel(DBBrowserDB& db, QObject* parent, size_t chunkSize, const QString& encoding)
     : QAbstractTableModel(parent)
     , m_db(db)
-    , m_rowCount(0)
+    , m_rowCountAdjustment(0)
     , m_chunkSize(chunkSize)
     , m_valid(false)
     , m_encoding(encoding)
@@ -28,7 +28,12 @@ void SqliteTableModel::reset()
     m_mutexDataCache.unlock();
     m_futureFetch.cancel();
     m_futureFetch.waitForFinished();
+    m_rowCount = QtConcurrent::run([=]() {
+        // Make sure we report 0 rows if anybody asks
+        return 0;
+    });
 
+    m_rowCountAdjustment = 0;
     m_sTable.clear();
     m_sRowidColumn.clear();
     m_iSortColumn = 0;
@@ -126,12 +131,14 @@ void SqliteTableModel::setQuery(const QString& sQuery, bool dontClearHeaders)
     removeCommentsFromQuery(m_sQuery);
 
     // do a count query to get the full row count in a fast manner
-    m_rowCount = getQueryRowCount();
-    if(m_rowCount == -1)
-    {
-        m_valid = false;
-        return;
-    }
+    m_rowCountAdjustment = 0;
+    m_rowCount = QtConcurrent::run([=]() {
+        int count = getQueryRowCount();
+        if(count == -1)
+            m_valid = false;
+
+        return count;
+    });
 
     // headers
     if(!dontClearHeaders)
@@ -202,7 +209,7 @@ int SqliteTableModel::rowCount(const QModelIndex&) const
 
 int SqliteTableModel::totalRowCount() const
 {
-    return m_rowCount;
+    return m_rowCount + m_rowCountAdjustment;
 }
 
 int SqliteTableModel::columnCount(const QModelIndex&) const
@@ -232,7 +239,7 @@ QVariant SqliteTableModel::data(const QModelIndex &index, int role) const
     if (!index.isValid())
         return QVariant();
 
-    if (index.row() >= m_rowCount)
+    if (index.row() >= (m_rowCount + m_rowCountAdjustment))
         return QVariant();
 
     QMutexLocker lock(&m_mutexDataCache);
@@ -380,7 +387,7 @@ bool SqliteTableModel::canFetchMore(const QModelIndex&) const
 {
     m_futureFetch.waitForFinished();
     QMutexLocker lock(&m_mutexDataCache);
-    return m_data.size() < m_rowCount;
+    return m_data.size() < (m_rowCount + m_rowCountAdjustment);
 }
 
 void SqliteTableModel::fetchMore(const QModelIndex&)
@@ -445,7 +452,7 @@ bool SqliteTableModel::insertRows(int row, int count, const QModelIndex& parent)
         {
             return false;
         }
-        m_rowCount++;
+        m_rowCountAdjustment++;
         tempList.append(blank_data);
         tempList[i - row].replace(0, rowid.toUtf8());
 
@@ -486,7 +493,7 @@ bool SqliteTableModel::removeRows(int row, int count, const QModelIndex& parent)
     {
         rowids.append(m_data.at(row + i).at(0));
         m_data.removeAt(row + i);
-        --m_rowCount;
+        --m_rowCountAdjustment;
     }
     if(!m_db.deleteRecords(m_sTable, rowids))
     {

--- a/src/sqlitetablemodel.h
+++ b/src/sqlitetablemodel.h
@@ -94,7 +94,8 @@ private:
     QByteArray decode(const QByteArray& str) const;
 
     DBBrowserDB& m_db;
-    int m_rowCount;
+    QFuture<int> m_rowCount;
+    int m_rowCountAdjustment;   // This needs to be added to the results of the m_rowCount future object to get the actual row count
     QStringList m_headers;
     typedef QList<QByteArrayList> DataType;
     DataType m_data;


### PR DESCRIPTION
In the SqliteTableModel class we need to know the total number of rows
in the table or returned by the query. This takes a considerable amount
of time and can be moved into a separate thread. I haven't done any
performance measurements with this but it might speed up switching
between large tables a bit.


And here's the next bit which can be tested :smile: Would be interesting to know if it helps with performance or not. Probably not much but still worth checking.