### PR TITLE
Remove `activateWindow()` when EditDock is toggled

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -863,7 +863,6 @@ void MainWindow::toggleEditDock(bool visible)
 {
     if (!visible) {
         // Update main window
-        activateWindow();
         ui->dataTable->setFocus();
     } else {
         // fill edit dock with actual data


### PR DESCRIPTION
There's no need to set sqlitebrowser as active window when updating
the main application window. The `activateWindow()` call prevents
switching workspaces in GNOME and Cinnamon desktops.

Fixes #934