### PR TITLE
New option in the context menu for using the value as filter

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -84,6 +84,9 @@ ExtendedTableWidget::ExtendedTableWidget(QWidget* parent) :
     QAction* nullAction = new QAction(tr("Set to NULL"), m_contextMenu);
     QAction* copyAction = new QAction(QIcon(":/icons/copy"), tr("Copy"), m_contextMenu);
     QAction* pasteAction = new QAction(QIcon(":/icons/paste"), tr("Paste"), m_contextMenu);
+    QAction* filterAction = new QAction(tr("Use as Filter"), m_contextMenu);
+    m_contextMenu->addAction(filterAction);
+    m_contextMenu->addSeparator();
     m_contextMenu->addAction(nullAction);
     m_contextMenu->addSeparator();
     m_contextMenu->addAction(copyAction);
@@ -101,6 +104,9 @@ ExtendedTableWidget::ExtendedTableWidget(QWidget* parent) :
 
         // Show menu
         m_contextMenu->popup(viewport()->mapToGlobal(pos));
+    });
+    connect(filterAction, &QAction::triggered, [&]() {
+        useAsFilter();
     });
     connect(nullAction, &QAction::triggered, [&]() {
         foreach(const QModelIndex& index, selectedIndexes())
@@ -339,6 +345,17 @@ void ExtendedTableWidget::paste()
         }
     }
 
+}
+
+void ExtendedTableWidget::useAsFilter()
+{
+    QModelIndex index = selectionModel()->currentIndex();
+
+    // Abort if there's nothing to filter
+    if (!index.isValid() || !selectionModel()->hasSelection())
+      return;
+
+    m_tableHeader->setFilter(index.column(), "=" + model()->data(index).toString());
 }
 
 void ExtendedTableWidget::keyPressEvent(QKeyEvent* event)

--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -353,9 +353,15 @@ void ExtendedTableWidget::useAsFilter()
 
     // Abort if there's nothing to filter
     if (!index.isValid() || !selectionModel()->hasSelection())
-      return;
+        return;
 
-    m_tableHeader->setFilter(index.column(), "=" + model()->data(index).toString());
+    QVariant data = model()->data(index, Qt::EditRole);
+
+    if (data.isNull())
+        m_tableHeader->setFilter(index.column(), "=NULL");
+    else
+        m_tableHeader->setFilter(index.column(), "=" + data.toString());
+
 }
 
 void ExtendedTableWidget::keyPressEvent(QKeyEvent* event)

--- a/src/ExtendedTableWidget.h
+++ b/src/ExtendedTableWidget.h
@@ -33,6 +33,7 @@ signals:
 private:
     void copy();
     void paste();
+    void useAsFilter();
 
     typedef QList<QByteArray> QByteArrayList;
     QList<QByteArrayList> m_buffer;


### PR DESCRIPTION
Added an option in the context menu of the extended table widget for using the currently selected cell value as filter for this column. This allows quick filtering by visible values.