### PR TITLE
Source trigger patch file drop

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -543,6 +543,14 @@ void ExtendedTableWidget::dragMoveEvent(QDragMoveEvent* event)
 void ExtendedTableWidget::dropEvent(QDropEvent* event)
 {
     QModelIndex index = indexAt(event->pos());
+    
+    if (!index.isValid())
+    {
+        if (event->mimeData()->hasUrls() && event->mimeData()->urls().first().isLocalFile())
+            emit openFileFromDropEvent(event->mimeData()->urls().first().toLocalFile());
+        return;
+    }
+    
     model()->dropMimeData(event->mimeData(), Qt::CopyAction, index.row(), index.column(), QModelIndex());
     event->acceptProposedAction();
 }

--- a/src/ExtendedTableWidget.h
+++ b/src/ExtendedTableWidget.h
@@ -29,6 +29,7 @@ public slots:
 signals:
     void foreignKeyClicked(const sqlb::ObjectIdentifier& table, const QString& column, const QByteArray& value);
     void switchTable(bool next);    // 'next' parameter is set to true if next table should be selected and to false if previous table should be selected
+    void openFileFromDropEvent(QString);
 
 private:
     void copy(const bool withHeaders = false);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -252,6 +252,7 @@ void MainWindow::init()
     connect(ui->dbTreeWidget->selectionModel(), SIGNAL(currentChanged(QModelIndex,QModelIndex)), this, SLOT(changeTreeSelection()));
     connect(ui->dataTable->horizontalHeader(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showDataColumnPopupMenu(QPoint)));
     connect(ui->dataTable->verticalHeader(), SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showRecordPopupMenu(QPoint)));
+    connect(ui->dataTable, SIGNAL(openFileFromDropEvent(QString)), this, SLOT(fileOpen(QString)));
     connect(ui->dockEdit, SIGNAL(visibilityChanged(bool)), this, SLOT(toggleEditDock(bool)));
     connect(m_remoteDb, SIGNAL(openFile(QString)), this, SLOT(fileOpen(QString)));
     connect(m_remoteDb, &RemoteDatabase::gotCurrentVersion, this, &MainWindow::checkNewVersion);


### PR DESCRIPTION
This fixes the problem that the application crashes when dragging a file to a non-valid index in the table. At the same time the file will be opened in this case.

I add a Signal/Slot to communicate with ExtendTableWidget and MainWindow and validate Index after drop anything. 