### PR TITLE
Save current filter, sort column and display formats as a new view

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2727,7 +2727,7 @@ void MainWindow::saveAsView(QString query)
     while(true)
     {
         name = QInputDialog::getText(this, qApp->applicationName(), tr("Please specify the view name")).trimmed();
-        if(name.isEmpty())
+        if(name.isNull())
             return;
         if(db.getObjectByName(sqlb::ObjectIdentifier("main", name)) != nullptr)
             QMessageBox::warning(this, qApp->applicationName(), tr("There is already an object with that name. Please choose a different name."));
@@ -2749,6 +2749,5 @@ void MainWindow::saveFilterAsView()
         // Save as view a custom query without rowid
         saveAsView(m_browseTableModel->customQuery(false));
     else
-        QMessageBox::information(this, qApp->applicationName(), tr("There is not any filter set for this table. View will not be created."));
-
+        QMessageBox::information(this, qApp->applicationName(), tr("There is no filter set for this table. View will not be created."));
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -190,6 +190,7 @@ private:
     void activateFields(bool enable = true);
     void enableEditing(bool enable_edit, bool enable_insertdelete);
     void loadExtensionsFromSettings();
+    void saveAsView(QString query);
 
     sqlb::ObjectIdentifier currentlyBrowsedTableName() const;
 
@@ -291,6 +292,7 @@ private slots:
     void renameSqlTab(int index);
     void setFindFrameVisibility(bool show);
     void openFindReplaceDialog();
+    void saveFilterAsView();
 };
 
 #endif

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -159,6 +159,20 @@
            </widget>
           </item>
           <item>
+           <widget class="QToolButton" name="buttonSaveFilterAsView">
+            <property name="toolTip">
+             <string>Save the current filter as a view</string>
+            </property>
+            <property name="text">
+             <string>...</string>
+            </property>
+            <property name="icon">
+             <iconset resource="icons/icons.qrc">
+              <normaloff>:/icons/save_table</normaloff>:/icons/save_table</iconset>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="horizontalSpacer">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -3014,6 +3028,22 @@
     <hint type="sourcelabel">
      <x>330</x>
      <y>372</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>518</x>
+     <y>314</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonSaveFilterAsView</sender>
+   <signal>clicked()</signal>
+   <receiver>MainWindow</receiver>
+   <slot>saveFilterAsView()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>290</x>
+     <y>127</y>
     </hint>
     <hint type="destinationlabel">
      <x>518</x>

--- a/src/SqlExecutionArea.cpp
+++ b/src/SqlExecutionArea.cpp
@@ -103,28 +103,6 @@ void SqlExecutionArea::saveAsCsv()
     dialog.exec();
 }
 
-void SqlExecutionArea::saveAsView()
-{
-    // Let the user select a name for the new view and make sure it doesn't already exist
-    QString name;
-    while(true)
-    {
-        name = QInputDialog::getText(this, qApp->applicationName(), tr("Please specify the view name")).trimmed();
-        if(name.isEmpty())
-            return;
-        if(db.getObjectByName(sqlb::ObjectIdentifier("main", name)) != nullptr)
-            QMessageBox::warning(this, qApp->applicationName(), tr("There is already an object with that name. Please choose a different name."));
-        else
-            break;
-    }
-
-    // Create the view
-    if(db.executeSQL(QString("CREATE VIEW %1 AS %2;").arg(sqlb::escapeIdentifier(name)).arg(model->query())))
-        QMessageBox::information(this, qApp->applicationName(), tr("View successfully created."));
-    else
-        QMessageBox::warning(this, qApp->applicationName(), tr("Error creating view: %1").arg(db.lastError()));
-}
-
 void SqlExecutionArea::reloadSettings()
 {
     // Reload editor and table settings

--- a/src/SqlExecutionArea.h
+++ b/src/SqlExecutionArea.h
@@ -33,7 +33,6 @@ public:
 public slots:
     virtual void finishExecution(const QString& result, const bool ok);
     virtual void saveAsCsv();
-    virtual void saveAsView();
     virtual void reloadSettings();
     void fetchedData();
     void setFindFrameVisibility(bool show);

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -605,8 +605,10 @@ QString SqliteTableModel::customQuery(bool withRowid)
 
         for(QMap<int, QString>::const_iterator i=m_mWhere.constBegin();i!=m_mWhere.constEnd();++i)
         {
-            QString column = sqlb::escapeIdentifier(m_headers.at(i.key()));
-            where.append(QString("%1 %2 AND ").arg(column).arg(i.value()));
+            QString columnId = sqlb::escapeIdentifier(m_headers.at(i.key()));
+            if(m_vDisplayFormat.size() && m_vDisplayFormat.at(i.key()-1) != columnId)
+                columnId = sqlb::escapeIdentifier(m_headers.at(i.key()) + "_");
+            where.append(QString("%1 %2 AND ").arg(columnId).arg(i.value()));
         }
 
         // Remove last 'AND '
@@ -621,12 +623,13 @@ QString SqliteTableModel::customQuery(bool withRowid)
     {
         selector += "*";
     } else {
+        QString columnId;
         for(int i=0;i<m_vDisplayFormat.size();i++) {
-            QString column = sqlb::escapeIdentifier(m_headers.at(i+1));
-            if (m_vDisplayFormat.at(i) == column)
-                selector += column + ",";
+            columnId = sqlb::escapeIdentifier(m_headers.at(i+1));
+            if (columnId != m_vDisplayFormat.at(i))
+                selector += m_vDisplayFormat.at(i) + " AS " + sqlb::escapeIdentifier(m_headers.at(i+1) + "_") + ",";
             else
-                selector += m_vDisplayFormat.at(i) + " AS " + column + ",";
+                selector += columnId + ",";
         }
         selector.chop(1);
     }

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -216,6 +216,11 @@ int SqliteTableModel::columnCount(const QModelIndex&) const
     return m_headers.size();
 }
 
+int SqliteTableModel::filterCount() const
+{
+    return m_mWhere.size();
+}
+
 QVariant SqliteTableModel::headerData(int section, Qt::Orientation orientation, int role) const
 {
     if (role != Qt::DisplayRole)
@@ -590,7 +595,7 @@ void SqliteTableModel::fetchData(unsigned int from, unsigned to)
     });
 }
 
-void SqliteTableModel::buildQuery()
+QString SqliteTableModel::customQuery(bool withRowid)
 {
     QString where;
 
@@ -600,12 +605,8 @@ void SqliteTableModel::buildQuery()
 
         for(QMap<int, QString>::const_iterator i=m_mWhere.constBegin();i!=m_mWhere.constEnd();++i)
         {
-            QString column;
-            if(m_vDisplayFormat.size())
-                column = QString("col%1").arg(i.key());
-            else
-                column = m_headers.at(i.key());
-            where.append(QString("%1 %2 AND ").arg(sqlb::escapeIdentifier(column)).arg(i.value()));
+            QString column = sqlb::escapeIdentifier(m_headers.at(i.key()));
+            where.append(QString("%1 %2 AND ").arg(column).arg(i.value()));
         }
 
         // Remove last 'AND '
@@ -613,12 +614,20 @@ void SqliteTableModel::buildQuery()
     }
 
     QString selector;
+    if (withRowid)
+        selector = sqlb::escapeIdentifier(m_headers.at(0)) + ",";
+
     if(m_vDisplayFormat.empty())
     {
-        selector = "*";
+        selector += "*";
     } else {
-        for(int i=0;i<m_vDisplayFormat.size();i++)
-            selector += m_vDisplayFormat.at(i) + " AS " + QString("col%1").arg(i+1) + ",";
+        for(int i=0;i<m_vDisplayFormat.size();i++) {
+            QString column = sqlb::escapeIdentifier(m_headers.at(i+1));
+            if (m_vDisplayFormat.at(i) == column)
+                selector += column + ",";
+            else
+                selector += m_vDisplayFormat.at(i) + " AS " + column + ",";
+        }
         selector.chop(1);
     }
 
@@ -626,15 +635,18 @@ void SqliteTableModel::buildQuery()
     // The reason is that we're adding '%' characters automatically around search terms (and even if we didn't the user could add
     // them manually) which means that e.g. searching for '1' results in another '%1' in the string which then totally confuses
     // the QString::arg() function, resulting in an invalid SQL.
-    QString sql = QString("SELECT %1,%2 FROM %3 ")
-            .arg(sqlb::escapeIdentifier(m_headers.at(0)))
+    return QString("SELECT %1 FROM %2 ")
             .arg(selector)
             .arg(m_sTable.toString())
             + where
             + QString("ORDER BY %1 %2")
             .arg(sqlb::escapeIdentifier(m_headers.at(m_iSortColumn)))
             .arg(m_sSortOrder);
-    setQuery(sql, true);
+}
+
+void SqliteTableModel::buildQuery()
+{
+    setQuery(customQuery(true), true);
 }
 
 void SqliteTableModel::removeCommentsFromQuery(QString& query) {

--- a/src/sqlitetablemodel.h
+++ b/src/sqlitetablemodel.h
@@ -26,6 +26,7 @@ public:
     int rowCount(const QModelIndex &parent = QModelIndex()) const;
     int totalRowCount() const;
     int columnCount(const QModelIndex &parent = QModelIndex()) const;
+    int filterCount() const;
     QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const;
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const;
     bool setData(const QModelIndex& index, const QVariant& value, int role = Qt::EditRole);
@@ -40,6 +41,7 @@ public:
 
     void setQuery(const QString& sQuery, bool dontClearHeaders = false);
     QString query() const { return m_sQuery; }
+    QString customQuery(bool withRowid);
     void setTable(const sqlb::ObjectIdentifier& table, int sortColumn = 0, Qt::SortOrder sortOrder = Qt::AscendingOrder, const QVector<QString> &display_format = QVector<QString>());
     void setChunkSize(size_t chunksize);
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);


### PR DESCRIPTION
A new button is added to the Browse Data tab for saving the current display
of the table (current filter, sort column and display formats) as a new
view. This allows (specially for non advanced users) the creation of simple
views. It can be seen, either as a way of storing the current
filtering or as an easy way of creating views.

This reuses the query set in sqlitetablemodel, but the column aliases, when
a display format is used, has been changed from `col%1` to the original column
names, i.e.: format(`orig`) AS `orig`.

That is the part where I am not sure about these changes. Can this name preserving break anything? Apparently not, but I don't dare to commit this without review.

This change can be made compatible with the other pull request that I opened, but they overlap somehow and this concept is more powerful when one tries to save a filter for later usage. if this is merged, maybe the other is not worth enough for merging.