### PR TITLE
Allow users to drag and drop fields from DB Schema dock to editor

### DIFF
--- a/src/DbStructureModel.cpp
+++ b/src/DbStructureModel.cpp
@@ -66,9 +66,9 @@ Qt::ItemFlags DbStructureModel::flags(const QModelIndex &index) const
     // All items are enabled and selectable
     Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable | Qt::ItemIsDropEnabled;
 
-    // Only enable dragging for entire table objects
+    // Only enable dragging for entire table objects and for fields (composition in SQL text editor)
     QString type = data(index.sibling(index.row(), ColumnObjectType), Qt::DisplayRole).toString();
-    if(type == "table" || type == "view" || type == "index" || type == "trigger")
+    if(type == "table" || type == "field" || type == "view" || type == "index" || type == "trigger")
         flags |= Qt::ItemIsDragEnabled;
 
     return flags;
@@ -194,28 +194,36 @@ QMimeData* DbStructureModel::mimeData(const QModelIndexList& indices) const
     QByteArray d;
     for(const QModelIndex& index : indices)
     {
-        // Only export data for valid indices and only for the SQL column, i.e. only once per row
-        if(index.isValid() && index.column() == ColumnSQL)
-        {
-            // Add the SQL code used to create the object
-            d = d.append(data(index, Qt::DisplayRole).toString() + ";\n");
+        // Only export data for valid indices and only once per row (SQL column, except for fields).
+        // For fields, export an escaped identifier of the field for statement composition in SQL editor.
+        if(index.isValid()) {
+            QString objectType = data(index.sibling(index.row(), ColumnObjectType), Qt::DisplayRole).toString();
 
-            // If it is a table also add the content
-            if(data(index.sibling(index.row(), ColumnObjectType), Qt::DisplayRole).toString() == "table")
+            if(objectType == "field" && index.column() == ColumnName)
+                d = d.append(sqlb::escapeIdentifier(data(index, Qt::DisplayRole).toString()));
+
+            if(objectType != "field" && index.column() == ColumnSQL)
             {
-                SqliteTableModel tableModel(m_db);
-                sqlb::ObjectIdentifier objid(data(index.sibling(index.row(), ColumnSchema), Qt::DisplayRole).toString(),
-                                             data(index.sibling(index.row(), ColumnName), Qt::DisplayRole).toString());
-                tableModel.setTable(objid);
-                tableModel.waitForFetchingFinished();
-                for(int i=0; i < tableModel.rowCount(); ++i)
+                // Add the SQL code used to create the object
+                d = d.append(data(index, Qt::DisplayRole).toString() + ";\n");
+
+                // If it is a table also add the content
+                if(objectType == "table")
                 {
-                    QString insertStatement = "INSERT INTO " + objid.toString() + " VALUES(";
-                    for(int j=1; j < tableModel.columnCount(); ++j)
-                        insertStatement += QString("'%1',").arg(tableModel.data(tableModel.index(i, j)).toString());
-                    insertStatement.chop(1);
-                    insertStatement += ");\n";
-                    d = d.append(insertStatement);
+                    SqliteTableModel tableModel(m_db);
+                    sqlb::ObjectIdentifier objid(data(index.sibling(index.row(), ColumnSchema), Qt::DisplayRole).toString(),
+                                                 data(index.sibling(index.row(), ColumnName), Qt::DisplayRole).toString());
+                    tableModel.setTable(objid);
+                    tableModel.waitForFetchingFinished();
+                    for(int i=0; i < tableModel.rowCount(); ++i)
+                    {
+                        QString insertStatement = "INSERT INTO " + objid.toString() + " VALUES(";
+                        for(int j=1; j < tableModel.columnCount(); ++j)
+                            insertStatement += QString("'%1',").arg(tableModel.data(tableModel.index(i, j)).toString());
+                        insertStatement.chop(1);
+                        insertStatement += ");\n";
+                        d = d.append(insertStatement);
+                    }
                 }
             }
         }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -117,6 +117,7 @@ void MainWindow::init()
     ui->treeSchemaDock->setColumnWidth(DbStructureModel::ColumnName, 300);
     ui->treeSchemaDock->setColumnHidden(DbStructureModel::ColumnObjectType, true);
     ui->treeSchemaDock->setColumnHidden(DbStructureModel::ColumnSchema, true);
+    ui->treeSchemaDock->setDragDropMode(QAbstractItemView::DragOnly);
 
     // Set up the table combo box in the Browse Data tab
     ui->comboBrowseTable->setModel(dbStructureModel);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -117,7 +117,6 @@ void MainWindow::init()
     ui->treeSchemaDock->setColumnWidth(DbStructureModel::ColumnName, 300);
     ui->treeSchemaDock->setColumnHidden(DbStructureModel::ColumnObjectType, true);
     ui->treeSchemaDock->setColumnHidden(DbStructureModel::ColumnSchema, true);
-    ui->treeSchemaDock->setDragDropMode(QAbstractItemView::DragOnly);
 
     // Set up the table combo box in the Browse Data tab
     ui->comboBrowseTable->setModel(dbStructureModel);

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -63,6 +63,11 @@
           <property name="contextMenuPolicy">
            <enum>Qt::CustomContextMenu</enum>
           </property>
+          <property name="whatsThis">
+           <string>This is the structure of the opened database.
+You can drag SQL sentences from an object row and drop them into other applications or into another instance of 'DB Browser for SQLite'.
+</string>
+          </property>
           <property name="dragEnabled">
            <bool>true</bool>
           </property>
@@ -1117,8 +1122,26 @@
     <layout class="QVBoxLayout" name="verticalLayout_9">
      <item>
       <widget class="QTreeView" name="treeSchemaDock">
+       <property name="whatsThis">
+        <string>This is the structure of the opened database.
+You can drag multiple object names from the Name column and drop them into the SQL editor .
+You can drag SQL sentences from the Schema column and drop them into the SQL editor or into other applications.
+</string>
+       </property>
+       <property name="dragEnabled">
+        <bool>true</bool>
+       </property>
+       <property name="dragDropMode">
+        <enum>QAbstractItemView::DragDrop</enum>
+       </property>
        <property name="alternatingRowColors">
         <bool>true</bool>
+       </property>
+       <property name="selectionMode">
+        <enum>QAbstractItemView::ExtendedSelection</enum>
+       </property>
+       <property name="selectionBehavior">
+        <enum>QAbstractItemView::SelectItems</enum>
        </property>
        <property name="verticalScrollMode">
         <enum>QAbstractItemView::ScrollPerPixel</enum>


### PR DESCRIPTION
This is the first attempt to provide the functionality described in #119.

Drag in the dock is enabled (it was only enabled in the Database Structure tab). Then the fields are enabled for dragging and finally the MIME data exported for the drag and drop is tailored for exporting only the escaped field identifier.

This may interfere to other uses of drag&drop in the Database Structure, so I open this pull request for discussion and refinement. I've reproduced a crash dropping a table between databases, I think it is not related with my changes, but I'll try to figure it out.

Possible improvements: there are two uses of drag&drop and users might be confused. Tables paste the SQL creation and population statements, and fields only the name. Maybe the Dock and the Database Structure should have their own different drag&drop behaviours? Dock for statement composition, sot it would only drop the names; and Database Structure, only for exporting full SQL statements (then in this tab the fields would be again not candidate for dragging).
