### PR TITLE
Always copy to clipboard and to internal buffer. Embedded image support.

### DIFF
--- a/src/ExtendedTableWidget.h
+++ b/src/ExtendedTableWidget.h
@@ -40,6 +40,7 @@ private:
 
     typedef QList<QByteArray> QByteArrayList;
     static QList<QByteArrayList> m_buffer;
+    static QString m_generatorStamp;
 
 private slots:
     void vscrollbarChanged(int value);


### PR DESCRIPTION
At the time of pasting, use the generator and date meta tags in the HTML
version for knowing whether our data in the system clipboard has been
overwritten. If not, the internal buffer has better data, so we use it.

Since the binary data is not excluded in the system clipboard, images
are also included embedded in the HTML table. Other binary data are encoded
as base64 strings.

See issue #1244 