### PR TITLE
Fix crash when Tab is pressed at the last cell of a view's grid

### DIFF
--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -938,7 +938,7 @@ void SqliteTableModel::setPseudoPk(const QString& pseudoPk)
 
 bool SqliteTableModel::isEditable() const
 {
-    return !m_sTable.isEmpty();
+    return !m_sTable.isEmpty() && m_db.getObjectByName(m_sTable)->type() == sqlb::Object::Types::Table;
 }
 
 void SqliteTableModel::waitForFetchingFinished()

--- a/src/sqlitetablemodel.h
+++ b/src/sqlitetablemodel.h
@@ -64,7 +64,7 @@ public:
 
     // This returns true if the model is set up for editing. The model is able to operate in more or less two different modes, table browsing
     // and query browsing. We only support editing data for the table browsing mode and not for the query mode. This function returns true if
-    // the model is currently editable, i.e. it's running in table mode.
+    // the model is currently editable, i.e. it's running in table mode and it isn't a view.
     bool isEditable() const;
 
     // Helper function for removing all comments from a SQL query


### PR DESCRIPTION
The crash is avoided if the table model is not editable, since insertRows
checks that. A table model for a DB view should be not editable, so this
fix avoids the crash and possibly other possible misbehaviours.

I open this pull request:
- May have this any side effect?
- How would interact with a future implementation of #141. Probably it should be reverted back to the original version.
