### PR TITLE
Scale the interface based on target monitor's pixel ratio

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -4,7 +4,7 @@ DB Browser for SQLite requires Qt as well as SQLite. For more information on Qt
 please consult http://www.qt.io and for SQLite please see https://sqlite.org/.
 
 Please note that all versions after 3.9.1 will require:
-* Qt 5.5 or later, however we advise you to use 5.7 or later
+* Qt 5.5 or later, however we advise you to use 5.7 or later *(if you use multiple monitors or a single High DPI display Qt 5.6 or later is recommended to get application scaling support)*
 * A C++ compiler with support for C++11 or later
 
 Without these or with older versions you won't be able to compile DB Browser for

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -14,6 +14,14 @@
 Application::Application(int& argc, char** argv) :
     QApplication(argc, argv)
 {
+#if QT_VERSION >= 0x050600
+    // Match the target monitors pixel ratio
+    setAttribute(Qt::AA_EnableHighDpiScaling);
+#endif
+
+    // Generate and use high res pixmaps where applicable
+    setAttribute(Qt::AA_UseHighDpiPixmaps);
+
     // Set organisation and application names
     setOrganizationName("sqlitebrowser");
     setApplicationName("DB Browser for SQLite");


### PR DESCRIPTION
This is a band-aid of sorts on a larger OS centric problem but will result in the application handling resolution scale/change events gracefully without cramping any UI element. Fixes #1285.