### PR TITLE
Avoid unnecessary queries when populating filtered table (workaround for invalid rows)

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -554,9 +554,9 @@ void MainWindow::populateTable()
             }
         }
         if(only_defaults)
-            m_browseTableModel->setTable(tablename, storedData.sortOrderIndex, storedData.sortOrderMode);
+            m_browseTableModel->setTable(tablename, storedData.sortOrderIndex, storedData.sortOrderMode, storedData.filterValues);
         else
-            m_browseTableModel->setTable(tablename, storedData.sortOrderIndex, storedData.sortOrderMode, v);
+            m_browseTableModel->setTable(tablename, storedData.sortOrderIndex, storedData.sortOrderMode, storedData.filterValues, v);
 
         // There is information stored for this table, so extract it and apply it
 
@@ -579,10 +579,12 @@ void MainWindow::populateTable()
         // Sorting
         ui->dataTable->filterHeader()->setSortIndicator(storedData.sortOrderIndex, storedData.sortOrderMode);
 
-        // Filters
+        // Set filters blocking signals, since the filter is already applied to the browse table model
         FilterTableHeader* filterHeader = qobject_cast<FilterTableHeader*>(ui->dataTable->horizontalHeader());
+        bool oldState = filterHeader->blockSignals(true);
         for(auto filterIt=storedData.filterValues.constBegin();filterIt!=storedData.filterValues.constEnd();++filterIt)
             filterHeader->setFilter(filterIt.key(), filterIt.value());
+        filterHeader->blockSignals(oldState);
 
         // Encoding
         m_browseTableModel->setEncoding(storedData.encoding);

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -54,7 +54,7 @@ void SqliteTableModel::setChunkSize(size_t chunksize)
     m_chunkSize = chunksize;
 }
 
-void SqliteTableModel::setTable(const sqlb::ObjectIdentifier& table, int sortColumn, Qt::SortOrder sortOrder, const QVector<QString>& display_format)
+void SqliteTableModel::setTable(const sqlb::ObjectIdentifier& table, int sortColumn, Qt::SortOrder sortOrder, const QMap<int, QString> filterValues, const QVector<QString>& display_format)
 {
     // Unset all previous settings. When setting a table all information on the previously browsed data set is removed first.
     reset();
@@ -62,6 +62,9 @@ void SqliteTableModel::setTable(const sqlb::ObjectIdentifier& table, int sortCol
     // Save the other parameters
     m_sTable = table;
     m_vDisplayFormat = display_format;
+
+    for(auto filterIt=filterValues.constBegin(); filterIt!=filterValues.constEnd(); ++filterIt)
+        updateFilter(filterIt.key(), filterIt.value(), false);
 
     // The first column is the rowid column and therefore is always of type integer
     m_vDataTypes.push_back(SQLITE_INTEGER);
@@ -734,7 +737,7 @@ QStringList SqliteTableModel::getColumns(const QString& sQuery, QVector<int>& fi
     return listColumns;
 }
 
-void SqliteTableModel::updateFilter(int column, const QString& value)
+void SqliteTableModel::updateFilter(int column, const QString& value, bool applyQuery)
 {
     // Check for any special comparison operators at the beginning of the value string. If there are none default to LIKE.
     QString op = "LIKE";
@@ -846,7 +849,8 @@ void SqliteTableModel::updateFilter(int column, const QString& value)
     }
 
     // Build the new query
-    buildQuery();
+    if (applyQuery)
+        buildQuery();
 }
 
 void SqliteTableModel::clearCache()

--- a/src/sqlitetablemodel.h
+++ b/src/sqlitetablemodel.h
@@ -42,7 +42,7 @@ public:
     void setQuery(const QString& sQuery, bool dontClearHeaders = false);
     QString query() const { return m_sQuery; }
     QString customQuery(bool withRowid);
-    void setTable(const sqlb::ObjectIdentifier& table, int sortColumn = 0, Qt::SortOrder sortOrder = Qt::AscendingOrder, const QVector<QString> &display_format = QVector<QString>());
+    void setTable(const sqlb::ObjectIdentifier& table, int sortColumn = 0, Qt::SortOrder sortOrder = Qt::AscendingOrder, const QMap<int, QString> filterValues = QMap<int, QString>(), const QVector<QString> &display_format = QVector<QString>());
     void setChunkSize(size_t chunksize);
     void sort(int column, Qt::SortOrder order = Qt::AscendingOrder);
     const sqlb::ObjectIdentifier& currentTableName() const { return m_sTable; }
@@ -74,7 +74,7 @@ public:
     void waitForFetchingFinished();
 
 public slots:
-    void updateFilter(int column, const QString& value);
+    void updateFilter(int column, const QString& value, bool applyQuery = true);
 
     // This cancels the execution of the current query. It can't guarantee that the query is stopped immediately or after returning but it should
     // stop soon afterwards. If some data has already been loaded into the model, that data is not deleted


### PR DESCRIPTION
When a table is filtered and the browsed tabled is changed and then we
return to this filtered table, the table view shows several incorrect
disabled rows. The same may happen when refreshing this table. This seems
to be produced by a (yet unsolved) concurrency problem triggered by
several consecutive queries, that are signalled by setting the text of
the stored filters in the table header filter.

These unnecessary queries are avoided by setting the stored filter values
at the same time as the table in the SQL table model, making sure that
no intermediate queries are executed while the filters are set.

This seems to work around the concurrency problem and the symptom of the
invalid rows does not appear in those situations.

These are the queries that I get before the fix:

```sql
SELECT COUNT(*) FROM (SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` ORDER BY `_rowid_` ASC);
SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` ORDER BY `_rowid_` ASC LIMIT 0, 300;
SELECT COUNT(*) FROM (SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` WHERE `Category` = 'Medical'  ORDER BY `_rowid_` ASC);
SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` WHERE `Category` = 'Medical'  ORDER BY `_rowid_` ASC LIMIT 0, 300;
SELECT COUNT(*) FROM (SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` WHERE `Category` = 'Medical'  AND `Item` = 'Syringes'  ORDER BY `_rowid_` ASC);
SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` WHERE `Category` = 'Medical'  AND `Item` = 'Syringes'  ORDER BY `_rowid_` ASC LIMIT 0, 300;
```

After the fix:
```sql
SELECT COUNT(*) FROM (SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` WHERE `Category` = 'Medical'  AND `Item` = 'Syringes'  ORDER BY `_rowid_` ASC);
SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` WHERE `Category` = 'Medical'  AND `Item` = 'Syringes'  ORDER BY `_rowid_` ASC LIMIT 0, 300;
```

But I'm still able to reproduce the invalid rows problem. This is what happens when you open a project with saved filters for a table:

```sql
SELECT COUNT(*) FROM (SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` ORDER BY `_rowid_` ASC);
SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` ORDER BY `_rowid_` ASC LIMIT 0, 300;
SELECT COUNT(*) FROM (SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` WHERE `Category` = 'Medical'  AND `Item` = 'Syringes'  ORDER BY `_rowid_` ASC);
SELECT `_rowid_`,* FROM `main`.`100m2012Autumn` WHERE `Category` = 'Medical'  AND `Item` = 'Syringes'  ORDER BY `_rowid_` ASC LIMIT 0, 300;
```
Since there are two consecutive count queries, the problem is reproduced. And in that case the filter values in the table header are not displayed, as I already reported in #1222.

I hope this helps to find the concurrency problem but, in any case, removing unnecessary queries is good. But it should be carefully reviewed, since I'm not sure about possible side effects of the solution.

(The tests are made with this DB: https://db4s-beta.dbhub.io/nicva/Marine%20Litter%20Survey%20(Keep%20Northern%20Ireland%20Beautiful).sqlite)