### PR TITLE
Extension loading strips ".so" and ".dll" from file name

### DIFF
--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -1566,6 +1566,7 @@ bool DBBrowserDB::setPragma(const QString& pragma, int value, int& originalvalue
 
 bool DBBrowserDB::loadExtension(const QString& filename)
 {
+    QString extensionName = filename;
     if(!isOpen())
         return false;
 
@@ -1576,9 +1577,14 @@ bool DBBrowserDB::loadExtension(const QString& filename)
         return false;
     }
 
+    if (extensionName.endsWith(".so"))
+        extensionName.chop(3);
+    else if (extensionName.endsWith(".dll"))
+        extensionName.chop(4);
+
     // Try to load extension
     char* error;
-    if(sqlite3_load_extension(_db, filename.toUtf8(), nullptr, &error) == SQLITE_OK)
+    if(sqlite3_load_extension(_db, extensionName.toUtf8(), nullptr, &error) == SQLITE_OK)
     {
         return true;
     } else {


### PR DESCRIPTION
This is a workaround for the issue in sqlite3_load_extension. It only gives real error messages when the provided filename has been stripped from the library suffix.

Should we add this workaround?

See issue #1290