### PR TITLE
doc: BUILDING: Debian: Don't install the entire Git distribution just for cloning the repo

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -54,7 +54,7 @@ The same process works for building the code in any platform supported by Qt
 ### Ubuntu Linux
 
 ```bash
-$ sudo apt install build-essential git cmake libsqlite3-dev qt5-default qttools5-dev-tools \
+$ sudo apt install build-essential git-core cmake libsqlite3-dev qt5-default qttools5-dev-tools \
     libsqlcipher-dev
 $ git clone https://github.com/sqlitebrowser/sqlitebrowser
 $ cd sqlitebrowser


### PR DESCRIPTION
The download and disk usage difference is apparent and should be avoided when possible

```
$ apt show git-core git 2>/dev/null | grep '^Installed-Size'
Installed-Size: 8,192 B
Installed-Size: 24.1 MB
```

Signed-off-by: 林博仁 <Buo.Ren.Lin@gmail.com>