### PR TITLE
Add automatic crypted databases open via dotenvs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,8 @@ set(SQLB_MOC_HDR
 	src/FindReplaceDialog.h
 	src/ExtendedScintilla.h
 	src/FileExtensionManager.h
+	src/CipherSettings.h
+	src/DotenvFormat.h
 )
 
 set(SQLB_SRC
@@ -182,6 +184,8 @@ set(SQLB_SRC
 	src/ExtendedScintilla.cpp
 	src/FileExtensionManager.cpp
 	src/Data.cpp
+	src/CipherSettings.cpp
+	src/DotenvFormat.cpp
 )
 
 set(SQLB_FORMS

--- a/src/CipherDialog.cpp
+++ b/src/CipherDialog.cpp
@@ -49,34 +49,33 @@ CipherDialog::~CipherDialog()
     delete ui;
 }
 
-CipherSettings::KeyFormats CipherDialog::keyFormat() const
+CipherSettings CipherDialog::getCipherSettings() const
 {
-    return static_cast<CipherSettings::KeyFormats>(ui->comboKeyFormat->currentIndex());
-}
+    CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(ui->comboKeyFormat->currentIndex());
+    QString password = ui->editPassword->text();
+    int pageSize = ui->comboPageSize->itemData(ui->comboPageSize->currentIndex()).toInt();
 
-QString CipherDialog::password() const
-{
-    if(keyFormat() == CipherSettings::KeyFormats::Passphrase)
-        return QString("'%1'").arg(ui->editPassword->text().replace("'", "''"));
-    else
-        return QString("\"x'%1'\"").arg(ui->editPassword->text().mid(2));   // Remove the '0x' part at the beginning
-}
+    CipherSettings cipherSettings;
 
-int CipherDialog::pageSize() const
-{
-    return ui->comboPageSize->itemData(ui->comboPageSize->currentIndex()).toInt();
+    cipherSettings.setKeyFormat(keyFormat);
+    cipherSettings.setPassword(password);
+    cipherSettings.setPageSize(pageSize);
+
+    return cipherSettings;
 }
 
 void CipherDialog::checkInputFields()
 {
     if(sender() == ui->comboKeyFormat)
     {
-        if(keyFormat() == CipherSettings::KeyFormats::Passphrase)
+        CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(ui->comboKeyFormat->currentIndex());
+
+        if(keyFormat == CipherSettings::KeyFormats::Passphrase)
         {
             ui->editPassword->setValidator(nullptr);
             ui->editPassword2->setValidator(nullptr);
             ui->editPassword->setPlaceholderText("");
-        } else if(keyFormat() == CipherSettings::KeyFormats::RawKey) {
+        } else if(keyFormat == CipherSettings::KeyFormats::RawKey) {
             ui->editPassword->setValidator(rawKeyValidator);
             ui->editPassword2->setValidator(rawKeyValidator);
             ui->editPassword->setPlaceholderText("0x...");

--- a/src/CipherDialog.cpp
+++ b/src/CipherDialog.cpp
@@ -49,14 +49,14 @@ CipherDialog::~CipherDialog()
     delete ui;
 }
 
-CipherDialog::KeyFormats CipherDialog::keyFormat() const
+CipherSettings::KeyFormats CipherDialog::keyFormat() const
 {
-    return static_cast<CipherDialog::KeyFormats>(ui->comboKeyFormat->currentIndex());
+    return static_cast<CipherSettings::KeyFormats>(ui->comboKeyFormat->currentIndex());
 }
 
 QString CipherDialog::password() const
 {
-    if(keyFormat() == KeyFormats::Passphrase)
+    if(keyFormat() == CipherSettings::KeyFormats::Passphrase)
         return QString("'%1'").arg(ui->editPassword->text().replace("'", "''"));
     else
         return QString("\"x'%1'\"").arg(ui->editPassword->text().mid(2));   // Remove the '0x' part at the beginning
@@ -71,12 +71,12 @@ void CipherDialog::checkInputFields()
 {
     if(sender() == ui->comboKeyFormat)
     {
-        if(keyFormat() == KeyFormats::Passphrase)
+        if(keyFormat() == CipherSettings::KeyFormats::Passphrase)
         {
             ui->editPassword->setValidator(nullptr);
             ui->editPassword2->setValidator(nullptr);
             ui->editPassword->setPlaceholderText("");
-        } else if(keyFormat() == KeyFormats::RawKey) {
+        } else if(keyFormat() == CipherSettings::KeyFormats::RawKey) {
             ui->editPassword->setValidator(rawKeyValidator);
             ui->editPassword2->setValidator(rawKeyValidator);
             ui->editPassword->setPlaceholderText("0x...");

--- a/src/CipherDialog.h
+++ b/src/CipherDialog.h
@@ -21,10 +21,7 @@ public:
     explicit CipherDialog(QWidget* parent, bool encrypt);
     ~CipherDialog();
 
-    // Allow read access to the input fields
-    CipherSettings::KeyFormats keyFormat() const;
-    QString password() const;
-    int pageSize() const;
+    CipherSettings getCipherSettings() const;
 
 private:
     Ui::CipherDialog* ui;

--- a/src/CipherDialog.h
+++ b/src/CipherDialog.h
@@ -3,6 +3,8 @@
 
 #include <QDialog>
 
+#include "CipherSettings.h"
+
 class QRegExpValidator;
 
 namespace Ui {
@@ -14,19 +16,13 @@ class CipherDialog : public QDialog
     Q_OBJECT
 
 public:
-    enum KeyFormats
-    {
-        Passphrase,
-        RawKey
-    };
-
     // Set the encrypt parameter to true when the dialog is used to encrypt a database;
     // set it to false if the dialog is used to ask the user for the key to decrypt a file.
     explicit CipherDialog(QWidget* parent, bool encrypt);
     ~CipherDialog();
 
     // Allow read access to the input fields
-    KeyFormats keyFormat() const;
+    CipherSettings::KeyFormats keyFormat() const;
     QString password() const;
     int pageSize() const;
 

--- a/src/CipherSettings.cpp
+++ b/src/CipherSettings.cpp
@@ -1,0 +1,1 @@
+#include "CipherSettings.h"

--- a/src/CipherSettings.cpp
+++ b/src/CipherSettings.cpp
@@ -1,1 +1,49 @@
 #include "CipherSettings.h"
+
+CipherSettings::KeyFormats CipherSettings::getKeyFormat() const
+{
+    return keyFormat;
+}
+
+void CipherSettings::setKeyFormat(const KeyFormats &value)
+{
+    keyFormat = value;
+}
+
+QString CipherSettings::getPassword() const
+{
+    if(keyFormat == Passphrase)
+    {
+        QString tempPassword = password;
+
+        tempPassword.replace("'", "''");
+
+        return QString("'%1'").arg(tempPassword);
+    } else {
+        // Remove the '0x' part at the beginning
+        return QString("\"x'%1'\"").arg(password.mid(2));
+    }
+}
+
+void CipherSettings::setPassword(const QString &value)
+{
+    password = value;
+}
+
+int CipherSettings::getPageSize() const
+{
+    if (pageSize == 0)
+        return defaultPageSize;
+
+    return pageSize;
+}
+
+void CipherSettings::setPageSize(int value)
+{
+    pageSize = value;
+}
+
+CipherSettings::KeyFormats CipherSettings::getKeyFormat(int rawKeyFormat)
+{
+    return static_cast<CipherSettings::KeyFormats>(rawKeyFormat);
+}

--- a/src/CipherSettings.h
+++ b/src/CipherSettings.h
@@ -1,6 +1,8 @@
 #ifndef CIPHERSETTINGS_H
 #define CIPHERSETTINGS_H
 
+#include <QString>
+
 class CipherSettings
 {
 public:
@@ -11,6 +13,22 @@ public:
     };
 
     static const int defaultPageSize = 1024;
+
+    KeyFormats getKeyFormat() const;
+    void setKeyFormat(const KeyFormats &value);
+
+    QString getPassword() const;
+    void setPassword(const QString &value);
+
+    int getPageSize() const;
+    void setPageSize(int value);
+
+    static KeyFormats getKeyFormat(int rawKeyFormat);
+
+private:
+    KeyFormats keyFormat;
+    QString password;
+    int pageSize;
 };
 
 #endif // CIPHERSETTINGS_H

--- a/src/CipherSettings.h
+++ b/src/CipherSettings.h
@@ -4,6 +4,12 @@
 class CipherSettings
 {
 public:
+    enum KeyFormats
+    {
+        Passphrase,
+        RawKey
+    };
+
     static const int defaultPageSize = 1024;
 };
 

--- a/src/CipherSettings.h
+++ b/src/CipherSettings.h
@@ -1,0 +1,10 @@
+#ifndef CIPHERSETTINGS_H
+#define CIPHERSETTINGS_H
+
+class CipherSettings
+{
+public:
+    static const int defaultPageSize = 1024;
+};
+
+#endif // CIPHERSETTINGS_H

--- a/src/DotenvFormat.cpp
+++ b/src/DotenvFormat.cpp
@@ -1,0 +1,28 @@
+#include "DotenvFormat.h"
+
+#include <QRegularExpression>
+#include <QTextStream>
+
+bool DotenvFormat::readEnvFile(QIODevice &device, QSettings::SettingsMap &map)
+{
+    QTextStream in(&device);
+
+    QString line;
+
+    QRegularExpression keyValueRegex("^\\s*([\\w\\.\\-]+)\\s*=\\s*(.*)\\s*$");
+
+    while (in.readLineInto(&line)) {
+        QRegularExpressionMatch match = keyValueRegex.match(line);
+
+        if (match.capturedLength() < 3) {
+            continue;
+        }
+
+        QString key = match.captured(1);
+        QString value = match.captured(2);
+
+        map.insert(key, value);
+    }
+
+    return true;
+}

--- a/src/DotenvFormat.h
+++ b/src/DotenvFormat.h
@@ -1,0 +1,13 @@
+#ifndef DOTENVFORMAT_H
+#define DOTENVFORMAT_H
+
+#include <QIODevice>
+#include <QSettings>
+
+class DotenvFormat
+{
+public:
+    static bool readEnvFile(QIODevice &device, QSettings::SettingsMap &map);
+};
+
+#endif // DOTENVFORMAT_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2513,8 +2513,8 @@ void MainWindow::updateFilter(int column, const QString& value)
 void MainWindow::editEncryption()
 {
 #ifdef ENABLE_SQLCIPHER
-    CipherDialog dialog(this, true);
-    if(dialog.exec())
+    CipherDialog cipherDialog(this, true);
+    if(cipherDialog.exec())
     {
         // Show progress dialog even though we can't provide any detailed progress information but this
         // process might take some time.
@@ -2539,11 +2539,11 @@ void MainWindow::editEncryption()
         // Attach a new database using the new settings
         qApp->processEvents();
         if(ok)
-            ok = db.executeSQL(QString("ATTACH DATABASE '%1' AS sqlitebrowser_edit_encryption KEY %2;").arg(db.currentFile() + ".enctemp").arg(dialog.password()),
+            ok = db.executeSQL(QString("ATTACH DATABASE '%1' AS sqlitebrowser_edit_encryption KEY %2;").arg(db.currentFile() + ".enctemp").arg(cipherDialog.password()),
                                false, false);
         qApp->processEvents();
         if(ok)
-            ok = db.executeSQL(QString("PRAGMA sqlitebrowser_edit_encryption.cipher_page_size = %1").arg(dialog.pageSize()), false, false);
+            ok = db.executeSQL(QString("PRAGMA sqlitebrowser_edit_encryption.cipher_page_size = %1").arg(cipherDialog.pageSize()), false, false);
 
         // Export the current database to the new one
         qApp->processEvents();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2536,14 +2536,16 @@ void MainWindow::editEncryption()
             file.close();
         }
 
+        CipherSettings cipherSettings = cipherDialog.getCipherSettings();
+
         // Attach a new database using the new settings
         qApp->processEvents();
         if(ok)
-            ok = db.executeSQL(QString("ATTACH DATABASE '%1' AS sqlitebrowser_edit_encryption KEY %2;").arg(db.currentFile() + ".enctemp").arg(cipherDialog.password()),
+            ok = db.executeSQL(QString("ATTACH DATABASE '%1' AS sqlitebrowser_edit_encryption KEY %2;").arg(db.currentFile() + ".enctemp").arg(cipherSettings.getPassword()),
                                false, false);
         qApp->processEvents();
         if(ok)
-            ok = db.executeSQL(QString("PRAGMA sqlitebrowser_edit_encryption.cipher_page_size = %1").arg(cipherDialog.pageSize()), false, false);
+            ok = db.executeSQL(QString("PRAGMA sqlitebrowser_edit_encryption.cipher_page_size = %1").arg(cipherSettings.getPageSize()), false, false);
 
         // Export the current database to the new one
         qApp->processEvents();

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -8,6 +8,8 @@
 #include <QStandardPaths>
 #include <QPalette>
 
+#include "DotenvFormat.h"
+
 QHash<QString, QVariant> Settings::m_hCache;
 
 QVariant Settings::getValue(const QString& group, const QString& name)

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -8,8 +8,6 @@
 #include <QStandardPaths>
 #include <QPalette>
 
-#include "DotenvFormat.h"
-
 QHash<QString, QVariant> Settings::m_hCache;
 
 QVariant Settings::getValue(const QString& group, const QString& name)
@@ -357,11 +355,4 @@ void Settings::restoreDefaults ()
     QSettings settings(QApplication::organizationName(), QApplication::organizationName());
     settings.clear();
     m_hCache.clear();
-}
-
-QSettings::Format Settings::getDotenvFormat()
-{
-    static const QSettings::Format DotenvFormat = QSettings::registerFormat("env", &DotenvFormat::readEnvFile, nullptr);
-
-    return DotenvFormat;
 }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -356,3 +356,10 @@ void Settings::restoreDefaults ()
     settings.clear();
     m_hCache.clear();
 }
+
+QSettings::Format Settings::getDotenvFormat()
+{
+    static const QSettings::Format DotenvFormat = QSettings::registerFormat("env", &DotenvFormat::readEnvFile, nullptr);
+
+    return DotenvFormat;
+}

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -3,7 +3,10 @@
 
 #include <QApplication>
 #include <QHash>
+#include <QSettings>
 #include <QVariant>
+
+#include "DotenvFormat.h"
 
 class Settings
 {
@@ -13,6 +16,7 @@ public:
     static QVariant getValue(const QString& group, const QString& name);
     static void setValue(const QString& group, const QString& name, const QVariant& value, bool dont_save_to_disk = false);
     static void restoreDefaults();
+    static QSettings::Format getDotenvFormat();
 
 private:
     Settings() { } // class is fully static

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -2,8 +2,8 @@
 #define SETTINGS_H
 
 #include <QApplication>
-#include <QVariant>
 #include <QHash>
+#include <QVariant>
 
 class Settings
 {

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -3,7 +3,6 @@
 
 #include <QApplication>
 #include <QHash>
-#include <QSettings>
 #include <QVariant>
 
 class Settings
@@ -14,7 +13,6 @@ public:
     static QVariant getValue(const QString& group, const QString& name);
     static void setValue(const QString& group, const QString& name, const QVariant& value, bool dont_save_to_disk = false);
     static void restoreDefaults();
-    static QSettings::Format getDotenvFormat();
 
 private:
     Settings() { } // class is fully static

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -6,8 +6,6 @@
 #include <QSettings>
 #include <QVariant>
 
-#include "DotenvFormat.h"
-
 class Settings
 {
     friend class PreferencesDialog;

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -354,8 +354,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                     return false;
                 }
 
-                if (cipherSettings)
-                    delete cipherSettings;
+                delete cipherSettings;
 
                 cipherSettings = new CipherSettings(cipherDialog->getCipherSettings());
 
@@ -370,11 +369,8 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
             } else {
                 sqlite3_close(dbHandle);
                 *encrypted = false;
-                if (cipherSettings)
-                {
-                    delete cipherSettings;
-                    cipherSettings = nullptr;
-                }
+                delete cipherSettings;
+                cipherSettings = nullptr;
                 return false;
             }
 #else

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -285,7 +285,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
             {
                 // Close and reopen database first to be in a clean state after the failed read attempt from above
                 sqlite3_close(dbHandle);
-                if(sqlite3_open_v2(filePath.toUtf8(), &dbHandle, SQLITE_OPEN_READONLY, NULL) != SQLITE_OK)
+                if(sqlite3_open_v2(filePath.toUtf8(), &dbHandle, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK)
                 {
                     delete cipherSettings;
                     cipherSettings = nullptr;
@@ -293,9 +293,9 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                 }
 
                 // Set key and, if it differs from the default value, the page size
-                sqlite3_exec(dbHandle, QString("PRAGMA key = %1").arg(cipherSettings->password()).toUtf8(), NULL, NULL, NULL);
+                sqlite3_exec(dbHandle, QString("PRAGMA key = %1").arg(cipherSettings->password()).toUtf8(), nullptr, nullptr, nullptr);
                 if(cipherSettings->pageSize() != 1024)
-                    sqlite3_exec(dbHandle, QString("PRAGMA cipher_page_size = %1;").arg(cipherSettings->pageSize()).toUtf8(), NULL, NULL, NULL);
+                    sqlite3_exec(dbHandle, QString("PRAGMA cipher_page_size = %1;").arg(cipherSettings->pageSize()).toUtf8(), nullptr, nullptr, nullptr);
 
                 *encrypted = true;
             } else {

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -292,8 +292,10 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                     return false;
                 }
 
-                // Set key and, if it differs from the default value, the page size
+                // Set the key
                 sqlite3_exec(dbHandle, QString("PRAGMA key = %1").arg(cipherSettings->password()).toUtf8(), nullptr, nullptr, nullptr);
+
+                // Set the page size if it differs from the default value
                 if(cipherSettings->pageSize() != 1024)
                     sqlite3_exec(dbHandle, QString("PRAGMA cipher_page_size = %1;").arg(cipherSettings->pageSize()).toUtf8(), nullptr, nullptr, nullptr);
 

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -348,6 +348,9 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
             CipherDialog *cipherDialog = new CipherDialog(nullptr, false);
             if(cipherDialog->exec())
             {
+                delete cipherSettings;
+                cipherSettings = new CipherSettings(cipherDialog->getCipherSettings());
+
                 // Close and reopen database first to be in a clean state after the failed read attempt from above
                 sqlite3_close(dbHandle);
                 if(sqlite3_open_v2(filePath.toUtf8(), &dbHandle, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK)
@@ -356,10 +359,6 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                     cipherSettings = nullptr;
                     return false;
                 }
-
-                delete cipherSettings;
-
-                cipherSettings = new CipherSettings(cipherDialog->getCipherSettings());
 
                 // Set the key
                 sqlite3_exec(dbHandle, QString("PRAGMA key = %1").arg(cipherSettings->getPassword()).toUtf8(), nullptr, nullptr, nullptr);

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -315,6 +315,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                     QVariant pageSizeValue = dotenv.value(databaseFileName + "_pageSize", QVariant(CipherSettings::defaultPageSize));
                     int pageSize = pageSizeValue.toInt();
 
+                    delete cipherSettings;
                     cipherSettings = new CipherSettings();
 
                     cipherSettings->setKeyFormat(keyFormat);
@@ -325,6 +326,8 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                     sqlite3_close(dbHandle);
                     if(sqlite3_open_v2(filePath.toUtf8(), &dbHandle, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK)
                     {
+	                    delete cipherSettings;
+	                    cipherSettings = nullptr;
                         return false;
                     }
 

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -3,6 +3,7 @@
 #include "sqlitetablemodel.h"
 #include "CipherDialog.h"
 #include "CipherSettings.h"
+#include "DotenvFormat.h"
 #include "Settings.h"
 
 #include <QFile>
@@ -295,7 +296,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                 QString databaseFileName(databaseFileInfo.fileName());
 
                 QString dotenvFilePath = databaseDirectoryPath + "/.env";
-                QSettings::Format dotenvFormat = Settings::getDotenvFormat();
+                static const QSettings::Format dotenvFormat = QSettings::registerFormat("env", &DotenvFormat::readEnvFile, nullptr);
                 QSettings dotenv(dotenvFilePath, dotenvFormat);
 
                 QVariant passwordValue = dotenv.value(databaseFileName);

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -2,6 +2,7 @@
 #include "sqlite.h"
 #include "sqlitetablemodel.h"
 #include "CipherDialog.h"
+#include "CipherSettings.h"
 #include "Settings.h"
 
 #include <QFile>
@@ -120,7 +121,7 @@ bool DBBrowserDB::open(const QString& db, bool readOnly)
     if(isEncrypted && cipher)
     {
         executeSQL(QString("PRAGMA key = %1").arg(cipher->password()), false, false);
-        if(cipher->pageSize() != 1024)
+        if(cipher->pageSize() != CipherSettings::defaultPageSize)
             executeSQL(QString("PRAGMA cipher_page_size = %1;").arg(cipher->pageSize()), false, false);
     }
 #endif
@@ -226,7 +227,7 @@ bool DBBrowserDB::attach(const QString& filePath, QString attach_as)
         QMessageBox::warning(nullptr, qApp->applicationName(), lastErrorMessage);
         return false;
     }
-    if(cipher && cipher->pageSize() != 1024)
+    if(cipher && cipher->pageSize() != CipherSettings::defaultPageSize)
     {
         if(!executeSQL(QString("PRAGMA %1.cipher_page_size = %2").arg(sqlb::escapeIdentifier(attach_as)).arg(cipher->pageSize()), false))
         {
@@ -296,7 +297,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                 sqlite3_exec(dbHandle, QString("PRAGMA key = %1").arg(cipherSettings->password()).toUtf8(), nullptr, nullptr, nullptr);
 
                 // Set the page size if it differs from the default value
-                if(cipherSettings->pageSize() != 1024)
+                if(cipherSettings->pageSize() != CipherSettings::defaultPageSize)
                     sqlite3_exec(dbHandle, QString("PRAGMA cipher_page_size = %1;").arg(cipherSettings->pageSize()).toUtf8(), nullptr, nullptr, nullptr);
 
                 *encrypted = true;

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -301,11 +301,11 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
 
                 QVariant passwordValue = dotenv.value(databaseFileName);
 
-                bool foundPassword = !passwordValue.isNull();
+                bool foundDotenvPassword = !passwordValue.isNull();
 
                 isDotenvChecked = true;
 
-                if (foundPassword)
+                if (foundDotenvPassword)
                 {
                     QString password = passwordValue.toString();
 
@@ -340,7 +340,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
 
                     *encrypted = true;
 
-                    // Skip the CipherDialog prompt for now to test if the saved password was correct
+                    // Skip the CipherDialog prompt for now to test if the dotenv password was correct
                     continue;
                 }
             }

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -287,6 +287,8 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
         {
             sqlite3_finalize(vm);
 #ifdef ENABLE_SQLCIPHER
+            bool foundDotenvPassword = false;
+
             // Being in a while loop, we don't want to check the same file multiple times
             if (!isDotenvChecked) {
                 QFile databaseFile(filePath);
@@ -301,7 +303,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
 
                 QVariant passwordValue = dotenv.value(databaseFileName);
 
-                bool foundDotenvPassword = !passwordValue.isNull();
+                foundDotenvPassword = !passwordValue.isNull();
 
                 isDotenvChecked = true;
 
@@ -322,59 +324,44 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                     cipherSettings->setPassword(password);
                     cipherSettings->setPageSize(pageSize);
 
-                    // Close and reopen database first to be in a clean state after the failed read attempt from above
-                    sqlite3_close(dbHandle);
-                    if(sqlite3_open_v2(filePath.toUtf8(), &dbHandle, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK)
-                    {
-	                    delete cipherSettings;
-	                    cipherSettings = nullptr;
-                        return false;
-                    }
-
-                    // Set the key
-                    sqlite3_exec(dbHandle, QString("PRAGMA key = %1").arg(cipherSettings->getPassword()).toUtf8(), nullptr, nullptr, nullptr);
-
-                    // Set the page size if it differs from the default value
-                    if(cipherSettings->getPageSize() != CipherSettings::defaultPageSize)
-                        sqlite3_exec(dbHandle, QString("PRAGMA cipher_page_size = %1;").arg(cipherSettings->getPageSize()).toUtf8(), nullptr, nullptr, nullptr);
-
-                    *encrypted = true;
-
-                    // Skip the CipherDialog prompt for now to test if the dotenv password was correct
-                    continue;
                 }
             }
 
-            CipherDialog *cipherDialog = new CipherDialog(nullptr, false);
-            if(cipherDialog->exec())
+            if(foundDotenvPassword)
             {
-                delete cipherSettings;
-                cipherSettings = new CipherSettings(cipherDialog->getCipherSettings());
-
-                // Close and reopen database first to be in a clean state after the failed read attempt from above
-                sqlite3_close(dbHandle);
-                if(sqlite3_open_v2(filePath.toUtf8(), &dbHandle, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK)
-                {
-                    delete cipherSettings;
-                    cipherSettings = nullptr;
-                    return false;
-                }
-
-                // Set the key
-                sqlite3_exec(dbHandle, QString("PRAGMA key = %1").arg(cipherSettings->getPassword()).toUtf8(), nullptr, nullptr, nullptr);
-
-                // Set the page size if it differs from the default value
-                if(cipherSettings->getPageSize() != CipherSettings::defaultPageSize)
-                    sqlite3_exec(dbHandle, QString("PRAGMA cipher_page_size = %1;").arg(cipherSettings->getPageSize()).toUtf8(), nullptr, nullptr, nullptr);
-
-                *encrypted = true;
+                // Skip the CipherDialog prompt for now to test if the dotenv password was correct
             } else {
-                sqlite3_close(dbHandle);
-                *encrypted = false;
+	            CipherDialog *cipherDialog = new CipherDialog(nullptr, false);
+	            if(cipherDialog->exec())
+	            {
+	                delete cipherSettings;
+	                cipherSettings = new CipherSettings(cipherDialog->getCipherSettings());
+	            } else {
+	                sqlite3_close(dbHandle);
+	                *encrypted = false;
+	                delete cipherSettings;
+	                cipherSettings = nullptr;
+	                return false;
+	            }
+	        }
+
+            // Close and reopen database first to be in a clean state after the failed read attempt from above
+            sqlite3_close(dbHandle);
+            if(sqlite3_open_v2(filePath.toUtf8(), &dbHandle, SQLITE_OPEN_READONLY, nullptr) != SQLITE_OK)
+            {
                 delete cipherSettings;
                 cipherSettings = nullptr;
                 return false;
             }
+
+            // Set the key
+            sqlite3_exec(dbHandle, QString("PRAGMA key = %1").arg(cipherSettings->getPassword()).toUtf8(), nullptr, nullptr, nullptr);
+
+            // Set the page size if it differs from the default value
+            if(cipherSettings->getPageSize() != CipherSettings::defaultPageSize)
+                sqlite3_exec(dbHandle, QString("PRAGMA cipher_page_size = %1;").arg(cipherSettings->getPageSize()).toUtf8(), nullptr, nullptr, nullptr);
+
+            *encrypted = true;
 #else
             lastErrorMessage = QString::fromUtf8((const char*)sqlite3_errmsg(dbHandle));
             sqlite3_close(dbHandle);

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -235,6 +235,7 @@ bool DBBrowserDB::attach(const QString& filePath, QString attach_as)
             return false;
         }
     }
+    delete cipher;
 #else
     // Attach database
     if(!executeSQL(QString("ATTACH '%1' AS %2").arg(filePath).arg(sqlb::escapeIdentifier(attach_as)), false))

--- a/src/sqlitedb.h
+++ b/src/sqlitedb.h
@@ -13,6 +13,7 @@
 
 struct sqlite3;
 class CipherDialog;
+class CipherSettings;
 
 enum
 {
@@ -205,7 +206,7 @@ private:
 
     void collationNeeded(void* pData, sqlite3* db, int eTextRep, const char* sCollationName);
 
-    bool tryEncryptionSettings(const QString& filename, bool* encrypted, CipherDialog*& cipherSettings);
+    bool tryEncryptionSettings(const QString& filename, bool* encrypted, CipherSettings*& cipherSettings);
 
     bool dontCheckForStructureUpdates;
 

--- a/src/sqlitedb.h
+++ b/src/sqlitedb.h
@@ -12,7 +12,6 @@
 #include <QByteArray>
 
 struct sqlite3;
-class CipherDialog;
 class CipherSettings;
 
 enum

--- a/src/src.pro
+++ b/src/src.pro
@@ -66,7 +66,8 @@ HEADERS += \
     ExtendedScintilla.h \
     FileExtensionManager.h \
     Data.h \
-    CipherSettings.h
+    CipherSettings.h \
+    DotenvFormat.h
 
 SOURCES += \
     sqlitedb.cpp \
@@ -109,7 +110,8 @@ SOURCES += \
     ExtendedScintilla.cpp \
     FileExtensionManager.cpp \
     Data.cpp \
-    CipherSettings.cpp
+    CipherSettings.cpp \
+    DotenvFormat.cpp
 
 RESOURCES += icons/icons.qrc \
              translations/flags/flags.qrc \

--- a/src/src.pro
+++ b/src/src.pro
@@ -65,7 +65,8 @@ HEADERS += \
     FindReplaceDialog.h \
     ExtendedScintilla.h \
     FileExtensionManager.h \
-    Data.h
+    Data.h \
+    CipherSettings.h
 
 SOURCES += \
     sqlitedb.cpp \
@@ -107,7 +108,8 @@ SOURCES += \
     FindReplaceDialog.cpp \
     ExtendedScintilla.cpp \
     FileExtensionManager.cpp \
-    Data.cpp
+    Data.cpp \
+    CipherSettings.cpp
 
 RESOURCES += icons/icons.qrc \
              translations/flags/flags.qrc \

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -17,6 +17,8 @@ set(TESTSQLOBJECTS_SRC
     ../Settings.cpp
     testsqlobjects.cpp
     ../Data.cpp
+    ../CipherSettings.cpp
+    ../DotenvFormat.cpp
 )
 
 set(TESTSQLOBJECTS_HDR
@@ -32,6 +34,8 @@ set(TESTSQLOBJECTS_MOC_HDR
     ../sqlitetablemodel.h
     ../Settings.h
     testsqlobjects.h
+    ../CipherSettings.h
+    ../DotenvFormat.h
 )
 
 if(sqlcipher)
@@ -92,6 +96,8 @@ set(TESTREGEX_SRC
     ../Settings.cpp
     TestRegex.cpp
     ../Data.cpp
+    ../CipherSettings.cpp
+    ../DotenvFormat.cpp
 )
 
 set(TESTREGEX_HDR
@@ -107,6 +113,8 @@ set(TESTREGEX_MOC_HDR
     ../sqlitetablemodel.h
     ../Settings.h
     TestRegex.h
+    ../CipherSettings.h
+    ../DotenvFormat.h
 )
 
 if(sqlcipher)


### PR DESCRIPTION
This adds support for `.env` files next to the crypted databases that
are to be opened that contains the needed cipher settings.

The only required one is the plain-text password as a value for the key
with the name of the database like this:

    myCryptedDatabase.sqlite = MyPassword

This way, databases with a different extension are supported too:

    myCryptedDatabase.db = MyPassword

You can also specify a custom page size adding a different line
(anywhere in the file) like this:

    myCryptedDatabase.db_pageSize = 2048

If not specified, `1024` is used.

You can also specify the format of the specified key using the
associated integer id:

    anotherCryptedDatabase.sqlite = 0xCAFEBABE
    anotherCryptedDatabase.sqlite_keyFormat = 1

where `1` means a Raw key. If not specified, `0` is used, which means a
simple text Passphrase.

Dotenv files (`.env`) are already used on other platforms and by
different tools to manage environment variables, and it's recommended
to be ignored from version control systems, so they won't leak.

Related to #625.