### PR TITLE
Preference for quoting identifier mechanism

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1990,6 +1990,8 @@ void MainWindow::reloadSettings()
 
     // Reload remote dock settings
     remoteDock->reloadSettings();
+
+    sqlb::setIdentifierQuoting(static_cast<sqlb::escapeQuoting>(Settings::getValue("editor", "identifier_quotes").toInt()));
 }
 
 void MainWindow::checkNewVersion(const QString& versionstring, const QString& url)

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -168,6 +168,7 @@ void PreferencesDialog::loadSettings()
     ui->spinTabSize->setValue(Settings::getValue("editor", "tabsize").toInt());
     ui->spinLogFontSize->setValue(Settings::getValue("log", "fontsize").toInt());
     ui->wrapComboBox->setCurrentIndex(Settings::getValue("editor", "wrap_lines").toInt());
+    ui->quoteComboBox->setCurrentIndex(Settings::getValue("editor", "identifier_quotes").toInt());
     ui->checkAutoCompletion->setChecked(Settings::getValue("editor", "auto_completion").toBool());
     ui->checkCompleteUpper->setEnabled(Settings::getValue("editor", "auto_completion").toBool());
     ui->checkCompleteUpper->setChecked(Settings::getValue("editor", "upper_keywords").toBool());
@@ -223,6 +224,7 @@ void PreferencesDialog::saveSettings()
     Settings::setValue("editor", "tabsize", ui->spinTabSize->value());
     Settings::setValue("log", "fontsize", ui->spinLogFontSize->value());
     Settings::setValue("editor", "wrap_lines", ui->wrapComboBox->currentIndex());
+    Settings::setValue("editor", "identifier_quotes", ui->quoteComboBox->currentIndex());
     Settings::setValue("editor", "auto_completion", ui->checkAutoCompletion->isChecked());
     Settings::setValue("editor", "upper_keywords", ui->checkCompleteUpper->isChecked());
     Settings::setValue("editor", "error_indicators", ui->checkErrorIndicators->isChecked());

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -128,7 +128,7 @@
           <string>Toolbar style</string>
          </property>
          <property name="buddy">
-          <cstring>languageComboBox</cstring>
+          <cstring>toolbarStyleComboBox</cstring>
          </property>
         </widget>
        </item>
@@ -187,6 +187,9 @@
          <property name="text">
           <string>Show remote options</string>
          </property>
+         <property name="buddy">
+          <cstring>checkUseRemotes</cstring>
+         </property>
         </widget>
        </item>
        <item row="3" column="1">
@@ -220,6 +223,9 @@
         <widget class="QLabel" name="label_16">
          <property name="text">
           <string>DB file extensions</string>
+         </property>
+         <property name="buddy">
+          <cstring>buttonManageFileExtension</cstring>
          </property>
         </widget>
        </item>
@@ -381,6 +387,9 @@
         <widget class="QLabel" name="defaultFieldTypeLabel">
          <property name="text">
           <string>Default field type</string>
+         </property>
+         <property name="buddy">
+          <cstring>defaultFieldTypeComboBox</cstring>
          </property>
         </widget>
        </item>
@@ -931,20 +940,23 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QFontComboBox" name="comboEditorFont"/>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_6">
-           <property name="text">
-            <string>SQL &amp;editor font size</string>
-           </property>
-           <property name="buddy">
-            <cstring>spinEditorFontSize</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QFontComboBox" name="comboEditorFont"/>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_6">
+             <property name="text">
+              <string>SQL &amp;editor font size</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+             </property>
+             <property name="buddy">
+              <cstring>spinEditorFontSize</cstring>
+             </property>
+            </widget>
+           </item>
            <item>
             <widget class="QSpinBox" name="spinEditorFontSize">
              <property name="minimum">
@@ -952,40 +964,24 @@
              </property>
             </widget>
            </item>
-           <item>
-            <spacer name="horizontalSpacer">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeType">
-              <enum>QSizePolicy::Minimum</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
-            <widget class="QLabel" name="label_7">
-             <property name="text">
-              <string>SQL &amp;results font size</string>
-             </property>
-             <property name="buddy">
-              <cstring>spinLogFontSize</cstring>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QSpinBox" name="spinLogFontSize">
-             <property name="minimum">
-              <number>1</number>
-             </property>
-            </widget>
-           </item>
           </layout>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>SQL &amp;results font size</string>
+           </property>
+           <property name="buddy">
+            <cstring>spinLogFontSize</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QSpinBox" name="spinLogFontSize">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+          </widget>
          </item>
          <item row="2" column="0">
           <widget class="QLabel" name="label_13">
@@ -1013,7 +1009,7 @@
          <item row="3" column="0">
           <widget class="QLabel" name="wrapLabel">
            <property name="text">
-            <string>Wrap lines</string>
+            <string>&amp;Wrap lines</string>
            </property>
            <property name="buddy">
             <cstring>wrapComboBox</cstring>
@@ -1042,6 +1038,16 @@
              <string>At whitespace boundaries</string>
             </property>
            </item>
+          </widget>
+         </item>
+         <item row="4" column="0">
+          <widget class="QLabel" name="label_25">
+           <property name="text">
+            <string>&amp;Quotes for identifiers</string>
+           </property>
+           <property name="buddy">
+            <cstring>quoteComboBox</cstring>
+           </property>
           </widget>
          </item>
          <item row="4" column="1">
@@ -1143,16 +1149,6 @@
            </property>
            <property name="text">
             <string>enabled</string>
-           </property>
-          </widget>
-         </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="label_25">
-           <property name="text">
-            <string>Quotes for identifiers</string>
-           </property>
-           <property name="buddy">
-            <cstring>quoteComboBox</cstring>
            </property>
           </widget>
          </item>

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -944,30 +944,50 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QSpinBox" name="spinEditorFontSize">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-          </widget>
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QSpinBox" name="spinEditorFontSize">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeType">
+              <enum>QSizePolicy::Minimum</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_7">
+             <property name="text">
+              <string>SQL &amp;results font size</string>
+             </property>
+             <property name="buddy">
+              <cstring>spinLogFontSize</cstring>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QSpinBox" name="spinLogFontSize">
+             <property name="minimum">
+              <number>1</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item row="2" column="0">
-          <widget class="QLabel" name="label_7">
-           <property name="text">
-            <string>SQL &amp;results font size</string>
-           </property>
-           <property name="buddy">
-            <cstring>spinLogFontSize</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QSpinBox" name="spinLogFontSize">
-           <property name="minimum">
-            <number>1</number>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="0">
           <widget class="QLabel" name="label_13">
            <property name="text">
             <string>Tab size</string>
@@ -977,7 +997,7 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="1">
+         <item row="2" column="1">
           <widget class="QSpinBox" name="spinTabSize">
            <property name="minimum">
             <number>1</number>
@@ -990,7 +1010,7 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="0">
+         <item row="3" column="0">
           <widget class="QLabel" name="wrapLabel">
            <property name="text">
             <string>Wrap lines</string>
@@ -1000,7 +1020,7 @@
            </property>
           </widget>
          </item>
-         <item row="4" column="1">
+         <item row="3" column="1">
           <widget class="QComboBox" name="wrapComboBox">
            <item>
             <property name="text">
@@ -1024,7 +1044,7 @@
            </item>
           </widget>
          </item>
-         <item row="5" column="1">
+         <item row="4" column="1">
           <widget class="QComboBox" name="quoteComboBox">
            <property name="toolTip">
             <string>Choose the quoting mechanism used by the application for identifiers in SQL code.</string>
@@ -1049,7 +1069,7 @@
            </item>
           </widget>
          </item>
-         <item row="6" column="0">
+         <item row="5" column="0">
           <widget class="QLabel" name="label_20">
            <property name="text">
             <string>Code co&amp;mpletion</string>
@@ -1059,14 +1079,14 @@
            </property>
           </widget>
          </item>
-         <item row="6" column="1">
+         <item row="5" column="1">
           <widget class="QCheckBox" name="checkAutoCompletion">
            <property name="text">
             <string>enabled</string>
            </property>
           </widget>
          </item>
-         <item row="7" column="0">
+         <item row="6" column="0">
           <widget class="QLabel" name="label_24">
            <property name="text">
             <string>Keywords in &amp;UPPER CASE</string>
@@ -1076,7 +1096,7 @@
            </property>
           </widget>
          </item>
-         <item row="7" column="1">
+         <item row="6" column="1">
           <widget class="QCheckBox" name="checkCompleteUpper">
            <property name="toolTip">
             <string>When set, the SQL keywords are completed in UPPER CASE letters.</string>
@@ -1086,7 +1106,7 @@
            </property>
           </widget>
          </item>
-         <item row="8" column="0">
+         <item row="7" column="0">
           <widget class="QLabel" name="label_15">
            <property name="text">
             <string>Error indicators</string>
@@ -1096,7 +1116,7 @@
            </property>
           </widget>
          </item>
-         <item row="8" column="1">
+         <item row="7" column="1">
           <widget class="QCheckBox" name="checkErrorIndicators">
            <property name="toolTip">
             <string>When set, the SQL code lines that caused errors during the last execution are highlighted and the results frame indicates the error in the background</string>
@@ -1106,7 +1126,7 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="0">
+         <item row="8" column="0">
           <widget class="QLabel" name="label_10">
            <property name="text">
             <string>Hori&amp;zontal tiling</string>
@@ -1116,7 +1136,7 @@
            </property>
           </widget>
          </item>
-         <item row="9" column="1">
+         <item row="8" column="1">
           <widget class="QCheckBox" name="checkHorizontalTiling">
            <property name="toolTip">
             <string>If enabled the SQL code editor and the result table view are shown side by side instead of one over the other.</string>
@@ -1126,7 +1146,7 @@
            </property>
           </widget>
          </item>
-         <item row="5" column="0">
+         <item row="4" column="0">
           <widget class="QLabel" name="label_25">
            <property name="text">
             <string>Quotes for identifiers</string>

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -920,6 +920,19 @@
        </item>
        <item>
         <layout class="QFormLayout" name="formLayout_2">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_14">
+           <property name="text">
+            <string>SQL editor &amp;font</string>
+           </property>
+           <property name="buddy">
+            <cstring>comboEditorFont</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QFontComboBox" name="comboEditorFont"/>
+         </item>
          <item row="1" column="0">
           <widget class="QLabel" name="label_6">
            <property name="text">
@@ -977,93 +990,13 @@
            </property>
           </widget>
          </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_14">
+         <item row="4" column="0">
+          <widget class="QLabel" name="wrapLabel">
            <property name="text">
-            <string>SQL editor &amp;font</string>
+            <string>Wrap lines</string>
            </property>
            <property name="buddy">
-            <cstring>comboEditorFont</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QFontComboBox" name="comboEditorFont"/>
-         </item>
-          <item row="5" column="0">
-          <widget class="QLabel" name="label_20">
-           <property name="text">
-            <string>Code co&amp;mpletion</string>
-           </property>
-           <property name="buddy">
-            <cstring>checkAutoCompletion</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="5" column="1">
-          <widget class="QCheckBox" name="checkAutoCompletion">
-           <property name="text">
-            <string>enabled</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0">
-          <widget class="QLabel" name="label_24">
-           <property name="text">
-            <string>Keywords in &amp;UPPER CASE</string>
-           </property>
-           <property name="buddy">
-            <cstring>checkCompleteUpper</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="1">
-          <widget class="QCheckBox" name="checkCompleteUpper">
-           <property name="toolTip">
-            <string>When set, the SQL keywords are completed in UPPER CASE letters.</string>
-           </property>
-           <property name="text">
-            <string>enabled</string>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="0">
-          <widget class="QLabel" name="label_15">
-           <property name="text">
-            <string>Error indicators</string>
-           </property>
-           <property name="buddy">
-            <cstring>checkErrorIndicators</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="7" column="1">
-          <widget class="QCheckBox" name="checkErrorIndicators">
-           <property name="toolTip">
-            <string>When set, the SQL code lines that caused errors during the last execution are highlighted and the results frame indicates the error in the background</string>
-           </property>
-           <property name="text">
-            <string>enabled</string>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="0">
-          <widget class="QLabel" name="label_10">
-           <property name="text">
-            <string>Hori&amp;zontal tiling</string>
-           </property>
-           <property name="buddy">
-            <cstring>checkHorizontalTiling</cstring>
-           </property>
-          </widget>
-         </item>
-         <item row="8" column="1">
-          <widget class="QCheckBox" name="checkHorizontalTiling">
-           <property name="toolTip">
-            <string>If enabled the SQL code editor and the result table view are shown side by side instead of one over the other.</string>
-           </property>
-           <property name="text">
-            <string>enabled</string>
+            <cstring>wrapComboBox</cstring>
            </property>
           </widget>
          </item>
@@ -1091,13 +1024,115 @@
            </item>
           </widget>
          </item>
-         <item row="4" column="0">
-          <widget class="QLabel" name="wrapLabel">
+         <item row="5" column="1">
+          <widget class="QComboBox" name="quoteComboBox">
+           <property name="toolTip">
+            <string>Choose the quoting mechanism used by the application for identifiers in SQL code.</string>
+           </property>
+           <property name="whatsThis">
+            <string/>
+           </property>
+           <item>
+            <property name="text">
+             <string>&quot;Double quotes&quot;</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>`Grave accents`</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>[Square brackets]</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_20">
            <property name="text">
-            <string>Wrap lines</string>
+            <string>Code co&amp;mpletion</string>
            </property>
            <property name="buddy">
-            <cstring>wrapComboBox</cstring>
+            <cstring>checkAutoCompletion</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="6" column="1">
+          <widget class="QCheckBox" name="checkAutoCompletion">
+           <property name="text">
+            <string>enabled</string>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="label_24">
+           <property name="text">
+            <string>Keywords in &amp;UPPER CASE</string>
+           </property>
+           <property name="buddy">
+            <cstring>checkCompleteUpper</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QCheckBox" name="checkCompleteUpper">
+           <property name="toolTip">
+            <string>When set, the SQL keywords are completed in UPPER CASE letters.</string>
+           </property>
+           <property name="text">
+            <string>enabled</string>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="0">
+          <widget class="QLabel" name="label_15">
+           <property name="text">
+            <string>Error indicators</string>
+           </property>
+           <property name="buddy">
+            <cstring>checkErrorIndicators</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="8" column="1">
+          <widget class="QCheckBox" name="checkErrorIndicators">
+           <property name="toolTip">
+            <string>When set, the SQL code lines that caused errors during the last execution are highlighted and the results frame indicates the error in the background</string>
+           </property>
+           <property name="text">
+            <string>enabled</string>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="0">
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>Hori&amp;zontal tiling</string>
+           </property>
+           <property name="buddy">
+            <cstring>checkHorizontalTiling</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="9" column="1">
+          <widget class="QCheckBox" name="checkHorizontalTiling">
+           <property name="toolTip">
+            <string>If enabled the SQL code editor and the result table view are shown side by side instead of one over the other.</string>
+           </property>
+           <property name="text">
+            <string>enabled</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0">
+          <widget class="QLabel" name="label_25">
+           <property name="text">
+            <string>Quotes for identifiers</string>
+           </property>
+           <property name="buddy">
+            <cstring>quoteComboBox</cstring>
            </property>
           </widget>
          </item>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -296,7 +296,7 @@ QVariant Settings::getDefaultValue(const QString& group, const QString& name)
 
     // editor/identifier_quotes
     if(group == "editor" && name == "identifier_quotes")
-        return 0; // sqlb::DoubleQuotes
+        return 1; // sqlb::GraveAccents
 
     // editor/auto_completion?
     if(group == "editor" && name == "auto_completion")

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -294,6 +294,10 @@ QVariant Settings::getDefaultValue(const QString& group, const QString& name)
     if(group == "editor" && name == "wrap_lines")
         return 0; // QsciScintilla::WrapNone
 
+    // editor/identifier_quotes
+    if(group == "editor" && name == "identifier_quotes")
+        return 0; // sqlb::DoubleQuotes
+
     // editor/auto_completion?
     if(group == "editor" && name == "auto_completion")
         return true;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -296,7 +296,7 @@ QVariant Settings::getDefaultValue(const QString& group, const QString& name)
 
     // editor/identifier_quotes
     if(group == "editor" && name == "identifier_quotes")
-        return 1; // sqlb::GraveAccents
+        return 0; // sqlb::DoubleQuotes
 
     // editor/auto_completion?
     if(group == "editor" && name == "auto_completion")

--- a/src/sqlitetypes.cpp
+++ b/src/sqlitetypes.cpp
@@ -11,7 +11,7 @@ namespace sqlb {
 
 QStringList Field::Datatypes = QStringList() << "INTEGER" << "TEXT" << "BLOB" << "REAL" << "NUMERIC";
 
-escapeQuoting customQuoting = DoubleQuotes;
+escapeQuoting customQuoting = GraveAccents;
 
 void setIdentifierQuoting(escapeQuoting toQuoting)
 {

--- a/src/sqlitetypes.cpp
+++ b/src/sqlitetypes.cpp
@@ -11,7 +11,7 @@ namespace sqlb {
 
 QStringList Field::Datatypes = QStringList() << "INTEGER" << "TEXT" << "BLOB" << "REAL" << "NUMERIC";
 
-escapeQuoting customQuoting = GraveAccents;
+static escapeQuoting customQuoting = DoubleQuotes;
 
 void setIdentifierQuoting(escapeQuoting toQuoting)
 {
@@ -21,8 +21,6 @@ void setIdentifierQuoting(escapeQuoting toQuoting)
 QString escapeIdentifier(QString id)
 {
     switch(customQuoting) {
-    case DoubleQuotes:
-        return '"' + id.replace('"', "\"\"") + '"';
     case GraveAccents:
         return '`' + id.replace('`', "``") + '`';
     case SquareBrackets:
@@ -30,6 +28,12 @@ QString escapeIdentifier(QString id)
         // so we rely on the user to not enter these characters when this kind of quoting is
         // selected.
         return '[' + id + ']';
+    case DoubleQuotes:
+    default:
+        // This may produce a 'control reaches end of non-void function' warning if the
+        // default branch is removed, even though we have covered all possibilities in the
+        // switch statement.
+        return '"' + id.replace('"', "\"\"") + '"';
     }
 }
 

--- a/src/sqlitetypes.cpp
+++ b/src/sqlitetypes.cpp
@@ -11,9 +11,26 @@ namespace sqlb {
 
 QStringList Field::Datatypes = QStringList() << "INTEGER" << "TEXT" << "BLOB" << "REAL" << "NUMERIC";
 
+escapeQuoting customQuoting = DoubleQuotes;
+
+void setIdentifierQuoting(escapeQuoting toQuoting)
+{
+    customQuoting = toQuoting;
+}
+
 QString escapeIdentifier(QString id)
 {
-    return '`' + id.replace('`', "``") + '`';
+    switch(customQuoting) {
+    case DoubleQuotes:
+        return '"' + id.replace('"', "\"\"") + '"';
+    case GraveAccents:
+        return '`' + id.replace('`', "``") + '`';
+    case SquareBrackets:
+        // There aren't any escaping possibilities for square brackets inside the identifier,
+        // so we rely on the user to not enter these characters when this kind of quoting is
+        // selected.
+        return '[' + id + ']';
+    }
 }
 
 QStringList fieldVectorToFieldNames(const FieldVector& vector)

--- a/src/sqlitetypes.h
+++ b/src/sqlitetypes.h
@@ -38,6 +38,15 @@ uint qHash(const QVector<T>& key, uint seed = 0)
 }
 #endif
 
+enum escapeQuoting {
+    DoubleQuotes,
+    GraveAccents,
+    SquareBrackets
+};
+
+// Set quoting style for escapeIdentifier
+void setIdentifierQuoting(escapeQuoting toQuoting);
+
 QString escapeIdentifier(QString id);
 
 class ObjectIdentifier

--- a/src/sqltextedit.cpp
+++ b/src/sqltextedit.cpp
@@ -56,8 +56,11 @@ void SqlTextEdit::reloadSettings()
     switch(static_cast<sqlb::escapeQuoting>(Settings::getValue("editor", "identifier_quotes").toInt())) {
     case sqlb::DoubleQuotes:
         setupSyntaxHighlightingFormat(sqlLexer, "identifier", QsciLexerSQL::DoubleQuotedString);
+        sqlLexer->setQuotedIdentifiers(false);
         break;
     case sqlb::GraveAccents:
+        sqlLexer->setQuotedIdentifiers(true);
+        // Fall through, treat quoted string as literal string
     case sqlb::SquareBrackets:
         setupSyntaxHighlightingFormat(sqlLexer, "string", QsciLexerSQL::DoubleQuotedString);
         break;

--- a/src/sqltextedit.cpp
+++ b/src/sqltextedit.cpp
@@ -1,3 +1,4 @@
+#include "sqlitetypes.h"
 #include "sqltextedit.h"
 #include "Settings.h"
 #include "SqlUiLexer.h"
@@ -49,8 +50,18 @@ void SqlTextEdit::reloadSettings()
     setupSyntaxHighlightingFormat(sqlLexer, "keyword", QsciLexerSQL::Keyword);
     setupSyntaxHighlightingFormat(sqlLexer, "table", QsciLexerSQL::KeywordSet6);
     setupSyntaxHighlightingFormat(sqlLexer, "function", QsciLexerSQL::KeywordSet7);
-    setupSyntaxHighlightingFormat(sqlLexer, "string", QsciLexerSQL::DoubleQuotedString);
     setupSyntaxHighlightingFormat(sqlLexer, "string", QsciLexerSQL::SingleQuotedString);
+
+    // Highlight double quote strings as identifier or as literal string depending on user preference
+    switch(static_cast<sqlb::escapeQuoting>(Settings::getValue("editor", "identifier_quotes").toInt())) {
+    case sqlb::DoubleQuotes:
+        setupSyntaxHighlightingFormat(sqlLexer, "identifier", QsciLexerSQL::DoubleQuotedString);
+        break;
+    case sqlb::GraveAccents:
+    case sqlb::SquareBrackets:
+        setupSyntaxHighlightingFormat(sqlLexer, "string", QsciLexerSQL::DoubleQuotedString);
+        break;
+    }
     setupSyntaxHighlightingFormat(sqlLexer, "identifier", QsciLexerSQL::Identifier);
     setupSyntaxHighlightingFormat(sqlLexer, "identifier", QsciLexerSQL::QuotedIdentifier);
 }

--- a/src/tests/testsqlobjects.cpp
+++ b/src/tests/testsqlobjects.cpp
@@ -17,12 +17,55 @@ void TestTable::sqlOutput()
     tt.addField(fkm);
     tt.addConstraint({f, fkm}, ConstraintPtr(new PrimaryKeyConstraint()));
 
+    QCOMPARE(tt.sql(), QString("CREATE TABLE \"testtable\" (\n"
+                               "\t\"id\"\tinteger,\n"
+                               "\t\"car\"\ttext,\n"
+                               "\t\"km\"\tinteger CHECK(km > 1000),\n"
+                               "\tPRIMARY KEY(\"id\",\"km\")\n"
+                               ");"));
+}
+
+void TestTable::sqlGraveAccentOutput()
+{
+    Table tt("testtable");
+    FieldPtr f = FieldPtr(new Field("id", "integer"));
+    FieldPtr fkm = FieldPtr(new Field("km", "integer", false, "", "km > 1000"));
+    tt.addField(f);
+    tt.addField(FieldPtr(new Field("car", "text")));
+    tt.addField(fkm);
+    tt.addConstraint({f, fkm}, ConstraintPtr(new PrimaryKeyConstraint()));
+    sqlb::setIdentifierQuoting(sqlb::GraveAccents);
+
     QCOMPARE(tt.sql(), QString("CREATE TABLE `testtable` (\n"
                                "\t`id`\tinteger,\n"
                                "\t`car`\ttext,\n"
                                "\t`km`\tinteger CHECK(km > 1000),\n"
                                "\tPRIMARY KEY(`id`,`km`)\n"
                                ");"));
+
+    sqlb::setIdentifierQuoting(sqlb::DoubleQuotes);
+}
+
+
+void TestTable::sqlSquareBracketsOutput()
+{
+    Table tt("testtable");
+    FieldPtr f = FieldPtr(new Field("id", "integer"));
+    FieldPtr fkm = FieldPtr(new Field("km", "integer", false, "", "km > 1000"));
+    tt.addField(f);
+    tt.addField(FieldPtr(new Field("car", "text")));
+    tt.addField(fkm);
+    tt.addConstraint({f, fkm}, ConstraintPtr(new PrimaryKeyConstraint()));
+    sqlb::setIdentifierQuoting(sqlb::SquareBrackets);
+
+    QCOMPARE(tt.sql(), QString("CREATE TABLE [testtable] (\n"
+                               "\t[id]\tinteger,\n"
+                               "\t[car]\ttext,\n"
+                               "\t[km]\tinteger CHECK(km > 1000),\n"
+                               "\tPRIMARY KEY([id],[km])\n"
+                               ");"));
+
+    sqlb::setIdentifierQuoting(sqlb::DoubleQuotes);
 }
 
 void TestTable::autoincrement()
@@ -36,10 +79,10 @@ void TestTable::autoincrement()
     tt.addField(fkm);
     tt.addConstraint({f}, ConstraintPtr(new PrimaryKeyConstraint()));
 
-    QCOMPARE(tt.sql(), QString("CREATE TABLE `testtable` (\n"
-                               "\t`id`\tinteger PRIMARY KEY AUTOINCREMENT,\n"
-                               "\t`car`\ttext,\n"
-                               "\t`km`\tinteger\n"
+    QCOMPARE(tt.sql(), QString("CREATE TABLE \"testtable\" (\n"
+                               "\t\"id\"\tinteger PRIMARY KEY AUTOINCREMENT,\n"
+                               "\t\"car\"\ttext,\n"
+                               "\t\"km\"\tinteger\n"
                                ");"));
 }
 
@@ -54,10 +97,10 @@ void TestTable::notnull()
     tt.addField(fkm);
     tt.addConstraint({f}, ConstraintPtr(new PrimaryKeyConstraint()));
 
-    QCOMPARE(tt.sql(), QString("CREATE TABLE `testtable` (\n"
-                               "\t`id`\tinteger PRIMARY KEY AUTOINCREMENT,\n"
-                               "\t`car`\ttext NOT NULL,\n"
-                               "\t`km`\tinteger\n"
+    QCOMPARE(tt.sql(), QString("CREATE TABLE \"testtable\" (\n"
+                               "\t\"id\"\tinteger PRIMARY KEY AUTOINCREMENT,\n"
+                               "\t\"car\"\ttext NOT NULL,\n"
+                               "\t\"km\"\tinteger\n"
                                ");"));
 }
 
@@ -71,9 +114,9 @@ void TestTable::withoutRowid()
     tt.setRowidColumn("a");
     tt.addConstraint({f}, ConstraintPtr(new PrimaryKeyConstraint()));
 
-    QCOMPARE(tt.sql(), QString("CREATE TABLE `testtable` (\n"
-                               "\t`a`\tinteger PRIMARY KEY AUTOINCREMENT,\n"
-                               "\t`b`\tinteger\n"
+    QCOMPARE(tt.sql(), QString("CREATE TABLE \"testtable\" (\n"
+                               "\t\"a\"\tinteger PRIMARY KEY AUTOINCREMENT,\n"
+                               "\t\"b\"\tinteger\n"
                                ") WITHOUT ROWID;"));
 }
 
@@ -84,9 +127,9 @@ void TestTable::foreignKeys()
     tt.addField(f);
     tt.addConstraint({f}, sqlb::ConstraintPtr(new sqlb::ForeignKeyClause("b", QStringList("c"))));
 
-    QCOMPARE(tt.sql(), QString("CREATE TABLE `testtable` (\n"
-                               "\t`a`\tinteger,\n"
-                               "\tFOREIGN KEY(`a`) REFERENCES `b`(`c`)\n"
+    QCOMPARE(tt.sql(), QString("CREATE TABLE \"testtable\" (\n"
+                               "\t\"a\"\tinteger,\n"
+                               "\tFOREIGN KEY(\"a\") REFERENCES \"b\"(\"c\")\n"
                                ");"));
 }
 
@@ -102,11 +145,11 @@ void TestTable::uniqueConstraint()
     tt.addField(f3);
     tt.addConstraint({f2, f3}, sqlb::ConstraintPtr(new sqlb::UniqueConstraint()));
 
-    QCOMPARE(tt.sql(), QString("CREATE TABLE `testtable` (\n"
-                               "\t`a`\tinteger UNIQUE,\n"
-                               "\t`b`\tinteger,\n"
-                               "\t`c`\tinteger,\n"
-                               "\tUNIQUE(`b`,`c`)\n"
+    QCOMPARE(tt.sql(), QString("CREATE TABLE \"testtable\" (\n"
+                               "\t\"a\"\tinteger UNIQUE,\n"
+                               "\t\"b\"\tinteger,\n"
+                               "\t\"c\"\tinteger,\n"
+                               "\tUNIQUE(\"b\",\"c\")\n"
                                ");"));
 }
 
@@ -177,7 +220,7 @@ void TestTable::parseSQLMultiPk()
             "\tid1 integer,\n"
             "\tid2 integer,\n"
             "\tnonpkfield blob,\n"
-            "PRIMARY KEY(`id1`,`id2`)\n"
+            "PRIMARY KEY(\"id1\",\"id2\")\n"
             ");";
 
     Table tab = *(Table::parseSQL(sSQL).dynamicCast<sqlb::Table>());
@@ -215,6 +258,18 @@ void TestTable::parseSQLSingleQuotes()
     QVERIFY(tab.fields().at(1)->name() == "test");
 }
 
+void TestTable::parseSQLSquareBrackets()
+{
+    QString sSQL = "CREATE TABLE [test]([id],[test]);";
+
+    Table tab = *(Table::parseSQL(sSQL).dynamicCast<sqlb::Table>());
+
+    QVERIFY(tab.name() == "test");
+    QVERIFY(tab.fields().at(0)->name() == "id");
+    QVERIFY(tab.fields().at(1)->name() == "test");
+}
+
+
 void TestTable::parseSQLKeywordInIdentifier()
 {
     QString sSQL = "CREATE TABLE deffered(key integer primary key, if text);";
@@ -224,6 +279,20 @@ void TestTable::parseSQLKeywordInIdentifier()
     QVERIFY(tab.name() == "deffered");
     QVERIFY(tab.fields().at(0)->name() == "key");
     QVERIFY(tab.fields().at(1)->name() == "if");
+}
+
+
+void TestTable::parseSQLSomeKeywordsInIdentifier()
+{
+    QString sSQL = "CREATE TABLE \"Average Number of Volunteers by Area of Work\" ("
+      "`Area of Work`	TEXT,"
+      "`Average Number of Volunteers`	INTEGER);";
+
+    Table tab = *(Table::parseSQL(sSQL).dynamicCast<sqlb::Table>());
+
+    QVERIFY(tab.name() == "Average Number of Volunteers by Area of Work");
+    QVERIFY(tab.fields().at(0)->name() == "Area of Work");
+    QVERIFY(tab.fields().at(1)->name() == "Average Number of Volunteers");
 }
 
 void TestTable::parseSQLWithoutRowid()
@@ -249,6 +318,19 @@ void TestTable::parseNonASCIIChars()
     QVERIFY(tab.fields().at(0)->name() == "Fieldöäüß");
 }
 
+void TestTable::parseNonASCIICharsEs()
+{
+    QString sSQL = "CREATE TABLE \"Cigüeñas de Alcalá\" ("
+            "\"Field áéíóúÁÉÍÓÚñÑçÇ\"	INTEGER,"
+            "PRIMARY KEY(\"Field áéíóúÁÉÍÓÚñÑçÇ\")"
+            ");";
+
+    Table tab = *(Table::parseSQL(sSQL).dynamicCast<sqlb::Table>());
+
+    QVERIFY(tab.name() == "Cigüeñas de Alcalá");
+    QVERIFY(tab.fields().at(0)->name() == "Field áéíóúÁÉÍÓÚñÑçÇ");
+}
+
 void TestTable::parseSQLEscapedQuotes()
 {
     QString sSql = "CREATE TABLE double_quotes(a text default 'a''a');";
@@ -272,19 +354,19 @@ void TestTable::parseSQLForeignKeys()
     QCOMPARE(tab.constraint({tab.fields().at(0)}, sqlb::Constraint::ForeignKeyConstraintType).dynamicCast<sqlb::ForeignKeyClause>()->table(), QString("x"));
     QCOMPARE(tab.fields().at(1)->name(), QString("b"));
     QCOMPARE(tab.fields().at(1)->type(), QString("int"));
-    QCOMPARE(tab.constraint({tab.fields().at(1)}, sqlb::Constraint::ForeignKeyConstraintType).dynamicCast<sqlb::ForeignKeyClause>()->toString(), QString("`w`(`y`,`z`) on delete set null"));
+    QCOMPARE(tab.constraint({tab.fields().at(1)}, sqlb::Constraint::ForeignKeyConstraintType).dynamicCast<sqlb::ForeignKeyClause>()->toString(), QString("\"w\"(\"y\",\"z\") on delete set null"));
 }
 
 void TestTable::parseSQLCheckConstraint()
 {
-    QString sql = "CREATE TABLE a (`b` text CHECK(`b`='A' or `b`='B'));";
+    QString sql = "CREATE TABLE a (\"b\" text CHECK(\"b\"='A' or \"b\"='B'));";
 
     Table tab = *(Table::parseSQL(sql).dynamicCast<sqlb::Table>());
 
     QCOMPARE(tab.name(), QString("a"));
     QCOMPARE(tab.fields().at(0)->name(), QString("b"));
     QCOMPARE(tab.fields().at(0)->type(), QString("text"));
-    QCOMPARE(tab.fields().at(0)->check(), QString("`b` = 'A' or `b` = 'B'"));
+    QCOMPARE(tab.fields().at(0)->check(), QString("\"b\" = 'A' or \"b\" = 'B'"));
 }
 
 void TestTable::parseDefaultValues()

--- a/src/tests/testsqlobjects.h
+++ b/src/tests/testsqlobjects.h
@@ -8,6 +8,8 @@ class TestTable: public QObject
     Q_OBJECT
 private slots:
     void sqlOutput();
+    void sqlGraveAccentOutput();
+    void sqlSquareBracketsOutput();
     void autoincrement();
     void notnull();
     void withoutRowid();
@@ -15,13 +17,16 @@ private slots:
     void uniqueConstraint();
 
     void parseSQL();
+    void parseSQLSquareBrackets();
     void parseSQLdefaultexpr();
     void parseSQLMultiPk();
     void parseSQLForeignKey();
     void parseSQLSingleQuotes();
     void parseSQLKeywordInIdentifier();
+    void parseSQLSomeKeywordsInIdentifier();
     void parseSQLWithoutRowid();
     void parseNonASCIIChars();
+    void parseNonASCIICharsEs();
     void parseSQLEscapedQuotes();
     void parseSQLForeignKeys();
     void parseSQLCheckConstraint();


### PR DESCRIPTION
A new option is added to the SQL tab in Preferences for choosing which
quoting characters must be used by the application when it inserts an
identifier in SQL code. The three options supported by SQLite are
available.

Default quoting characters have been changed from \`Grave accents\` to
"Double quotes" (SQL standard).

This options also affect the highlighting of double quoted strings: when
the SQL standard is selected, double quoted expressions are highlighted as
identifiers, otherwise as literal strings.

See issues #683 and #1280.

Matters to be discussed:

- Default: should we stay by the custom and use \`grave accents\` or follow the standard and use "double quotes"? I prefer standard, but the highlighting provided by QScintilla isn't reversible: if we choose to use double quotes for identifiers, the quoted table identifiers loose their specific style. We can get consistent behaviour if we use [QsciLexerSQL::setQuotedIdentifiers](http://pyqt.sourceforge.net/Docs/QScintilla2/classQsciLexerSQL.html#ae6e5819a3ddec15ac6926b5e19927bff) but only by loosing the table style in all cases, with the positive side of getting proper highlighting of keywords inside \`grave accents\`. Note that unquoted identifiers written by the user would still, in any case, be highlighted as tables.
- Since escapeIdentifier(id) doesn't belong to a class, the usual reloadSettings slot cannot be used. Please, validate the proposed solution. 
- In order to not clutter the Preferences window I tried to move `SQL editor font size` box to the same row as  `SQL editor font` but I was unable to do it with qtcreator and didn't dare to change it manually without knowing if the UI change would be welcome.
- Should a `None` option be available? This would left the responsibility of using appropriate identifiers to the user. I've discarded this option because it feels problematic, but it was suggested in #1280.