### PR TITLE
Reset SQL results table when the query has not returned data

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1188,6 +1188,8 @@ void MainWindow::executeQuery()
                 // If we get here, the SQL statement doesn't return data and just executes. Don't run it again because it has already been executed.
                 // But do set the modified flag because statements that don't return data, often modify the database.
 
+                sqlWidget->getModel()->reset();
+
                 QString stmtHasChangedDatabase;
                 if(query_part_type == InsertStatement || query_part_type == UpdateStatement || query_part_type == DeleteStatement)
                     stmtHasChangedDatabase = tr(", %1 rows affected").arg(sqlite3_changes(pDb.get()));

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -95,6 +95,7 @@ void SqliteTableModel::handleRowCountComplete (int life_id, int num_rows)
 
 void SqliteTableModel::reset()
 {
+    beginResetModel();
     clearCache();
 
     m_sTable.clear();
@@ -106,6 +107,8 @@ void SqliteTableModel::reset()
     m_vDataTypes.clear();
     m_vDisplayFormat.clear();
     m_pseudoPk.clear();
+
+    endResetModel();
 }
 
 void SqliteTableModel::setChunkSize(size_t chunksize)


### PR DESCRIPTION
When we know that the just executed query has not returned data, reset the
table results model, so the results view is also reset.

Added QAbstractItemModel::beginResetModel() and
QAbstractItemModel::endResetModel() to the model's reset method. This
resets completely the table view.

This improves the situation for #1431, without addressing the underlying
problem of not detecting correctly the type of query. In any case, any
query not returning data should reset the results from previous queries.