### PR TITLE
Support for operator filters for strings

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -607,6 +607,11 @@ void ExtendedTableWidget::useAsFilter(const QString& filterOperator, bool binary
     else
         value = data.toString();
 
+    // When Containing filter is requested (empty operator) and the value starts with
+    // an operator character, the character is escaped.
+    if (filterOperator.isEmpty())
+        value.replace(QRegExp("^(<|>|=)"), Settings::getValue("databrowser", "filter_escape").toString() + QString("\\1"));
+
     // If binary operator, the cell data is used as first value and
     // the second value must be added by the user.
     if (binary)

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -739,24 +739,14 @@ void SqliteTableModel::updateFilter(int column, const QString& value)
                 numeric = true;
                 val = "''";
             } else {
-                bool ok;
-                value.mid(2).toFloat(&ok);
-                if(ok)
-                {
-                    op = value.left(2);
-                    val = value.mid(2);
-                    numeric = true;
-                }
+                value.mid(2).toFloat(&numeric);
+                op = value.left(2);
+                val = value.mid(2);
             }
         } else if(value.left(1) == ">" || value.left(1) == "<") {
-            bool ok;
-            value.mid(1).toFloat(&ok);
-            if(ok)
-            {
-                op = value.left(1);
-                val = value.mid(1);
-                numeric = true;
-            }
+            value.mid(1).toFloat(&numeric);
+            op = value.left(1);
+            val = value.mid(1);
         } else if(value.left(1) == "=") {
             val = value.mid(1);
 


### PR DESCRIPTION
I open this as a Pull Request, because it means a change in behaviour for filters, but probably necessary and useful.

This adds support for all operators when applied to string values.
Formerly they were always treated as a Containing (LIKE) operator, but
after the implementation of bbe2e33ea4f1f22c85d133bdc8af20ea986eea2f the
lack of these operators were more visible and, at least, the omission of
<> seems a bug. But the omission of the others may also be a limitation.

For easing the return to the old behaviour, the Containing filter option
now takes into account the necessity of escaping the value when it starts
by one of the operator characters.

For operators applied to strings the behaviour is documented by Sqlite3
here: https://www.sqlite.org/datatype3.html#collating_sequences

See related issue #1463.