### PR TITLE
Allow "getting" and setting case_sensitive_like pragma

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1835,6 +1835,7 @@ void MainWindow::loadPragmas()
     pragmaValues.temp_store = db.getPragma("temp_store").toInt();
     pragmaValues.user_version = db.getPragma("user_version").toInt();
     pragmaValues.wal_autocheckpoint = db.getPragma("wal_autocheckpoint").toInt();
+    pragmaValues.case_sensitive_like = db.getPragma("case_sensitive_like").toInt();
 
     updatePragmaUi();
 }
@@ -1858,6 +1859,7 @@ void MainWindow::updatePragmaUi()
     ui->comboboxPragmaTempStore->setCurrentIndex(pragmaValues.temp_store);
     ui->spinPragmaUserVersion->setValue(pragmaValues.user_version);
     ui->spinPragmaWalAutoCheckpoint->setValue(pragmaValues.wal_autocheckpoint);
+    ui->checkboxPragmaCaseSensitiveLike->setChecked(pragmaValues.case_sensitive_like);
 }
 
 void MainWindow::savePragmas()
@@ -1887,6 +1889,7 @@ void MainWindow::savePragmas()
     db.setPragma("temp_store", ui->comboboxPragmaTempStore->currentIndex(), pragmaValues.temp_store);
     db.setPragma("user_version", ui->spinPragmaUserVersion->value(), pragmaValues.user_version);
     db.setPragma("wal_autocheckpoint", ui->spinPragmaWalAutoCheckpoint->value(), pragmaValues.wal_autocheckpoint);
+    db.setPragma("case_sensitive_like", ui->checkboxPragmaCaseSensitiveLike->isChecked(), pragmaValues.case_sensitive_like);
 
     updatePragmaUi();
 }

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -114,6 +114,7 @@ private:
         int temp_store;
         int user_version;
         int wal_autocheckpoint;
+        int case_sensitive_like;
     } pragmaValues;
 
     enum StatementType

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -838,6 +838,9 @@ You can drag SQL statements from an object row and drop them into other applicat
             </item>
             <item row="17" column="1">
              <widget class="QCheckBox" name="checkboxPragmaCaseSensitiveLike">
+              <property name="toolTip">
+               <string>Warning: this pragma is not readable and this value has been inferred. Writing the pragma might overwrite a redefined LIKE provided by an SQLite extension.</string>
+              </property>
               <property name="text">
                <string/>
               </property>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -823,6 +823,26 @@ You can drag SQL statements from an object row and drop them into other applicat
               </property>
              </widget>
             </item>
+            <item row="17" column="0">
+             <widget class="QLabel" name="labelPragmaCaseSensitiveLike">
+              <property name="text">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_case_sensitive_like&quot;&gt;Case Sensitive Like&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="openExternalLinks">
+               <bool>true</bool>
+              </property>
+              <property name="buddy">
+               <cstring>checkboxPragmaCaseSensitiveLike</cstring>
+              </property>
+             </widget>
+            </item>
+            <item row="17" column="1">
+             <widget class="QCheckBox" name="checkboxPragmaCaseSensitiveLike">
+              <property name="text">
+               <string/>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </widget>

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -1635,7 +1635,12 @@ QString DBBrowserDB::getPragma(const QString& pragma)
     if(!isOpen())
         return QString();
 
-    QString sql = QString("PRAGMA %1").arg(pragma);
+    QString sql;
+    if (pragma=="case_sensitive_like")
+        sql = "SELECT 'x' NOT LIKE 'X'";
+    else
+        sql = QString("PRAGMA %1").arg(pragma);
+
     sqlite3_stmt* vm;
     const char* tail;
     QString retval;


### PR DESCRIPTION
In order to allow case insensitive filtering, the pragma
case_sensitive_like is added to the GUI. Given that this pragma cannot be
read, a special SELECT request is made in DBBrowserDB::getPragma for
inferring its value.

See issue #1489.

I think this cannot give any problem, but just in case, I open this pull request with the implementation.