### PR TITLE
Menu bar restructured so it follows a more standard layout

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -916,12 +916,8 @@ You can drag SQL statements from an object row and drop them into other applicat
     <addaction name="fileAttachAction"/>
     <addaction name="fileCloseAction"/>
     <addaction name="separator"/>
-    <addaction name="separator"/>
     <addaction name="fileSaveAction"/>
     <addaction name="fileRevertAction"/>
-    <addaction name="fileCompactAction"/>
-    <addaction name="actionEncryption"/>
-    <addaction name="actionLoadExtension"/>
     <addaction name="separator"/>
     <addaction name="menuImport"/>
     <addaction name="menuExport"/>
@@ -940,6 +936,8 @@ You can drag SQL statements from an object row and drop them into other applicat
     <addaction name="editDeleteObjectAction"/>
     <addaction name="separator"/>
     <addaction name="editCreateIndexAction"/>
+    <addaction name="separator"/>
+    <addaction name="viewPreferencesAction"/>
    </widget>
    <widget class="QMenu" name="viewMenu">
     <property name="title">
@@ -948,8 +946,6 @@ You can drag SQL statements from an object row and drop them into other applicat
     <addaction name="viewDBToolbarAction"/>
     <addaction name="viewExtraDBToolbarAction"/>
     <addaction name="viewProjectToolbarAction"/>
-    <addaction name="separator"/>
-    <addaction name="viewPreferencesAction"/>
    </widget>
    <widget class="QMenu" name="helpMenu">
     <property name="title">
@@ -962,9 +958,19 @@ You can drag SQL statements from an object row and drop them into other applicat
     <addaction name="actionBug_report"/>
     <addaction name="helpAboutAction"/>
    </widget>
+   <widget class="QMenu" name="menuTools">
+    <property name="title">
+     <string>Tools</string>
+    </property>
+    <addaction name="fileCompactAction"/>
+    <addaction name="actionEncryption"/>
+    <addaction name="separator"/>
+    <addaction name="actionLoadExtension"/>
+   </widget>
    <addaction name="fileMenu"/>
    <addaction name="editMenu"/>
    <addaction name="viewMenu"/>
+   <addaction name="menuTools"/>
    <addaction name="helpMenu"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1353,7 +1353,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Compact &amp;Database</string>
+    <string>Compact &amp;Database...</string>
    </property>
    <property name="toolTip">
     <string>Compact the database file, removing space wasted by deleted records</string>
@@ -1566,7 +1566,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
   </action>
   <action name="helpAboutAction">
    <property name="text">
-    <string>&amp;About...</string>
+    <string>&amp;About</string>
    </property>
    <property name="menuRole">
     <enum>QAction::AboutRole</enum>
@@ -1637,7 +1637,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
      <normaloff>:/icons/load_extension</normaloff>:/icons/load_extension</iconset>
    </property>
    <property name="text">
-    <string>&amp;Load extension</string>
+    <string>&amp;Load Extension...</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -1678,7 +1678,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
      <normaloff>:/icons/browser_open</normaloff>:/icons/browser_open</iconset>
    </property>
    <property name="text">
-    <string>&amp;Wiki...</string>
+    <string>&amp;Wiki</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -1690,7 +1690,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
      <normaloff>:/icons/browser_open</normaloff>:/icons/browser_open</iconset>
    </property>
    <property name="text">
-    <string>Bug &amp;report...</string>
+    <string>Bug &amp;Report...</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -1702,7 +1702,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
      <normaloff>:/icons/browser_open</normaloff>:/icons/browser_open</iconset>
    </property>
    <property name="text">
-    <string>Web&amp;site...</string>
+    <string>Web&amp;site</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -1714,7 +1714,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
      <normaloff>:/icons/project_save</normaloff>:/icons/project_save</iconset>
    </property>
    <property name="text">
-    <string>Sa&amp;ve Project</string>
+    <string>Sa&amp;ve Project...</string>
    </property>
    <property name="toolTip">
     <string>Save the current session to a file</string>
@@ -1735,7 +1735,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
      <normaloff>:/icons/project_open</normaloff>:/icons/project_open</iconset>
    </property>
    <property name="text">
-    <string>Open &amp;Project</string>
+    <string>Open &amp;Project...</string>
    </property>
    <property name="toolTip">
     <string>Load a working session from a file</string>
@@ -1759,7 +1759,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
      <normaloff>:/icons/db_attach</normaloff>:/icons/db_attach</iconset>
    </property>
    <property name="text">
-    <string>&amp;Attach Database</string>
+    <string>&amp;Attach Database...</string>
    </property>
    <property name="toolTip">
     <string>Add another database file to the current database connection</string>
@@ -1780,7 +1780,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
      <normaloff>:/icons/encryption</normaloff>:/icons/encryption</iconset>
    </property>
    <property name="text">
-    <string>&amp;Set Encryption</string>
+    <string>&amp;Set Encryption...</string>
    </property>
    <property name="menuRole">
     <enum>QAction::NoRole</enum>
@@ -1875,7 +1875,7 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
      <normaloff>:/icons/browser_open</normaloff>:/icons/browser_open</iconset>
    </property>
    <property name="text">
-    <string>SQLCipher &amp;FAQ...</string>
+    <string>SQLCipher &amp;FAQ</string>
    </property>
    <property name="toolTip">
     <string>Opens the SQLCipher FAQ in a browser window</string>


### PR DESCRIPTION
- Some actions not directly related to file operations over databases or
projects have been moved from "File" to a new "Tools" top-level menu entry.
Future tools can be added here.
- Preferences moved from "View" to "Edit" (MacOS is supposed to still have
it in the application menu).

See issue #1434 

