### PR TITLE
Issue #1511: failed deletion in the DB still deletes the rows from model

### DIFF
--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -507,21 +507,27 @@ bool SqliteTableModel::removeRows(int row, int count, const QModelIndex& parent)
         return false;
     }
 
-    beginRemoveRows(parent, row, row + count - 1);
-
     QStringList rowids;
     for(int i=count-1;i>=0;i--)
     {
         if(m_cache.count(row+i)) {
             rowids.append(m_cache.at(row + i).at(0));
         }
-        m_cache.erase(row + i);
-        m_currentRowCount--;
     }
 
     bool ok = m_db.deleteRecords(m_sTable, rowids, m_pseudoPk);
 
-    endRemoveRows();
+    if (ok) {
+        beginRemoveRows(parent, row, row + count - 1);
+
+        for(int i=count-1;i>=0;i--)
+        {
+            m_cache.erase(row + i);
+            m_currentRowCount--;
+        }
+
+        endRemoveRows();
+    }
     return ok;
 }
 


### PR DESCRIPTION
If the deletion of a record is rejected by the SQLite3, for example, due to
the presence of Foreign Key constraints, the corresponding rows must not
be deleted from the model.

This change is simple and it's apparently working, but I open this pull request because I'm not sure of the
implications of removing the database records outside of the beginRemoveRows(...)..endRemoveRows() calls. Apparently there's no way to abort the deletion inside this block.

Another effective, but hard and inefficient, solution is to refresh the table automatically if the deletion
fails:
```diff
diff --git a/src/MainWindow.cpp b/src/MainWindow.cpp
index 0b23d6f..7d0f32e 100644
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -741,6 +741,7 @@ void MainWindow::deleteRecord()
             if(!m_browseTableModel->removeRows(first_selected_row, selected_rows_count))
             {
                 QMessageBox::warning(this, QApplication::applicationName(), tr("Error deleting record:\n%1").arg(db.lastError()));
+                populateTable();
                 break;
             }
         }
```