### PR TITLE
Experimental implementation of completion of values based on current values in the column

### DIFF
--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -104,13 +104,16 @@ ExtendedTableWidgetEditorDelegate::ExtendedTableWidgetEditorDelegate(QObject* pa
 
 QWidget* ExtendedTableWidgetEditorDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /*option*/, const QModelIndex& index) const
 {
-    // Just create a normal line editor but set the maximum length to the highest possible value instead of the default 32768.
     QLineEdit* editor = new QLineEdit(parent);
-    QCompleter *completer = new QCompleter(editor);
-    completer->setModel(const_cast<QAbstractItemModel*>(index.model()));
-    completer->setCompletionColumn(index.column());
-    completer->setCompletionMode(QCompleter::InlineCompletion);
-    editor->setCompleter(completer);
+    // If the row count is not greater than the complete threshold setting, set a completer of values based on current values in the column.
+    if (index.model()->rowCount() <= Settings::getValue("databrowser", "complete_threshold").toInt()) {
+        QCompleter *completer = new QCompleter(editor);
+        completer->setModel(const_cast<QAbstractItemModel*>(index.model()));
+        completer->setCompletionColumn(index.column());
+        completer->setCompletionMode(QCompleter::InlineCompletion);
+        editor->setCompleter(completer);
+    }
+    // Set the maximum length to the highest possible value instead of the default 32768.
     editor->setMaxLength(std::numeric_limits<int>::max());
     return editor;
 }

--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -16,6 +16,7 @@
 #include <QMenu>
 #include <QDateTime>
 #include <QLineEdit>
+#include <QCompleter>
 #include <limits>
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 4, 0)
@@ -101,10 +102,15 @@ ExtendedTableWidgetEditorDelegate::ExtendedTableWidgetEditorDelegate(QObject* pa
 {
 }
 
-QWidget* ExtendedTableWidgetEditorDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /*option*/, const QModelIndex& /*index*/) const
+QWidget* ExtendedTableWidgetEditorDelegate::createEditor(QWidget* parent, const QStyleOptionViewItem& /*option*/, const QModelIndex& index) const
 {
     // Just create a normal line editor but set the maximum length to the highest possible value instead of the default 32768.
     QLineEdit* editor = new QLineEdit(parent);
+    QCompleter *completer = new QCompleter(editor);
+    completer->setModel(const_cast<QAbstractItemModel*>(index.model()));
+    completer->setCompletionColumn(index.column());
+    completer->setCompletionMode(QCompleter::InlineCompletion);
+    editor->setCompleter(completer);
     editor->setMaxLength(std::numeric_limits<int>::max());
     return editor;
 }

--- a/src/ExtendedTableWidget.h
+++ b/src/ExtendedTableWidget.h
@@ -6,10 +6,23 @@
 #include <QDropEvent>
 #include <QDragMoveEvent>
 #include <QStyledItemDelegate>
+#include <QSortFilterProxyModel>
 
 class QMenu;
 class FilterTableHeader;
 namespace sqlb { class ObjectIdentifier; }
+
+// Filter proxy model that only accepts distinct non-empty values.
+class UniqueFilterModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+
+public:
+    explicit UniqueFilterModel(QObject* parent = nullptr);
+    bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+ private:
+    QSet<QString> m_uniqueValues;
+};
 
 // We use this class to provide editor widgets for the ExtendedTableWidget. It's used for every cell in the table view.
 class ExtendedTableWidgetEditorDelegate : public QStyledItemDelegate

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -97,6 +97,7 @@ void PreferencesDialog::loadSettings()
     loadColorSetting(ui->fr_reg_bg, "reg_bg");
 
     ui->spinSymbolLimit->setValue(Settings::getValue("databrowser", "symbol_limit").toInt());
+    ui->spinCompleteThreshold->setValue(Settings::getValue("databrowser", "complete_threshold").toInt());
     ui->txtNull->setText(Settings::getValue("databrowser", "null_text").toString());
     ui->txtBlob->setText(Settings::getValue("databrowser", "blob_text").toString());
     ui->editFilterEscape->setText(Settings::getValue("databrowser", "filter_escape").toString());
@@ -206,6 +207,7 @@ void PreferencesDialog::saveSettings()
     saveColorSetting(ui->fr_bin_fg, "bin_fg");
     saveColorSetting(ui->fr_bin_bg, "bin_bg");
     Settings::setValue("databrowser", "symbol_limit", ui->spinSymbolLimit->value());
+    Settings::setValue("databrowser", "complete_threshold", ui->spinCompleteThreshold->value());
     Settings::setValue("databrowser", "null_text", ui->txtNull->text());
     Settings::setValue("databrowser", "blob_text", ui->txtBlob->text());
     Settings::setValue("databrowser", "filter_escape", ui->editFilterEscape->text());

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -469,6 +469,40 @@
               </property>
              </widget>
             </item>
+            <item row="1" column="1">
+             <widget class="QSpinBox" name="spinCompleteThreshold">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="toolTip">
+               <string>This is the maximum number of rows in a table for enabling the value completion based on current values in the column.
+Can be set to 0 for disabling completion.</string>
+              </property>
+              <property name="whatsThis">
+               <string>This is the maximum number of rows in a table for enabling the value completion based on current values in the column.
+Can be set to 0 for disabling completion.</string>
+              </property>
+              <property name="minimum">
+               <number>0</number>
+              </property>
+              <property name="maximum">
+               <number>100000000</number>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="labelCompleteThreshold">
+              <property name="text">
+               <string>Row count threshold for completion</string>
+              </property>
+              <property name="buddy">
+               <cstring>spinCompleteThreshold</cstring>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -176,6 +176,8 @@ QVariant Settings::getDefaultValue(const QString& group, const QString& name)
             return 10;
         if(name == "symbol_limit")
             return 5000;
+        if(name == "complete_threshold")
+            return 1000;
         if(name == "indent_compact")
             return false;
         if(name == "null_text")


### PR DESCRIPTION
Using the QCompleter class associated to the QLineEdit, an implementation of a completion of values in the Extended Table Widget is straightforward.

I've observed that this is slow with big databases, so if included, we probably need a new setting for disabling it, or disabling it automatically given a threshold in the row count.

If InlineCompletion is changed by PopupCompletion completions are displayed in a popup window (see http://doc.qt.io/qt-5/qcompleter.html#CompletionMode-enum). That would be probably nicer but the completions are repeated when the value is repeated in the table, so we should make some kind of unique filtering and the implementation would be trickier and maybe slower.

Is this considered useful?