### PR TITLE
Never mark the DB dirty if it is read-only. Issue #1514

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1317,7 +1317,7 @@ void MainWindow::executeQuery()
             // We're not trying to set a pragma or to vacuum the database. In this case make sure a savepoint has been created in order to avoid committing
             // all changes to the database immediately. Don't set more than one savepoint.
 
-            if(!savepoint_created)
+            if(!savepoint_created && !db.readOnly())
             {
                 // We have to start a transaction before we create the prepared statement otherwise every executed
                 // statement will get committed after the prepared statement gets finalized

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -411,6 +411,10 @@ bool DBBrowserDB::setSavepoint(const QString& pointname)
 {
     if(!isOpen())
         return false;
+    if(isReadOnly) {
+        qWarning() << "setSavepoint: not done. DB is read-only";
+        return false;
+    }
     if(savepointList.contains(pointname))
         return true;
 


### PR DESCRIPTION
Setting save points does not make sense for read-only databases, so
do never set a save-point while executing a user query if the database has
been opened in read-only mode.

If setSavePoint is ever called in read-only mode, a warning is printed and
the save-point is not set.

If ever a read-write query is executed, it would be rejected by SQLite so
there is no risk of immediately committing any change to the DB.