### PR TITLE
Avoid setting the db dirty with some trailing whitespace and comments

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1289,6 +1289,13 @@ void MainWindow::executeQuery()
     {
         // What type of query is this?
         QString qtail = QString(tail).trimmed();
+        // Remove trailing comments so we don't get fooled by some trailing text at the end of the stream.
+        // Otherwise we'll pass them to SQLite and its execution will trigger a savepoint that wouldn't be
+        // reverted.
+        SqliteTableModel::removeCommentsFromQuery(qtail);
+        if (qtail.isEmpty())
+            break;
+
         StatementType query_type = getQueryType(qtail);
 
         // Check whether the DB structure is changed by this statement


### PR DESCRIPTION
If we execute a select statement and there is some trailing whitespace or
comments in the buffer, we are passing that to SQLite and fooling
ourselves thinking that it may be a query modifying the database. Since
we aren't very smart about knowing which queries modify the database, this
change at least avoids this particular case by breaking when there is only
trailing whitespace and comments.

The issue has probably origin in #1455, since previously we didn't pass
the comments to SQLite.