### PR TITLE
Problems with WITHOUT ROWID tables with PK of string type

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -775,13 +775,12 @@ void MainWindow::closeEvent( QCloseEvent* event )
 void MainWindow::addRecord()
 {
     int row = m_browseTableModel->rowCount();
-    bool isWithoutRowidTable = db.getObjectByName(currentlyBrowsedTableName())->type() == sqlb::Object::Table && db.getObjectByName<sqlb::Table>(currentlyBrowsedTableName())->isWithoutRowidTable();
 
-    if(!isWithoutRowidTable && m_browseTableModel->insertRow(row))
+    if(m_browseTableModel->insertRow(row))
     {
         selectTableLine(row);
     } else {
-        // Table without rowid (let user enter value for PK) or error inserting empty row.
+        // Error inserting empty row.
         // User has to provide values acomplishing the constraints. Open Add Record Dialog.
         insertValues();
     }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -775,11 +775,13 @@ void MainWindow::closeEvent( QCloseEvent* event )
 void MainWindow::addRecord()
 {
     int row = m_browseTableModel->rowCount();
-    if(m_browseTableModel->insertRow(row))
+    bool isWithoutRowidTable = db.getObjectByName(currentlyBrowsedTableName())->type() == sqlb::Object::Table && db.getObjectByName<sqlb::Table>(currentlyBrowsedTableName())->isWithoutRowidTable();
+
+    if(!isWithoutRowidTable && m_browseTableModel->insertRow(row))
     {
         selectTableLine(row);
     } else {
-        // Error inserting empty row.
+        // Table without rowid (let user enter value for PK) or error inserting empty row.
         // User has to provide values acomplishing the constraints. Open Add Record Dialog.
         insertValues();
     }

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -1099,12 +1099,13 @@ QString DBBrowserDB::emptyInsertStmt(const QString& schemaName, const sqlb::Tabl
 
             if(!pk_value.isNull())
             {
-                vals << pk_value;
+                vals << (f.isText()? "'" + pk_value + "'" : pk_value);
             } else {
                 if(f.notnull())
                 {
                     QString maxval = this->max(sqlb::ObjectIdentifier(schemaName, t.name()), f);
-                    vals << QString::number(maxval.toLongLong() + 1);
+                    QString newval = QString::number(maxval.toLongLong() + 1);
+                    vals << (f.isText()? "'" + newval + "'" : newval);
                 } else {
                     vals << "NULL";
                 }

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -393,6 +393,12 @@ bool SqliteTableModel::setTypedData(const QModelIndex& index, bool isBlob, const
         {
             cached_row.replace(index.column(), newValue);
             lock.unlock();
+            // Special case for rowid columns
+            if(m_headers.at(index.column()) == m_sRowidColumn) {
+                cached_row.replace(0, newValue);
+                const QModelIndex& rowidIndex = index.sibling(index.row(), 0);
+                emit dataChanged(rowidIndex, rowidIndex);
+            }
             emit dataChanged(index, index);
             return true;
         } else {

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -392,12 +392,13 @@ bool SqliteTableModel::setTypedData(const QModelIndex& index, bool isBlob, const
         if(m_db.updateRecord(m_sTable, m_headers.at(index.column()), cached_row.at(0), newValue, isBlob, m_pseudoPk))
         {
             cached_row.replace(index.column(), newValue);
-            lock.unlock();
-            // Special case for rowid columns
             if(m_headers.at(index.column()) == m_sRowidColumn) {
                 cached_row.replace(0, newValue);
                 const QModelIndex& rowidIndex = index.sibling(index.row(), 0);
+                lock.unlock();
                 emit dataChanged(rowidIndex, rowidIndex);
+            } else {
+                lock.unlock();
             }
             emit dataChanged(index, index);
             return true;


### PR DESCRIPTION
This fixes two related problems:
- When the PK is updated the hidden column 0 must be updated too,
  otherwise any further editing of the same row before a table refresh is
  broken.
- When a new record is inserted and the PK has string type we cannot
  simply make a pseudo auto-increment and insert that value as rowid
  because that added key would be impossible to update because our
  UPDATE clause will try to update a column with a string and it contains
  an integer. In this case it's better to let the user enter the PK value,
  so the new Add Record dialog is directly invoked.

See issue #1332 and (tangentially) #1049. The first should be fixed now.
The later not, but at least there is now a workaround: removing the
AUTOINCREMENT option and use the WITHOUT ROWID one.