### PR TITLE
Allow any number of changes to the table schema in one alterTable call

### DIFF
--- a/src/EditTableDialog.h
+++ b/src/EditTableDialog.h
@@ -64,12 +64,10 @@ private:
     DBBrowserDB& pdb;
     ForeignKeyEditorDelegate* m_fkEditorDelegate;
     sqlb::ObjectIdentifier curTable;
+    QMap<QString, QString> trackColumns;
     sqlb::Table m_table;
-    QStringList types;
-    QStringList fields;
     bool m_bNewTable;
     QString m_sRestorePointName;
-    bool m_bForeignKeysEnabled;
 };
 
 #endif

--- a/src/sql/sqlitetypes.cpp
+++ b/src/sql/sqlitetypes.cpp
@@ -120,6 +120,18 @@ private:
     antlr::RefAST m_root;
 };
 
+bool Object::operator==(const Object& rhs) const
+{
+    if(m_name != rhs.m_name)
+        return false;
+    if(m_fullyParsed != rhs.m_fullyParsed)  // We check for the fully parsed flag to make sure not to lose anything in some corner cases
+        return false;
+
+    // We don't care about the original SQL text
+
+    return true;
+}
+
 QString Object::typeToString(Types type)
 {
     switch(type)
@@ -202,6 +214,28 @@ QString CheckConstraint::toSql(const QStringList&) const
     result += QString("CHECK(%1)").arg(m_expression);
 
     return result;
+}
+
+bool Field::operator==(const Field& rhs) const
+{
+    if(m_name != rhs.m_name)
+        return false;
+    if(m_type != rhs.m_type)
+        return false;
+    if(m_notnull != rhs.m_notnull)
+        return false;
+    if(m_check != rhs.m_check)
+        return false;
+    if(m_defaultvalue != rhs.m_defaultvalue)
+        return false;
+    if(m_autoincrement != rhs.m_autoincrement)
+        return false;
+    if(m_unique != rhs.m_unique)
+        return false;
+    if(m_collation != rhs.m_collation)
+        return false;
+
+    return true;
 }
 
 QString Field::toString(const QString& indent, const QString& sep) const
@@ -317,6 +351,23 @@ Table& Table::operator=(const Table& rhs)
     m_constraints = rhs.m_constraints;
 
     return *this;
+}
+
+bool Table::operator==(const Table& rhs) const
+{
+    if(!Object::operator==(rhs))
+        return false;
+
+    if(m_rowidColumn != rhs.m_rowidColumn)
+        return false;
+    if(m_constraints != rhs.m_constraints)
+        return false;
+    if(m_virtual != rhs.m_virtual)
+        return false;
+    if(fields != rhs.fields)
+        return false;
+
+    return true;
 }
 
 Table::field_iterator Table::findPk()

--- a/src/sqlitedb.h
+++ b/src/sqlitedb.h
@@ -3,13 +3,13 @@
 
 #include "sql/sqlitetypes.h"
 
+#include <condition_variable>
 #include <memory>
 #include <mutex>
-#include <condition_variable>
 
-#include <QStringList>
-#include <QMultiMap>
 #include <QByteArray>
+#include <QMultiMap>
+#include <QStringList>
 
 struct sqlite3;
 class CipherSettings;
@@ -155,17 +155,25 @@ public:
     bool addColumn(const sqlb::ObjectIdentifier& tablename, const sqlb::Field& field);
 
     /**
-     * @brief alterTable Can be used to rename, modify or drop an existing column of a given table
-     * @param schema Specifies the name of the schema, i.e. the database name, of the table
-     * @param tablename Specifies the name of the table to edit
-     * @param table Specifies the table to edit. The table constraints are used from this but not the columns
-     * @param name Name of the column to edit
-     * @param to The new field definition with changed name, type or the like. If Null-Pointer is given the column is dropped.
-     * @param move Set this to a value != 0 to move the new column to a different position
+     * @brief This type maps from old column names to new column names. Given the old and the new table definition, this suffices to
+     * track fields between the two.
+     * USE CASES:
+     * 1) Don't specify a column at all or specify equal column names: Keep its name as-is.
+     * 2) Specify different column names: Rename the field.
+     * 3) Map from an existing column name to a Null string: Delete the column.
+     * 4) Map from a Null column name to a new column name: Add the column.
+     */
+    using AlterTableTrackColumns = QMap<QString, QString>;
+
+    /**
+     * @brief alterTable Can be used to rename, modify or drop existing columns of a given table
+     * @param tablename Specifies the schema and name of the table to edit
+     * @param new_table Specifies the new table schema. This is exactly how the new table is going to look like.
+     * @param track_columns Maps old column names to new column names. This is used to copy the data from the old table to the new one.
      * @param newSchema Set this to a non-empty string to move the table to a new schema
      * @return true if renaming was successful, false if not. In the latter case also lastErrorMessage is set
      */
-    bool alterTable(const sqlb::ObjectIdentifier& tablename, const sqlb::Table& table, QString name, const sqlb::Field* to, int move = 0, QString newSchemaName = QString());
+    bool alterTable(const sqlb::ObjectIdentifier& tablename, const sqlb::Table& new_table, AlterTableTrackColumns track_columns, QString newSchemaName = QString());
 
     objectMap getBrowsableObjects(const QString& schema) const;
 


### PR DESCRIPTION
After #1561 here's the next, bigger step to improve our table editing. This one makes sure that in whatever way you change your table layout we will only recreate the table and copy the data one time.

This one needs good testing as errors here are relatively likely and could mean data loss. So be careful when testing this and make a backup :smile: 

@justinclift Can you maybe create binaries from this branch, too? Sorry for opening so many PRs which need extra testing :wink: 
 


**Original commit message**

In the Edit Table dialog we used to call our alterTable function (which
works around SQLite's missing full ALTER TABLE support by - besided
other things - copying all the data of the table) for pretty much every
change immediately. This was taking a lot of time for larger tables.

Our alterTable function allowed any number of changes if they affect
only one field of the table at once. So we could have reduced the number
of calls a lot by just using that capability. Instead however, this
commit improves the alterTable function to make possible transforming a
table completely in just one call. It does so by taking the new table
schema and using that without further modification. It also takes a new
parameter to keep track of what column in the old table becomes what
column in the new table, so the data can be preserved.

This commit obviously also changes the Edit Table dialog to make proper
use of the new features. This means that whatever changes you make to a
table, you will only have to wait once until for the alterTable call,
and that's when clicking the OK button.

See issue #1444.