### PR TITLE
Change project file format to support multiple sort columns

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -26,8 +26,25 @@ class MainWindow;
 
 struct BrowseDataTableSettings
 {
-    int sortOrderIndex;
-    Qt::SortOrder sortOrderMode;
+    struct SortedColumn
+    {
+        SortedColumn() :
+            index(0),
+            mode(Qt::AscendingOrder)
+        {}
+        SortedColumn(int index_, Qt::SortOrder mode_) :
+            index(index_),
+            mode(mode_)
+        {}
+        SortedColumn(int index_, int mode_) :
+            index(index_),
+            mode(static_cast<Qt::SortOrder>(mode_))
+        {}
+
+        int index;
+        Qt::SortOrder mode;
+    };
+    QVector<SortedColumn> sortOrder;
     QMap<int, int> columnWidths;
     QMap<int, QString> filterValues;
     QMap<int, QString> displayFormats;
@@ -39,18 +56,16 @@ struct BrowseDataTableSettings
     QMap<int, bool> hiddenColumns;
 
     BrowseDataTableSettings() :
-        sortOrderIndex(0),
-        sortOrderMode(Qt::AscendingOrder),
         showRowid(false)
     {
     }
 
     friend QDataStream& operator>>(QDataStream& stream, BrowseDataTableSettings& object)
     {
-        stream >> object.sortOrderIndex;
-        int sortordermode;
-        stream >> sortordermode;
-        object.sortOrderMode = static_cast<Qt::SortOrder>(sortordermode);
+        int sortOrderIndex, sortOrderMode;
+        stream >> sortOrderIndex;
+        stream >> sortOrderMode;
+        object.sortOrder.push_back(SortedColumn(sortOrderIndex, sortOrderMode));
         stream >> object.columnWidths;
         stream >> object.filterValues;
         stream >> object.displayFormats;


### PR DESCRIPTION
This commit changes the project file format (and some internal data
structures) to support multiple sort columns in the Browse Data tab.
Note that this does not add actual support for multiple sort columns,
it's just a preparation for that.

I want to cherry-pick this over to the v3.11.x branch. I think that's pretty handy because for 3.11 we already changed the project file format quite a bit and ask the users to re-save their files. This means these changes here are just on top of that. So when we add support for multiple sort columns one day, we won't have to change the project file format again. However, since the changes here won't get much testing before the release I hope you can have a quick look at the code and check if there are any obvious problems in there :smile: 