### PR TITLE
Regexp filters

### DIFF
--- a/src/CondFormat.cpp
+++ b/src/CondFormat.cpp
@@ -72,6 +72,10 @@ QString CondFormat::filterToSqlCondition(const QString& value, const QString& en
                 op = "IS";
                 numeric = true;
             }
+        } else if(value.left(1) == "/" && value.right(1) == "/" && value.length() > 2) {
+            val = value.mid(1, value.length() - 2);
+            op = "REGEXP";
+            numeric = false;
         } else {
             // Keep the default LIKE operator
 

--- a/src/ExtendedTableWidget.h
+++ b/src/ExtendedTableWidget.h
@@ -69,7 +69,7 @@ private:
     void copy(const bool withHeaders, const bool inSQL);
     void paste();
 
-    void useAsFilter(const QString& filterOperator, bool binary = false);
+    void useAsFilter(const QString& filterOperator, bool binary = false, const QString& operatorSuffix = "");
     void duplicateUpperCell();
 
     typedef QList<QByteArray> QByteArrayList;

--- a/src/FilterLineEdit.cpp
+++ b/src/FilterLineEdit.cpp
@@ -32,7 +32,8 @@ FilterLineEdit::FilterLineEdit(QWidget* parent, QList<FilterLineEdit*>* filters,
                     "<=\tEqual to or less\n"
                     "=\tEqual to: exact match\n"
                     "<>\tUnequal: exact inverse match\n"
-                    "x~y\tRange: values between x and y"));
+                    "x~y\tRange: values between x and y\n"
+                    "/regexp/\tValues matching the regular expression"));
 
     // Immediately emit the delayed filter value changed signal if the user presses the enter or the return key or
     // the line edit widget loses focus
@@ -94,11 +95,11 @@ void FilterLineEdit::setText(const QString& text)
     delayedSignalTimerTriggered();
 }
 
-void FilterLineEdit::setFilterHelper(const QString& filterOperator)
+void FilterLineEdit::setFilterHelper(const QString& filterOperator, const QString& operatorSuffix)
 {
-    setText(filterOperator + "?");
+    setText(filterOperator + "?" + operatorSuffix);
     // Select the value for easy editing of the expression
-    setSelection(filterOperator.length(), filterOperator.length());
+    setSelection(filterOperator.length(), 1);
 }
 
 void FilterLineEdit::showContextMenu(const QPoint &pos)
@@ -143,7 +144,11 @@ void FilterLineEdit::showContextMenu(const QPoint &pos)
     connect(isNotEmptyAction, &QAction::triggered, [&]() {
             setText("<>''");
         });
-
+    // Simplify this if we ever support a NOT LIKE filter
+    QAction* notContainingAction = new QAction(tr("Not containing..."), editContextMenu);
+    connect(notContainingAction, &QAction::triggered, [&]() {
+            setFilterHelper(QString ("/^((?!"), QString(").)*$/"));
+        });
     QAction* equalToAction = new QAction(tr("Equal to..."), editContextMenu);
     connect(equalToAction, &QAction::triggered, [&]() {
             setFilterHelper(QString ("="));
@@ -173,6 +178,11 @@ void FilterLineEdit::showContextMenu(const QPoint &pos)
             setFilterHelper(QString ("?~"));
         });
 
+    QAction* regexpAction = new QAction(tr("Regular expression..."), editContextMenu);
+    connect(regexpAction, &QAction::triggered, [&]() {
+            setFilterHelper(QString ("/"), QString ("/"));
+        });
+
     editContextMenu->addAction(conditionalFormatAction);
 
     filterMenu->addAction(whatsThisAction);
@@ -182,6 +192,7 @@ void FilterLineEdit::showContextMenu(const QPoint &pos)
     filterMenu->addAction(isEmptyAction);
     filterMenu->addAction(isNotEmptyAction);
     filterMenu->addSeparator();
+    filterMenu->addAction(notContainingAction);
     filterMenu->addAction(equalToAction);
     filterMenu->addAction(notEqualToAction);
     filterMenu->addAction(greaterThanAction);
@@ -189,6 +200,6 @@ void FilterLineEdit::showContextMenu(const QPoint &pos)
     filterMenu->addAction(greaterEqualAction);
     filterMenu->addAction(lessEqualAction);
     filterMenu->addAction(inRangeAction);
-
+    filterMenu->addAction(regexpAction);
     editContextMenu->exec(mapToGlobal(pos));
 }

--- a/src/FilterLineEdit.h
+++ b/src/FilterLineEdit.h
@@ -28,7 +28,7 @@ signals:
 
 protected:
     void keyReleaseEvent(QKeyEvent* event) override;
-    void setFilterHelper(const QString& filterOperator);
+    void setFilterHelper(const QString& filterOperator, const QString& operatorSuffix = "");
 
 private:
     QList<FilterLineEdit*>* filterList;


### PR DESCRIPTION
This adds support for the REGEXP operator using the syntax /regexp/ in the
filter line boxes.

A new helper option for a not-containing filter is added using this new
syntax. This could be simplified using a NOT LIKE filter, but we don't
currently support that.

The "Use in Filter Expression > Containing" option escapes a possible
slash in the beginning, so it is not interpreted as a regexp filter.

See issue #1522