### PR TITLE
Prepare for different options when the DB is in use

### DIFF
--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -612,7 +612,7 @@ DBBrowserDB::db_pointer_type DBBrowserDB::get(QString user)
     return db_pointer_type(_db, DatabaseReleaser(this));
 }
 
-void DBBrowserDB::waitForDbRelease()
+void DBBrowserDB::waitForDbRelease(ChoiceOnUse choice)
 {
     if(!_db)
         return;
@@ -623,14 +623,18 @@ void DBBrowserDB::waitForDbRelease()
         auto str = db_user;
         lk.unlock();
 
-        QMessageBox msgBox;
-        msgBox.setText(tr("The database is currently busy: ") + str);
-        msgBox.setInformativeText(tr("Do you want to abort that other operation?"));
-        msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-        msgBox.setDefaultButton(QMessageBox::No);
-        int ret = msgBox.exec();
+        bool cancel = choice == CancelOther;
+        if(choice == Ask) {
+            QMessageBox msgBox;
+            msgBox.setText(tr("The database is currently busy: ") + str);
+            msgBox.setInformativeText(tr("Do you want to abort that other operation?"));
+            msgBox.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+            msgBox.setDefaultButton(QMessageBox::No);
+            int ret = msgBox.exec();
 
-        if(ret == QMessageBox::Yes)
+            cancel = ret == QMessageBox::Yes;
+        }
+        if(cancel)
             sqlite3_interrupt(_db);
 
         lk.lock();
@@ -986,15 +990,11 @@ bool DBBrowserDB::executeMultiSQL(const QString& statement, bool dirty, bool log
     return true;
 }
 
-QByteArray DBBrowserDB::querySingleValueFromDb(const QString& sql, bool log)
+QByteArray DBBrowserDB::querySingleValueFromDb(const QString& sql, bool log, ChoiceOnUse choice)
 {
+    waitForDbRelease(choice);
     if(!_db)
         return QByteArray();
-
-    // If the threading mode is Single-thread or Multi-thread then wait for
-    // the DB release.
-    if (sqlite3_db_mutex(_db) == nullptr)
-        waitForDbRelease();
 
     if(log)
         logSQL(sql, kLogMsg_App);

--- a/src/sqlitedb.h
+++ b/src/sqlitedb.h
@@ -94,9 +94,16 @@ public:
 
     bool dump(const QString& filename, const QStringList& tablesToDump, bool insertColNames, bool insertNew, bool exportSchema, bool exportData, bool keepOldSchema);
 
+    enum ChoiceOnUse
+    {
+        Ask,
+        Wait,
+        CancelOther
+    };
+
     bool executeSQL(QString statement, bool dirtyDB = true, bool logsql = true);
     bool executeMultiSQL(const QString& statement, bool dirty = true, bool log = false);
-    QByteArray querySingleValueFromDb(const QString& sql, bool log = true);
+    QByteArray querySingleValueFromDb(const QString& sql, bool log = true, ChoiceOnUse choice = Ask);
 
     const QString& lastError() const { return lastErrorMessage; }
 
@@ -214,7 +221,7 @@ private:
     /// wait for release of the DB locked through a previous get(),
     /// giving users the option to discard running task through a
     /// message box.
-    void waitForDbRelease();
+    void waitForDbRelease(ChoiceOnUse choice = Ask);
 
     QString curDBFilename;
     QString lastErrorMessage;

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -316,7 +316,8 @@ QVariant SqliteTableModel::data(const QModelIndex &index, int role) const
 
                 // Unlock before querying from DB
                 lock.unlock();
-                if (m_db.querySingleValueFromDb(sql, false) == "1")
+                // Query the DB for the condition, waiting in case there is a loading in progress.
+                if (m_db.querySingleValueFromDb(sql, false, DBBrowserDB::Wait) == "1")
                     return eachCondFormat.color();
             }
         }


### PR DESCRIPTION
waitForDbRelease receives a parameter for waiting, cancelling the other
operation or asking the user; defaulting to ask.

The wait option is used for the conditional formatting, so it doesn't
interfere with the loading. This avoid opening a dialog when scrolling
the table over a still not fetched area with conditional formats.
And it is done independently of the threading model supported by SQLite.