### PR TITLE
Update BUILDING.md for Ubuntu 18.04

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -53,6 +53,8 @@ The same process works for building the code in any platform supported by Qt
 
 ### Ubuntu Linux
 
+** Note ** - On Ubuntu 18.04 you need to add `qttools5-dev` to the `sudo apt install` line below
+
 ```bash
 $ sudo apt install build-essential git-core cmake libsqlite3-dev qt5-default qttools5-dev-tools \
     libsqlcipher-dev


### PR DESCRIPTION
This is to deal with building on Ubuntu 18.04 and seeing the message:

>   Could not find a package configuration file provided by "Qt5LinguistTools"
>   with any of the following names:
> 
>     Qt5LinguistToolsConfig.cmake
>     qt5linguisttools-config.cmake