### PR TITLE
Use a specialised count query for browsing tables/views

### DIFF
--- a/src/RowLoader.h
+++ b/src/RowLoader.h
@@ -34,7 +34,7 @@ public:
         Cache & cache_data
         );
 
-    void setQuery (QString);
+    void setQuery (QString new_query, QString newCountQuery = QString());
 
     void triggerRowCountDetermination (int token);
 
@@ -77,6 +77,7 @@ private:
     mutable std::condition_variable cv;
 
     QString query;
+    QString countQuery;
 
     mutable std::future<void> row_counter;
 

--- a/src/sql/Query.cpp
+++ b/src/sql/Query.cpp
@@ -18,6 +18,28 @@ void Query::clear()
     m_sort.clear();
 }
 
+std::string Query::buildWherePart() const
+{
+    std::string where;
+    if(m_where.size())
+    {
+        where = "WHERE ";
+
+        for(auto i=m_where.cbegin();i!=m_where.cend();++i)
+        {
+            const auto it = findSelectedColumnByName(m_column_names.at(i->first));
+            std::string column = sqlb::escapeIdentifier(m_column_names.at(i->first));
+            if(it != m_selected_columns.cend() && it->selector != column)
+                column = it->selector;
+            where += column + " " + i->second + " AND ";
+        }
+
+        // Remove last ' AND '
+        where.erase(where.size() - 5);
+    }
+    return where;
+}
+
 std::string Query::buildQuery(bool withRowid) const
 {
     // Selector and display formats
@@ -40,23 +62,7 @@ std::string Query::buildQuery(bool withRowid) const
     }
 
     // Filter
-    std::string where;
-    if(m_where.size())
-    {
-        where = "WHERE ";
-
-        for(auto i=m_where.cbegin();i!=m_where.cend();++i)
-        {
-            const auto it = findSelectedColumnByName(m_column_names.at(i->first));
-            std::string column = sqlb::escapeIdentifier(m_column_names.at(i->first));
-            if(it != m_selected_columns.cend() && it->selector != column)
-                column = it->selector;
-            where += column + " " + i->second + " AND ";
-        }
-
-        // Remove last ' AND '
-        where.erase(where.size() - 5);
-    }
+    std::string where = buildWherePart();
 
     // Sorting
     std::string order_by;
@@ -70,6 +76,12 @@ std::string Query::buildQuery(bool withRowid) const
     }
 
     return "SELECT " + selector + " FROM " + m_table.toString().toStdString() + " " + where + " " + order_by;
+}
+
+std::string Query::buildCountQuery() const
+{
+    // Build simplest count query for this (filtered) table
+    return "SELECT COUNT(*) FROM " + m_table.toString().toStdString() + " " + buildWherePart();
 }
 
 std::vector<SelectedColumn>::iterator Query::findSelectedColumnByName(const std::string& name)

--- a/src/sql/Query.h
+++ b/src/sql/Query.h
@@ -48,6 +48,7 @@ public:
 
     void clear();
     std::string buildQuery(bool withRowid) const;
+    std::string buildCountQuery() const;
 
     void setColumNames(const std::vector<std::string>& column_names) { m_column_names = column_names; }
     std::vector<std::string> columnNames() const { return m_column_names; }
@@ -77,6 +78,7 @@ private:
 
     std::vector<SelectedColumn>::iterator findSelectedColumnByName(const std::string& name);
     std::vector<SelectedColumn>::const_iterator findSelectedColumnByName(const std::string& name) const;
+    std::string buildWherePart() const;
 };
 
 }

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -176,7 +176,7 @@ void SqliteTableModel::setQuery(const sqlb::Query& query)
     buildQuery();
 }
 
-void SqliteTableModel::setQuery(const QString& sQuery, bool dontClearHeaders)
+void SqliteTableModel::setQuery(const QString& sQuery, const QString& sCountQuery, bool dontClearHeaders)
 {
     // clear
     if(!dontClearHeaders)
@@ -190,7 +190,7 @@ void SqliteTableModel::setQuery(const QString& sQuery, bool dontClearHeaders)
     m_sQuery = sQuery.trimmed();
     removeCommentsFromQuery(m_sQuery);
 
-    worker->setQuery(m_sQuery);
+    worker->setQuery(m_sQuery, sCountQuery);
     worker->triggerRowCountDetermination(m_lifeCounter);
 
     if(!dontClearHeaders)
@@ -593,7 +593,7 @@ QModelIndex SqliteTableModel::dittoRecord(int old_row)
 
 void SqliteTableModel::buildQuery()
 {
-    setQuery(QString::fromStdString(m_query.buildQuery(true)), true);
+    setQuery(QString::fromStdString(m_query.buildQuery(true)), QString::fromStdString(m_query.buildCountQuery()), true);
 }
 
 void SqliteTableModel::removeCommentsFromQuery(QString& query)

--- a/src/sqlitetablemodel.h
+++ b/src/sqlitetablemodel.h
@@ -77,7 +77,7 @@ public:
     QModelIndex dittoRecord(int old_row);
 
     /// configure for browsing results of specified query
-    void setQuery(const QString& sQuery, bool dontClearHeaders = false);
+    void setQuery(const QString& sQuery, const QString& sCountQuery = QString(), bool dontClearHeaders = false);
 
     QString query() const { return m_sQuery; }
     QString customQuery(bool withRowid) const { return QString::fromStdString(m_query.buildQuery(withRowid)); }


### PR DESCRIPTION
For queries built from a table and filters, use a specialised count query
that only takes into account the where part of the statement. This will
speed-up the Browse Data tab for big tables.

See issue #1666 and last comments in #584