### PR TITLE
change ui size policy, make RU translation is shorter

### DIFF
--- a/src/EditDialog.ui
+++ b/src/EditDialog.ui
@@ -150,11 +150,6 @@
          <height>0</height>
         </size>
        </property>
-       <property name="font">
-        <font>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
        <property name="toolTip">
         <string>Import from file</string>
        </property>
@@ -174,11 +169,6 @@
          <height>0</height>
         </size>
        </property>
-       <property name="font">
-        <font>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
        <property name="toolTip">
         <string>Export to file</string>
        </property>
@@ -187,30 +177,6 @@
        </property>
        <property name="text">
         <string>&amp;Export</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="buttonNull">
-       <property name="minimumSize">
-        <size>
-         <width>50</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="font">
-        <font>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
-       <property name="toolTip">
-        <string>Set this cell to NULL</string>
-       </property>
-       <property name="whatsThis">
-        <string>Erases the contents of the cell</string>
-       </property>
-       <property name="text">
-        <string>Set as &amp;NULL</string>
        </property>
       </widget>
      </item>
@@ -282,49 +248,19 @@ Errors are indicated with a red squiggle underline.</string>
     </widget>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QLabel" name="labelType">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
          <property name="text">
           <string>Type of data currently in cell</string>
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QLabel" name="labelSize">
-         <property name="font">
-          <font>
-           <pointsize>8</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>Size of data currently in table</string>
-         </property>
-        </widget>
-       </item>
       </layout>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
+     <item row="0" column="2">
       <widget class="QPushButton" name="buttonApply">
        <property name="minimumSize">
         <size>
@@ -343,6 +279,45 @@ Errors are indicated with a red squiggle underline.</string>
        </property>
        <property name="default">
         <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="2">
+      <widget class="QPushButton" name="buttonNull">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Set this cell to NULL</string>
+       </property>
+       <property name="whatsThis">
+        <string>Erases the contents of the cell</string>
+       </property>
+       <property name="text">
+        <string>Set as &amp;NULL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="labelSize">
+       <property name="text">
+        <string>Size of data currently in table</string>
        </property>
       </widget>
      </item>
@@ -397,7 +372,6 @@ Errors are indicated with a red squiggle underline.</string>
  </widget>
  <tabstops>
   <tabstop>buttonExport</tabstop>
-  <tabstop>buttonNull</tabstop>
  </tabstops>
  <resources>
   <include location="icons/icons.qrc"/>

--- a/src/EditDialog.ui
+++ b/src/EditDialog.ui
@@ -260,7 +260,7 @@ Errors are indicated with a red squiggle underline.</string>
        </item>
       </layout>
      </item>
-     <item row="0" column="2">
+     <item row="1" column="2">
       <widget class="QPushButton" name="buttonApply">
        <property name="minimumSize">
         <size>
@@ -295,7 +295,7 @@ Errors are indicated with a red squiggle underline.</string>
        </property>
       </spacer>
      </item>
-     <item row="1" column="2">
+     <item row="0" column="2">
       <widget class="QPushButton" name="buttonNull">
        <property name="minimumSize">
         <size>

--- a/src/EditDialog.ui
+++ b/src/EditDialog.ui
@@ -31,9 +31,15 @@
      </item>
      <item>
       <widget class="QComboBox" name="comboMode">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="minimumSize">
         <size>
-         <width>0</width>
+         <width>50</width>
          <height>0</height>
         </size>
        </property>
@@ -99,9 +105,12 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::MinimumExpanding</enum>
+       </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>0</width>
          <height>20</height>
         </size>
        </property>
@@ -137,9 +146,14 @@
       <widget class="QPushButton" name="buttonImport">
        <property name="minimumSize">
         <size>
-         <width>0</width>
+         <width>50</width>
          <height>0</height>
         </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
        </property>
        <property name="toolTip">
         <string>Import from file</string>
@@ -156,9 +170,14 @@
       <widget class="QPushButton" name="buttonExport">
        <property name="minimumSize">
         <size>
-         <width>0</width>
+         <width>50</width>
          <height>0</height>
         </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
        </property>
        <property name="toolTip">
         <string>Export to file</string>
@@ -175,9 +194,14 @@
       <widget class="QPushButton" name="buttonNull">
        <property name="minimumSize">
         <size>
-         <width>0</width>
+         <width>50</width>
          <height>0</height>
         </size>
+       </property>
+       <property name="font">
+        <font>
+         <pointsize>8</pointsize>
+        </font>
        </property>
        <property name="toolTip">
         <string>Set this cell to NULL</string>
@@ -263,6 +287,11 @@ Errors are indicated with a red squiggle underline.</string>
       <layout class="QVBoxLayout" name="verticalLayout">
        <item>
         <widget class="QLabel" name="labelType">
+         <property name="font">
+          <font>
+           <pointsize>8</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Type of data currently in cell</string>
          </property>
@@ -270,6 +299,11 @@ Errors are indicated with a red squiggle underline.</string>
        </item>
        <item>
         <widget class="QLabel" name="labelSize">
+         <property name="font">
+          <font>
+           <pointsize>8</pointsize>
+          </font>
+         </property>
          <property name="text">
           <string>Size of data currently in table</string>
          </property>
@@ -292,6 +326,12 @@ Errors are indicated with a red squiggle underline.</string>
      </item>
      <item>
       <widget class="QPushButton" name="buttonApply">
+       <property name="minimumSize">
+        <size>
+         <width>50</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="toolTip">
         <string>Apply data to cell</string>
        </property>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -109,20 +109,20 @@ You can drag SQL statements from an object row and drop them into other applicat
           <item>
            <widget class="QComboBox" name="comboBrowseTable">
             <property name="sizePolicy">
-             <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>1</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
             <property name="minimumSize">
              <size>
-              <width>150</width>
+              <width>0</width>
               <height>0</height>
              </size>
             </property>
             <property name="maximumSize">
              <size>
-              <width>400</width>
+              <width>16777215</width>
               <height>16777215</height>
              </size>
             </property>
@@ -212,7 +212,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             </property>
             <property name="sizeHint" stdset="0">
              <size>
-              <width>200</width>
+              <width>40</width>
               <height>20</height>
              </size>
             </property>
@@ -220,6 +220,12 @@ You can drag SQL statements from an object row and drop them into other applicat
           </item>
           <item>
            <widget class="QToolButton" name="buttonNewRecord">
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="toolTip">
              <string>Insert a new record in the current table</string>
             </property>
@@ -233,6 +239,18 @@ You can drag SQL statements from an object row and drop them into other applicat
           </item>
           <item>
            <widget class="QToolButton" name="buttonDeleteRecord">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>50</width>
+              <height>0</height>
+             </size>
+            </property>
             <property name="toolTip">
              <string>Delete the current record</string>
             </property>

--- a/src/translations/sqlb_ru.ts
+++ b/src/translations/sqlb_ru.ts
@@ -686,7 +686,7 @@ Aborting execution%3.</source>
     <message>
         <location filename="../EditDialog.ui" line="151"/>
         <source>&amp;Import</source>
-        <translation>&amp;Импортировать</translation>
+        <translation>&amp;Импорт</translation>
     </message>
     <message>
         <source>Export text</source>
@@ -699,7 +699,7 @@ Aborting execution%3.</source>
     <message>
         <location filename="../EditDialog.ui" line="170"/>
         <source>&amp;Export</source>
-        <translation>&amp;Экспортировать</translation>
+        <translation>&amp;Экспорт</translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="183"/>


### PR DESCRIPTION
Minimum layout of the UI is to large

![sqlite_before](https://user-images.githubusercontent.com/15130560/50319768-b140ca00-04d1-11e9-8d91-cb141ec60680.png)

I'm make small changes that like a little bit smaller font at right side panel button, allows buttons crop the text, little change in left "data" combobox.

![sqlite_after](https://user-images.githubusercontent.com/15130560/50319676-37104580-04d1-11e9-903a-c5cea31d148f.png)
