### PR TITLE
Enable build against external QCustomPlot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,8 @@ if(WIN32 AND MSVC)
 	set(CMAKE_PREFIX_PATH "${QT5_PATH};${SQLITE3_PATH}")
 endif()
 
+find_package(Qt5 REQUIRED COMPONENTS Concurrent Gui LinguistTools Network PrintSupport Test Widgets Xml)
+
 if(NOT FORCE_INTERNAL_ANTLR)
     find_package(Antlr2 QUIET)
 endif()
@@ -86,8 +88,6 @@ if(NOT QCUSTOMPLOT_FOUND)
     set(QCUSTOMPLOT_DIR libs/qcustomplot-source)
     add_subdirectory(${QCUSTOMPLOT_DIR})
 endif()
-
-find_package(Qt5 REQUIRED COMPONENTS Concurrent Gui LinguistTools Network PrintSupport Test Widgets Xml)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" "${CMAKE_MODULE_PATH}"
 OPTION(ENABLE_TESTING "Enable the unit tests" OFF)
 OPTION(FORCE_INTERNAL_ANTLR "Don't use the distribution's Antlr library even if there is one" OFF)
 OPTION(FORCE_INTERNAL_QSCINTILLA "Don't use the distribution's QScintilla library even if there is one" OFF)
+OPTION(EXTERNAL_QCUSTOMPLOT "User distribution's QCustomPlot if available" OFF)
 OPTION(ALL_WARNINGS "Enable some useful warning flags" OFF)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -67,9 +68,10 @@ endif()
 if(NOT FORCE_INTERNAL_QSCINTILLA)
     find_package(QScintilla QUIET)
 endif()
-
+if(EXTERNAL_QCUSTOMPLOT)
+    find_package(QCustomPlot)
+endif()
 set(QHEXEDIT_DIR libs/qhexedit)
-set(QCUSTOMPLOT_DIR libs/qcustomplot-source)
 
 if(NOT ANTLR2_FOUND)
     set(ANTLR_DIR libs/antlr-2.7.7)
@@ -80,7 +82,10 @@ if(NOT QSCINTILLA_FOUND)
     add_subdirectory(${QSCINTILLA_DIR})
 endif()
 add_subdirectory(${QHEXEDIT_DIR})
-add_subdirectory(${QCUSTOMPLOT_DIR})
+if(NOT QCUSTOMPLOT_FOUND)
+    set(QCUSTOMPLOT_DIR libs/qcustomplot-source)
+    add_subdirectory(${QCUSTOMPLOT_DIR})
+endif()
 
 find_package(Qt5 REQUIRED COMPONENTS Concurrent Gui LinguistTools Network PrintSupport Test Widgets Xml)
 
@@ -347,9 +352,13 @@ endif()
 include_directories(
 		"${CMAKE_CURRENT_BINARY_DIR}"
 		${QHEXEDIT_DIR}
-		${QCUSTOMPLOT_DIR}
 		${ADDITIONAL_INCLUDE_PATHS}
 		src)
+if(QCUSTOMPLOT_FOUND)
+    include_directories(${QCUSTOMPLOT_INCLUDE_DIR})
+else()
+    include_directories(${QCUSTOMPLOT_DIR})
+endif()
 if(ANTLR2_FOUND)
     include_directories(${ANTLR2_INCLUDE_DIRS})
 else()
@@ -379,7 +388,10 @@ if (ALL_WARNINGS AND CMAKE_COMPILER_IS_GNUCC)
     endif()
 endif()
 
-add_dependencies(${PROJECT_NAME} qhexedit qcustomplot)
+add_dependencies(${PROJECT_NAME} qhexedit)
+if(NOT QCUSTOMPLOT_FOUND)
+    add_dependencies(${PROJECT_NAME} qcustomplot)
+endif()
 if(NOT ANTLR2_FOUND)
     add_dependencies(${PROJECT_NAME} antlr)
 endif()
@@ -389,8 +401,10 @@ endif()
 
 link_directories(
 	"${CMAKE_CURRENT_BINARY_DIR}/${QHEXEDIT_DIR}"
-	"${CMAKE_CURRENT_BINARY_DIR}/${QCUSTOMPLOT_DIR}"
 )
+if(NOT QCUSTOMPLOT_FOUND)
+    link_directories("${CMAKE_CURRENT_BINARY_DIR}/${QCUSTOMPLOT_DIR}")
+endif()
 if(NOT ANTLR2_FOUND)
     link_directories("${CMAKE_CURRENT_BINARY_DIR}/${ANTLR_DIR}")
 endif()
@@ -402,12 +416,16 @@ set(QT_LIBS Qt5::Gui Qt5::Test Qt5::PrintSupport Qt5::Widgets Qt5::Network Qt5::
 
 target_link_libraries(${PROJECT_NAME}
     qhexedit
-    qcustomplot
     ${LPTHREAD}
     ${QT_LIBS}
     ${WIN32_STATIC_LINK}
     ${LIBSQLITE}
     ${ADDITIONAL_LIBS})
+if(QCUSTOMPLOT_FOUND)
+    target_link_libraries(${PROJECT_NAME} ${QCUSTOMPLOT_LIBRARIES})
+else()
+    target_link_libraries(${PROJECT_NAME} qcustomplot)
+endif()    
 if(ANTLR2_FOUND)
     target_link_libraries(${PROJECT_NAME} ${ANTLR2_LIBRARIES})
 else()

--- a/cmake/FindQCustomPlot.cmake
+++ b/cmake/FindQCustomPlot.cmake
@@ -1,0 +1,46 @@
+# - try to find QCustomPlot
+# Once done this will define:
+#
+#  QCUSTOMPLOT_FOUND - system has QCustomPlot
+#  QCUSTOMPLOT_INCLUDE_DIRS - the include directories for QCustomPlot
+#  QCUSTOMPLOT_LIBRARIES - Link these to use QCustomPlot
+
+# Copyright (C) 2019, Scott Furry, <scott.wl.furry@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+# 3. The name of the author may not be used to endorse or promote products
+#    derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+# NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+# THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+find_library(QCUSTOMPLOT_LIBRARY qcustomplot)
+set(QCUSTOMPLOT_LIBRARIES "${QCUSTOMPLOT_LIBRARY}")
+
+find_path(QCUSTOMPLOT_INCLUDE_DIR qcustomplot.h)
+set(QCUSTOMPLOT_INCLUDE_DIRS "${QCUSTOMPLOT_INCLUDE_DIR}")
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(QCUSTOMPLOT DEFAULT_MSG QCUSTOMPLOT_LIBRARIES QCUSTOMPLOT_INCLUDE_DIRS)
+
+mark_as_advanced(
+  QCUSTOMPLOT_INCLUDE_DIRS
+  QCUSTOMPLOT_LIBRARIES
+)

--- a/cmake/FindQScintilla.cmake
+++ b/cmake/FindQScintilla.cmake
@@ -44,7 +44,9 @@
 
 
 find_path ( QSCINTILLA_INCLUDE_DIR qsciscintilla.h
-  HINTS /usr/local/include/Qsci /usr/local/opt/qscintilla2/include/Qsci
+  HINTS /usr/local/include/Qsci
+        /usr/local/opt/qscintilla2/include/Qsci
+        ${Qt5Widgets_INCLUDE_DIRS}/Qsci
 )
 
 set ( QSCINTILLA_INCLUDE_DIRS ${QSCINTILLA_INCLUDE_DIR} )
@@ -79,7 +81,9 @@ endif ()
 
 find_library ( QSCINTILLA_LIBRARY
   NAMES qscintilla2 qscintilla2_qt5
-  HINTS /usr/local/lib /usr/local/opt/qscintilla2/lib
+  HINTS /usr/local/lib
+        /usr/local/opt/qscintilla2/lib
+        ${Qt5Widgets_LIBRARIES}
 )
 
 set ( QSCINTILLA_LIBRARIES ${QSCINTILLA_LIBRARY} )


### PR DESCRIPTION
Feature request - #1782 
Source-based distributions have QCustomPlot available.
Modify build instructions to use external or fallback to internal if not found.

Change makes available the "EXTERNAL_QCUSTOMPLOT" flag (default OFF).
Methodology employed is derived from and similar to Antlr2 searching