### PR TITLE
Improve FindQScintilla.cmake functioning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,11 +61,13 @@ if(WIN32 AND MSVC)
 	set(CMAKE_PREFIX_PATH "${QT5_PATH};${SQLITE3_PATH}")
 endif()
 
+find_package(Qt5 REQUIRED COMPONENTS Concurrent Gui LinguistTools Network PrintSupport Test Widgets Xml)
+
 if(NOT FORCE_INTERNAL_ANTLR)
     find_package(Antlr2 QUIET)
 endif()
 if(NOT FORCE_INTERNAL_QSCINTILLA)
-    find_package(QScintilla QUIET)
+    find_package(QScintilla 2.8.10 QUIET)
 endif()
 
 set(QHEXEDIT_DIR libs/qhexedit)
@@ -81,8 +83,6 @@ if(NOT QSCINTILLA_FOUND)
 endif()
 add_subdirectory(${QHEXEDIT_DIR})
 add_subdirectory(${QCUSTOMPLOT_DIR})
-
-find_package(Qt5 REQUIRED COMPONENTS Concurrent Gui LinguistTools Network PrintSupport Test Widgets Xml)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/cmake/FindQScintilla.cmake
+++ b/cmake/FindQScintilla.cmake
@@ -42,9 +42,23 @@
 # either expressed or implied, of the FreeBSD Project.
 #=============================================================================
 
-
+# When using pkg-config, paths may contain odd slash placement. Each
+# include directory is pre-processed here. Resultant list variable
+# then used for search hinting. Depends on successful find_package(Qt5).
+set(Qt5QScintillaHintDirs)
+if(UNIX)
+    foreach(item ${Qt5Widgets_INCLUDE_DIRS})
+        # remove slash at end of line
+        STRING(REGEX REPLACE "\\/$" "" item ${item})
+        # replace double slashes is single slashes
+        STRING(REGEX REPLACE "\\/\\/" "/" item ${item})
+        list(APPEND Qt5QScintillaHintDirs "${item}/Qsci")
+    endforeach()
+endif()
 find_path ( QSCINTILLA_INCLUDE_DIR qsciscintilla.h
-  HINTS /usr/local/include/Qsci /usr/local/opt/qscintilla2/include/Qsci
+  HINTS /usr/local/include/Qsci
+        /usr/local/opt/qscintilla2/include/Qsci
+        ${Qt5QScintillaHintDirs}
 )
 
 set ( QSCINTILLA_INCLUDE_DIRS ${QSCINTILLA_INCLUDE_DIR} )


### PR DESCRIPTION
Changes depend on successful find_package(Qt5...) call and when
building against external QScintilla.

Modified FindQScintilla.cmake providing extra hints of locations
to search for needed header files. Hints include paths based on
where Qt5 is installed. Presuming Unix/Linux distributions will
put QScintilla header files under Qt5 header folders.

Also, ensure building against external QScintilla is at or above minimum required version.