### PR TITLE
Resolve -Wsign-conversion Warning Messages:

### DIFF
--- a/src/AddRecordDialog.cpp
+++ b/src/AddRecordDialog.cpp
@@ -198,7 +198,7 @@ void AddRecordDialog::populateFields()
         pk = QStringList(pseudo_pk);
     }
 
-    for(uint i = 0; i < fields.size(); i++)
+    for(size_t i = 0; i < fields.size(); i++)
     {
         const sqlb::Field& f = fields[i];
         QTreeWidgetItem *tbitem = new QTreeWidgetItem(ui->treeWidget);
@@ -217,7 +217,7 @@ void AddRecordDialog::populateFields()
         }
         if (contains(pk, f.name()))
             tbitem->setIcon(kName, QIcon(":/icons/field_key"));
-        else if (fks[i])
+        else if (fks.at(static_cast<int>(i)))
             tbitem->setIcon(kName, QIcon(":/icons/field_fk"));
         else
             tbitem->setIcon(kName, QIcon(":/icons/field"));
@@ -234,7 +234,7 @@ void AddRecordDialog::populateFields()
         if (!f.check().isEmpty())
             toolTip.append(tr("Check constraint:\t %1\n").arg (f.check()));
 
-        auto fk = std::dynamic_pointer_cast<sqlb::ForeignKeyClause>(fks[i]);
+        auto fk = std::dynamic_pointer_cast<sqlb::ForeignKeyClause>(fks.at(static_cast<int>(i)));
         if(fk)
             toolTip.append(tr("Foreign key:\t %1\n").arg(fk->toString()));
 

--- a/src/EditTableDialog.cpp
+++ b/src/EditTableDialog.cpp
@@ -261,9 +261,9 @@ bool EditTableDialog::eventFilter(QObject *object, QEvent *event)
 void EditTableDialog::itemChanged(QTreeWidgetItem *item, int column)
 {
     int index = ui->treeWidget->indexOfTopLevelItem(item);
-    if(index < static_cast<int>(m_table.fields.size()))
+    if((index < static_cast<int>(m_table.fields.size())) && (index >= 0))
     {
-        sqlb::Field& field = m_table.fields.at(index);
+        sqlb::Field& field = m_table.fields.at(static_cast<size_t>(index));
         QString oldFieldName = field.name();
 
         switch(column)
@@ -528,7 +528,7 @@ void EditTableDialog::addField()
     // Find an unused name for the field by starting with 'Fieldx' where x is the number of fields + 1.
     // If this name happens to exist already, increase x by one until we find an unused name.
     {
-        unsigned int field_number = ui->treeWidget->topLevelItemCount();
+        unsigned int field_number = static_cast<unsigned int>(ui->treeWidget->topLevelItemCount());
         QString field_name;
         do
         {
@@ -633,8 +633,11 @@ void EditTableDialog::moveDown()
 void EditTableDialog::moveCurrentField(bool down)
 {
     int currentRow = ui->treeWidget->currentIndex().row();
+	if(currentRow < 0 )
+		return;
     int newRow = currentRow + (down ? 1 : -1);
-
+	if(newRow < 0)
+		return;
     // Save the combobox first by making a copy
     QComboBox* oldCombo = qobject_cast<QComboBox*>(ui->treeWidget->itemWidget(ui->treeWidget->topLevelItem(currentRow), kType));
     QComboBox* newCombo = new QComboBox(ui->treeWidget);
@@ -655,7 +658,8 @@ void EditTableDialog::moveCurrentField(bool down)
     ui->treeWidget->setCurrentIndex(ui->treeWidget->currentIndex().sibling(newRow, 0));
 
     // Finally update the table SQL
-    std::swap(m_table.fields[newRow], m_table.fields[currentRow]);
+    std::swap(m_table.fields.at(static_cast<size_t>(newRow)),
+			  m_table.fields.at(static_cast<size_t>(currentRow)));
 
     // Update the SQL preview
     updateSqlText();

--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -149,7 +149,8 @@ QWidget* ExtendedTableWidgetEditorDelegate::createEditor(QWidget* parent, const 
 
         // if the current column of the current table does NOT have not-null constraint,
         // the NULL is united to the query to get the possible values in the combo-box.
-        if (!currentTable->fields.at(index.column()-1).notnull())
+        if ((( index.column() - 1 ) >= 0) &&
+			(!currentTable->fields.at(static_cast<size_t>(index.column() - 1)).notnull()))
             query.append (" UNION SELECT NULL");
 
         SqliteTableModel* fkModel = new SqliteTableModel(m->db(), parent, m->chunkSize(), m->encoding());

--- a/src/ForeignKeyEditorDelegate.cpp
+++ b/src/ForeignKeyEditorDelegate.cpp
@@ -123,7 +123,7 @@ void ForeignKeyEditorDelegate::setEditorData(QWidget* editor, const QModelIndex&
     ForeignKeyEditor* fkEditor = static_cast<ForeignKeyEditor*>(editor);
 
     int column = index.row(); // weird? I know right
-    const sqlb::Field& field = m_table.fields.at(column);
+    const sqlb::Field& field = m_table.fields.at(static_cast<size_t>(column));
     auto fk = std::dynamic_pointer_cast<sqlb::ForeignKeyClause>(m_table.constraint({field.name()}, sqlb::Constraint::ForeignKeyConstraintType));
     if (fk) {
         fkEditor->tablesComboBox->setCurrentText(fk->table());
@@ -141,7 +141,7 @@ void ForeignKeyEditorDelegate::setModelData(QWidget* editor, QAbstractItemModel*
     QString sql = fkEditor->getSql();
 
     int column = index.row();
-    const sqlb::Field& field = m_table.fields.at(column);
+    const sqlb::Field& field = m_table.fields.at(static_cast<size_t>(column));
     if (sql.isEmpty()) {
         // Remove the foreign key
         m_table.removeConstraints({field.name()}, sqlb::Constraint::ConstraintTypes::ForeignKeyConstraintType);

--- a/src/ImportCsvDialog.cpp
+++ b/src/ImportCsvDialog.cpp
@@ -377,8 +377,8 @@ CSVParser::ParserResult ImportCsvDialog::parseCSV(const QString &fileName, std::
     CSVParser csv(ui->checkBoxTrimFields->isChecked(), currentSeparatorChar(), currentQuoteChar());
 
     // Only show progress dialog if we parse all rows. The assumption here is that if a row count limit has been set, it won't be a very high one.
-    if(count == 0)
-        csv.setCSVProgress(new CSVImportProgress(file.size()));
+    if(( count == 0 ) && (file.size() >= 0))
+        csv.setCSVProgress(new CSVImportProgress(static_cast<size_t>(file.size())));
 
     QTextStream tstream(&file);
     tstream.setCodec(currentEncoding().toUtf8());

--- a/src/PlotDock.cpp
+++ b/src/PlotDock.cpp
@@ -359,8 +359,8 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                 }
 
                 // Line type and point shape are not supported by the String X type (Bars)
-                ui->comboLineType->setEnabled(xtype != QVariant::String);
-                ui->comboPointShape->setEnabled(xtype != QVariant::String);
+                ui->comboLineType->setEnabled(xtype != static_cast<int>(QVariant::String));
+                ui->comboPointShape->setEnabled(xtype != static_cast<int>(QVariant::String));
 
                 // WARN: ssDot is removed
                 int shapeIdx = ui->comboPointShape->currentIndex();
@@ -373,7 +373,8 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                 // When it is not sorted by x, we draw a curve, so the order selected by the user in the table or in the query is
                 // respected.  In this case the line will have loops and only None and Line is supported as line style.
                 // TODO: how to make the user aware of this without disturbing.
-                if (xtype == QVariant::String) {
+                if (xtype == static_cast<int>(QVariant::String))
+				{
                     QCPBars* bars = new QCPBars(ui->plotWidget->xAxis, ui->plotWidget->yAxis);
                     plottable = bars;
                     bars->setData(xdata, ydata);
@@ -519,7 +520,8 @@ void PlotDock::on_treePlotColumns_itemDoubleClicked(QTreeWidgetItem* item, int c
 
     int type = item->data(PlotColumnType, Qt::UserRole).toInt();
 
-    if(column == PlotColumnY && type == QVariant::Double)
+    if((column == PlotColumnY) &&
+	   (type == static_cast<int>(QVariant::Double)))
     {
         // On double click open the colordialog
         QColorDialog colordialog(this);

--- a/src/SqlExecutionArea.cpp
+++ b/src/SqlExecutionArea.cpp
@@ -21,7 +21,7 @@ SqlExecutionArea::SqlExecutionArea(DBBrowserDB& _db, QWidget* parent) :
     ui->setupUi(this);
 
     // Create model
-    model = new SqliteTableModel(db, this, Settings::getValue("db", "prefetchsize").toInt());
+    model = new SqliteTableModel(db, this, Settings::getValue("db", "prefetchsize").toUInt());
     ui->tableResult->setModel(model);
     connect(model, &SqliteTableModel::finishedFetch, this, &SqlExecutionArea::fetchedData);
 
@@ -131,7 +131,7 @@ void SqlExecutionArea::reloadSettings()
         ui->splitter->setOrientation(Qt::Vertical);
 
     // Set prefetch settings
-    model->setChunkSize(Settings::getValue("db", "prefetchsize").toInt());
+    model->setChunkSize(Settings::getValue("db", "prefetchsize").toUInt());
 
     // Check if error indicators are enabled for the not-ok background clue
     showErrorIndicators = Settings::getValue("editor", "error_indicators").toBool();

--- a/src/sql/Query.cpp
+++ b/src/sql/Query.cpp
@@ -25,10 +25,10 @@ std::string Query::buildWherePart() const
     {
         where = "WHERE ";
 
-        for(auto i=m_where.cbegin();i!=m_where.cend();++i)
+        for(auto i = m_where.cbegin(); i != m_where.cend(); ++i)
         {
-            const auto it = findSelectedColumnByName(m_column_names.at(i->first));
-            std::string column = sqlb::escapeIdentifier(m_column_names.at(i->first));
+            const auto it = findSelectedColumnByName(m_column_names.at(static_cast<size_t>(i->first)));
+            std::string column = sqlb::escapeIdentifier(m_column_names.at(static_cast<size_t>(i->first)));
             if(it != m_selected_columns.cend() && it->selector != column)
                 column = it->selector;
             where += column + " " + i->second + " AND ";
@@ -68,8 +68,9 @@ std::string Query::buildQuery(bool withRowid) const
     std::string order_by;
     for(const auto& sorted_column : m_sort)
     {
-        if(sorted_column.column < m_column_names.size())
-            order_by += sqlb::escapeIdentifier(m_column_names.at(sorted_column.column)) + " "
+        if(static_cast<size_t>(sorted_column.column) < m_column_names.size())
+            order_by += sqlb::escapeIdentifier(m_column_names.at(static_cast<size_t>(sorted_column.column)))
+					+ " "
                     + (sorted_column.direction == sqlb::Ascending ? "ASC" : "DESC") + ",";
     }
     if(order_by.size())


### PR DESCRIPTION
Building with Project Flag -DALL_WARNINGS=True, compiler flagged
numerous lines where there were implicit value conversions. These lines
were function calls that had arguments, for the most part, expecting
integer sign change.

Passed values were explicitly converted (static_cast). Where possible,
tests of variables were added to ensure contents were acceptable to
function call.

If problem occurred with QVariant.toInt() call, the .toUInt() function
was used instead. Note: this does not resolve whether QVariant stores
a negative value in the first place.

Std keyword `auto` replaced when compiler is unable to determine type
to use because of multiple types in assignment statement.

NOTE: -Wsign-conversion warnings in the following files were untouched:
[project root]/src/RowCache.h
[project root]/src/csvparser.cpp
[project root]/src/sqlitedb.cpp
[project root]/src/grammar/Sqlite3Lexer.cpp
(previously discussed in #1788)
[project root]/src/grammar/Sqlite3Parser.cpp
(previously discussed in #1788)

Note: index accessor to std::vector elements uses size_type
<aka long unsigned int>
while QVector element accessors utilize integer.