### PR TITLE
Visual sort indicators for multi-column sorting

### DIFF
--- a/src/FilterTableHeader.cpp
+++ b/src/FilterTableHeader.cpp
@@ -10,7 +10,8 @@ FilterTableHeader::FilterTableHeader(QTableView* parent) :
 {
     // Activate the click signals to allow sorting
     setSectionsClickable(true);
-    setSortIndicatorShown(true);
+    // But use our own indicators allowing multi-column sorting
+    setSortIndicatorShown(false);
 
     // Do some connects: Basically just resize and reposition the input widgets whenever anything changes
     connect(this, SIGNAL(sectionResized(int,int,int)), this, SLOT(adjustPositions()));

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -746,9 +746,6 @@ void MainWindow::populateTable()
         for(int i=1;i<m_browseTableModel->columnCount();i++)
             ui->dataTable->setColumnWidth(i, ui->dataTable->horizontalHeader()->defaultSectionSize());
 
-        // Sorting
-        ui->dataTable->filterHeader()->setSortIndicator(0, Qt::AscendingOrder);
-
         // Encoding
         m_browseTableModel->setEncoding(defaultBrowseTableEncoding);
 
@@ -845,15 +842,6 @@ void MainWindow::applyBrowseTableSettings(BrowseDataTableSettings storedData, bo
     // Column widths
     for(auto widthIt=storedData.columnWidths.constBegin();widthIt!=storedData.columnWidths.constEnd();++widthIt)
         ui->dataTable->setColumnWidth(widthIt.key(), widthIt.value());
-
-    // Sorting
-    // For now just use the first sort column for the sort indicator
-    if(storedData.query.orderBy().size())
-    {
-        ui->dataTable->filterHeader()->setSortIndicator(
-                    storedData.query.orderBy().front().column,
-                    storedData.query.orderBy().front().direction == sqlb::Ascending ? Qt::AscendingOrder : Qt::DescendingOrder);
-    }
 
     // Filters
     if(!skipFilters)

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -222,9 +222,6 @@ You can drag SQL statements from an object row and drop them into other applicat
           <property name="selectionMode">
            <enum>QAbstractItemView::ContiguousSelection</enum>
           </property>
-          <attribute name="horizontalHeaderShowSortIndicator" stdset="0">
-           <bool>true</bool>
-          </attribute>
          </widget>
         </item>
         <item>

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -221,16 +221,16 @@ int SqliteTableModel::filterCount() const
 static QString toSuperScript(int number)
 {
     QString superScript = QString::number(number);
-    superScript.replace('0', u'⁰');
-    superScript.replace('1', u'¹');
-    superScript.replace('2', u'²');
-    superScript.replace('3', u'³');
-    superScript.replace('4', u'⁴');
-    superScript.replace('5', u'⁵');
-    superScript.replace('6', u'⁶');
-    superScript.replace('7', u'⁷');
-    superScript.replace('8', u'⁸');
-    superScript.replace('9', u'⁹');
+    superScript.replace("0", "⁰");
+    superScript.replace("1", "¹");
+    superScript.replace("2", "²");
+    superScript.replace("3", "³");
+    superScript.replace("4", "⁴");
+    superScript.replace("5", "⁵");
+    superScript.replace("6", "⁶");
+    superScript.replace("7", "⁷");
+    superScript.replace("8", "⁸");
+    superScript.replace("9", "⁹");
     return superScript;
 }
 


### PR DESCRIPTION
This adds visual sort indicators to the already working multi-column
sorting. Qt sort indicator is disabled, so only one indicator per column
is visible.

Unicode characters are used to indicate direction (triangles) and sort
column order (superscript numbers).

See issue #1761