### PR TITLE
Resolve sign conversion warnings - prefetch preference

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -91,12 +91,11 @@ static std::vector<sqlb::SortedColumn> toSortOrderVector(int index, Qt::SortOrde
     return vector;
 }
 
-
 MainWindow::MainWindow(QWidget* parent)
     : QMainWindow(parent),
       ui(new Ui::MainWindow),
       db(),
-      m_browseTableModel(new SqliteTableModel(db, this, Settings::getValue("db", "prefetchsize").toInt())),
+      m_browseTableModel(new SqliteTableModel(db, this, static_cast<std::size_t>(Settings::getValue("db", "prefetchsize").toUInt()))),
       m_currentTabTableModel(m_browseTableModel),
       m_remoteDb(new RemoteDatabase),
       editDock(new EditDialog(this)),
@@ -2444,7 +2443,7 @@ void MainWindow::reloadSettings()
     ui->toolbarSql->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue("General", "toolbarStyleSql").toInt()));
 
     // Set prefetch sizes for lazy population of table models
-    m_browseTableModel->setChunkSize(Settings::getValue("db", "prefetchsize").toInt());
+    m_browseTableModel->setChunkSize(static_cast<std::size_t>(Settings::getValue("db", "prefetchsize").toUInt()));
     for(int i=0;i<ui->tabSqlAreas->count();++i)
         qobject_cast<SqlExecutionArea*>(ui->tabSqlAreas->widget(i))->reloadSettings();
 

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -74,7 +74,7 @@ QVariant Settings::getDefaultValue(const QString& group, const QString& name)
 
     // db/prefetchsize?
     if(group == "db" && name == "prefetchsize")
-        return 50000;
+        return 50000U;
 
     // db/defaultsqltext?
     if(group == "db" && name == "defaultsqltext")

--- a/src/SqlExecutionArea.cpp
+++ b/src/SqlExecutionArea.cpp
@@ -22,7 +22,7 @@ SqlExecutionArea::SqlExecutionArea(DBBrowserDB& _db, QWidget* parent) :
     ui->setupUi(this);
 
     // Create model
-    model = new SqliteTableModel(db, this, Settings::getValue("db", "prefetchsize").toInt());
+    model = new SqliteTableModel(db, this, static_cast<std::size_t>(Settings::getValue("db", "prefetchsize").toUInt()));
     ui->tableResult->setModel(model);
     connect(model, &SqliteTableModel::finishedFetch, this, &SqlExecutionArea::fetchedData);
 
@@ -88,7 +88,7 @@ void SqlExecutionArea::fetchedData()
 
     // Set column widths according to their contents but make sure they don't exceed a certain size
     ui->tableResult->resizeColumnsToContents();
-    for(int i=0;i<model->columnCount();i++)
+    for(int i = 0; i < model->columnCount(); i++)
     {
         if(ui->tableResult->columnWidth(i) > 300)
             ui->tableResult->setColumnWidth(i, 300);
@@ -135,7 +135,7 @@ void SqlExecutionArea::reloadSettings()
         ui->splitter->setOrientation(Qt::Vertical);
 
     // Set prefetch settings
-    model->setChunkSize(Settings::getValue("db", "prefetchsize").toInt());
+    model->setChunkSize(static_cast<std::size_t>(Settings::getValue("db", "prefetchsize").toUInt()));
 
     // Check if error indicators are enabled for the not-ok background clue
     showErrorIndicators = Settings::getValue("editor", "error_indicators").toBool();

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -200,7 +200,7 @@ void SqliteTableModel::setQuery(const QString& sQuery, const QString& sCountQuer
         m_headers.append(getColumns(worker->getDb(), sQuery, m_vDataTypes));
 
     // now fetch the first entries
-    triggerCacheLoad(m_chunkSize / 2 - 1);
+    triggerCacheLoad(static_cast<int>(m_chunkSize / 2) - 1);
 
     emit layoutChanged();
 }
@@ -872,11 +872,13 @@ bool SqliteTableModel::isEditable() const
 
 void SqliteTableModel::triggerCacheLoad (int row) const
 {
-    size_t row_begin = std::max(0, row - int(m_chunkSize) / 2);
-    size_t row_end = row + m_chunkSize / 2;
+    int halfChunk = static_cast<int>( m_chunkSize / 2);
+    size_t row_begin = static_cast<std::size_t>(std::max(0, row - halfChunk));
+    size_t row_end = static_cast<std::size_t>(row + halfChunk);
 
-    if(rowCountAvailable() == RowCount::Complete) {
-        row_end = std::min(row_end, size_t(rowCount()));
+    if(rowCountAvailable() == RowCount::Complete)
+    {
+        row_end = std::min(row_end, static_cast<std::size_t>(rowCount()));
     } else {
         // will be truncated by reader
     }
@@ -909,7 +911,7 @@ bool SqliteTableModel::completeCache () const
     waitUntilIdle();
 
     // This loop fetches all data by loading it block by block into the cache
-    for(int i=0;i<rowCount()+static_cast<int>(m_chunkSize)/2;i+=m_chunkSize)
+    for(int i = 0; i < (rowCount() + static_cast<int>( m_chunkSize / 2)); i += static_cast<int>(m_chunkSize))
     {
         progress.setValue(i);
         qApp->processEvents();


### PR DESCRIPTION
Resolve sign conversion warnings - prefetch preference

Resolve warnings that occur when building w/ ALL_WARNINGS enabled. Source tree
examined to enusre prefetch size is handled as type std::size_t. Also, tree was
modified correcting handling of the chunkSize variable in sqlitetablemodel that
uses the prefetch preference setting.

Also, some minor editing of sources was taken to improve readability
as well as consistency.