### PR TITLE
During GCC build, series of warning messages regarding shadowed varia…

### DIFF
--- a/src/sql/sqlitetypes.cpp
+++ b/src/sql/sqlitetypes.cpp
@@ -462,49 +462,49 @@ std::string Table::sql(const std::string& schema, bool ifNotExists) const
     return sql + ";";
 }
 
-void Table::addConstraint(const StringVector& fields, ConstraintPtr constraint)
+void Table::addConstraint(const StringVector& vStrFields, ConstraintPtr constraint)
 {
-    m_constraints.insert({fields, constraint});
+    m_constraints.insert({vStrFields, constraint});
 }
 
-void Table::setConstraint(const StringVector& fields, ConstraintPtr constraint)
+void Table::setConstraint(const StringVector& vStrFields, ConstraintPtr constraint)
 {
     // Delete any old constraints of this type for these fields
-    removeConstraints(fields, constraint->type());
+    removeConstraints(vStrFields, constraint->type());
 
     // Add the new constraint to the table, effectively overwriting all old constraints for that fields/type combination
-    addConstraint(fields, constraint);
+    addConstraint(vStrFields, constraint);
 }
 
-void Table::removeConstraints(const StringVector& fields, Constraint::ConstraintTypes type)
+void Table::removeConstraints(const StringVector& vStrFields, Constraint::ConstraintTypes type)
 {
     for(auto it = m_constraints.begin();it!=m_constraints.end();)
     {
-        if(it->first == fields && it->second->type() == type)
+        if(it->first == vStrFields && it->second->type() == type)
             m_constraints.erase(it++);
         else
             ++it;
     }
 }
 
-ConstraintPtr Table::constraint(const StringVector& fields, Constraint::ConstraintTypes type) const
+ConstraintPtr Table::constraint(const StringVector& vStrFields, Constraint::ConstraintTypes type) const
 {
-    auto list = constraints(fields, type);
+    auto list = constraints(vStrFields, type);
     if(list.size())
         return list.at(0);
     else
         return ConstraintPtr(nullptr);
 }
 
-std::vector<ConstraintPtr> Table::constraints(const StringVector& fields, Constraint::ConstraintTypes type) const
+std::vector<ConstraintPtr> Table::constraints(const StringVector& vStrFields, Constraint::ConstraintTypes type) const
 {
     ConstraintMap::const_iterator begin, end;
-    if(fields.empty())
+    if(vStrFields.empty())
     {
         begin = m_constraints.begin();
         end = m_constraints.end();
     } else {
-        std::tie(begin, end) = m_constraints.equal_range(fields);
+        std::tie(begin, end) = m_constraints.equal_range(vStrFields);
     }
 
     std::vector<ConstraintPtr> clist;

--- a/src/sql/sqlitetypes.h
+++ b/src/sql/sqlitetypes.h
@@ -329,11 +329,11 @@ public:
 
     FieldInfoList fieldInformation() const override;
 
-    void addConstraint(const StringVector& fields, ConstraintPtr constraint);
-    void setConstraint(const StringVector& fields, ConstraintPtr constraint);
-    void removeConstraints(const StringVector& fields = StringVector(), Constraint::ConstraintTypes type = Constraint::NoType); //! Only removes the first constraint, if any
-    ConstraintPtr constraint(const StringVector& fields = StringVector(), Constraint::ConstraintTypes type = Constraint::NoType) const;   //! Only returns the first constraint, if any
-    std::vector<ConstraintPtr> constraints(const StringVector& fields = StringVector(), Constraint::ConstraintTypes type = Constraint::NoType) const;
+    void addConstraint(const StringVector& vStrFields, ConstraintPtr constraint);
+    void setConstraint(const StringVector& vStrFields, ConstraintPtr constraint);
+    void removeConstraints(const StringVector& vStrFields = StringVector(), Constraint::ConstraintTypes type = Constraint::NoType); //! Only removes the first constraint, if any
+    ConstraintPtr constraint(const StringVector& vStrFields = StringVector(), Constraint::ConstraintTypes type = Constraint::NoType) const;   //! Only returns the first constraint, if any
+    std::vector<ConstraintPtr> constraints(const StringVector& vStrFields = StringVector(), Constraint::ConstraintTypes type = Constraint::NoType) const;
     ConstraintMap allConstraints() const { return m_constraints; }
     void setConstraints(const ConstraintMap& constraints);
     StringVector& primaryKeyRef();


### PR DESCRIPTION
During GCC build, series of warning messages regarding shadowed variables were produced. Messages would take the form:

[SQLB root]/src/sql/sqlitetypes.cpp:465:79: warning: declaration of ‘fields’ shadows a member of ‘sqlb::Table’ [-Wshadow]

and reference

[SQLB root]/src/sql/sqlitetypes.h:310:17: note: shadowed declaration is here
     FieldVector fields;

All incidents isolated to [SQLDB root]/src/sql/sqlitetypes.{h,cpp}.
Change renames local variables to silence warnings.

No errors after execution w/ gcc/clang builds on Linux.