### PR TITLE
Normalize qhexedit.h include path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ else()
     find_package(QCustomPlot)
 endif()
 set(QHEXEDIT_DIR libs/qhexedit)
+set(QHEXEDIT_INCL_DIR ${QHEXEDIT_DIR}/src)
 set(JSON_DIR libs/json)
 
 if(NOT ANTLR2_FOUND)
@@ -360,7 +361,7 @@ endif()
 
 include_directories(
 		"${CMAKE_CURRENT_BINARY_DIR}"
-		${QHEXEDIT_DIR}
+		${QHEXEDIT_INCL_DIR}
 		${JSON_DIR}
 		${ADDITIONAL_INCLUDE_PATHS}
 		src)

--- a/src/EditDialog.cpp
+++ b/src/EditDialog.cpp
@@ -2,7 +2,7 @@
 #include "ui_EditDialog.h"
 #include "sqlitedb.h"
 #include "Settings.h"
-#include "src/qhexedit.h"
+#include "qhexedit.h"
 #include "docktextedit.h"
 #include "FileDialog.h"
 #include "Data.h"


### PR DESCRIPTION
Include path used for QHexEdit in EditDialog.cpp is "implementation specific"
to how DB4S uses the QHexEdit library. Change is to make usage of library
more generic.