### PR TITLE
Centralize File Filter and Resolve End CSV Import Message

### DIFF
--- a/src/EditDialog.cpp
+++ b/src/EditDialog.cpp
@@ -289,11 +289,12 @@ void EditDialog::importData()
     image_formats.chop(1);
 
     QStringList filters;
-    filters << tr("Text files (*.txt)") <<
-        tr("JSON files (*.json)") <<
-        tr("XML files (*.xml)") <<
-        tr("Image files (%1)").arg(image_formats) <<
-        tr("Binary files (*.bin)") << tr("All files (*)");
+    filters << FILE_FILTER_TXT
+            << FILE_FILTER_JSON
+            << FILE_FILTER_XML
+            << tr("Image files (%1)").arg(image_formats)
+            << FILE_FILTER_BIN
+            << FILE_FILTER_ALL;
 
     QString selectedFilter;
 
@@ -303,19 +304,19 @@ void EditDialog::importData()
     // Set as selected filter the appropriate for the current mode.
     switch (mode) {
     case TextEditor:
-        selectedFilter = tr("Text files (*.txt)");
+        selectedFilter = FILE_FILTER_TXT;
         break;
     case HexEditor:
-        selectedFilter = tr("Binary files (*.bin)");
+        selectedFilter = FILE_FILTER_BIN;
         break;
     case ImageViewer:
         selectedFilter = tr("Image files (%1)").arg(image_formats);
         break;
     case JsonEditor:
-        selectedFilter = tr("JSON files (*.json)");
+        selectedFilter = FILE_FILTER_JSON;
         break;
     case XmlEditor:
-        selectedFilter = tr("XML files (*.xml)");
+        selectedFilter = FILE_FILTER_XML;
         break;
     }
     QString fileName = FileDialog::getOpenFileName(
@@ -363,27 +364,29 @@ void EditDialog::exportData()
     case Text:
         // Include the XML case on the text data type, since XML detection is not very sofisticated.
         if (ui->comboMode->currentIndex() == XmlEditor)
-            filters << tr("XML files (*.xml)") << tr("Text files (*.txt)");
+            filters << FILE_FILTER_XML
+                    << FILE_FILTER_TXT;
         else
-            filters << tr("Text files (*.txt)") << tr("XML files (*.xml)");
+            filters << FILE_FILTER_TXT
+                    << FILE_FILTER_XML;
         break;
     case JSON:
-        filters << tr("JSON files (*.json)");
+        filters << FILE_FILTER_JSON;
         break;
     case SVG:
-        filters << tr("SVG files (*.svg)");
+        filters << FILE_FILTER_SVG;
         break;
     case XML:
-        filters << tr("XML files (*.xml)");
+        filters << FILE_FILTER_XML;
         break;
     case Null:
         return;
     }
 
     if (dataSource == HexBuffer)
-        filters << tr("Hex dump files (*.txt)");
+        filters << FILE_FILTER_HEX;
 
-    filters << tr("All files (*)");
+    filters << FILE_FILTER_ALL;
 
     QString selectedFilter = filters.first();
     QString fileName = FileDialog::getSaveFileName(
@@ -402,7 +405,7 @@ void EditDialog::exportData()
           case HexBuffer:
               // Data source is the hex buffer
               // If text option has been selected, the readable representation of the content is saved to file.
-              if (selectedFilter == tr("Hex dump files (*.txt)"))
+              if (selectedFilter == FILE_FILTER_HEX)
                   file.write(hexEdit->toReadableString().toUtf8());
               else
                   file.write(hexEdit->data());

--- a/src/ExportDataDialog.cpp
+++ b/src/ExportDataDialog.cpp
@@ -296,17 +296,23 @@ bool ExportDataDialog::exportQueryJson(const QString& sQuery, const QString& sFi
 
 void ExportDataDialog::accept()
 {
-    QString file_dialog_filter;
+    QStringList file_dialog_filter;
     QString default_file_extension;
     switch(m_format)
     {
     case ExportFormatCsv:
-        file_dialog_filter = tr("Text files(*.csv *.txt)");
-        default_file_extension = ".csv";
+        file_dialog_filter << FILE_FILTER_CSV
+                           << FILE_FILTER_TSV
+                           << FILE_FILTER_DSV
+                           << FILE_FILTER_TXT
+                           << FILE_FILTER_ALL;
+        default_file_extension = FILE_EXT_CSV_DEFAULT;
         break;
     case ExportFormatJson:
-        file_dialog_filter = tr("Text files(*.json *.js *.txt)");
-        default_file_extension = ".json";
+        file_dialog_filter << FILE_FILTER_JSON
+                           << FILE_FILTER_TXT
+                           << FILE_FILTER_ALL;
+        default_file_extension = FILE_EXT_JSON_DEFAULT;
         break;
     }
 
@@ -317,7 +323,7 @@ void ExportDataDialog::accept()
                 CreateDataFile,
                 this,
                 tr("Choose a filename to export data"),
-                file_dialog_filter);
+                file_dialog_filter.join(";;"));
         if(sFilename.isEmpty())
         {
             close();
@@ -344,7 +350,7 @@ void ExportDataDialog::accept()
                     CreateDataFile,
                     this,
                     tr("Choose a filename to export data"),
-                    file_dialog_filter,
+                    file_dialog_filter.join(";;"),
                     selectedItems.at(0)->text() + default_file_extension);
             if(fileName.isEmpty())
             {

--- a/src/ExportSqlDialog.cpp
+++ b/src/ExportSqlDialog.cpp
@@ -78,15 +78,15 @@ void ExportSqlDialog::accept()
     // Try to find a default file name
     QString defaultFileName;
     if(selectedItems.count() == 1)  // One table -> Suggest table name
-        defaultFileName = selectedItems.at(0)->text() + ".sql";
+        defaultFileName = selectedItems.at(0)->text() + FILE_EXT_SQL_DEFAULT;
     else if(selectedItems.count() == ui->listTables->count())   // All tables -> Suggest database name
-        defaultFileName = pdb->currentFile() + ".sql";;
+        defaultFileName = pdb->currentFile() + FILE_EXT_SQL_DEFAULT;;
 
     QString fileName = FileDialog::getSaveFileName(
                 CreateSQLFile,
                 this,
                 tr("Choose a filename to export"),
-                tr("Text files(*.sql *.txt)"),
+                FILE_FILTER_SQL,
                 defaultFileName);
     if(fileName.isEmpty())
         return;

--- a/src/FileDialog.h
+++ b/src/FileDialog.h
@@ -3,6 +3,54 @@
 
 #include <QFileDialog>
 
+//
+// File Extensions Filters
+//  - space separated list of file extensions in QString
+//  - used during import/export
+//  - passed to QFileDialog to filter files shown based on extension
+//
+// SQLite DB File Extensions
+static const QString FILE_FILTER_SQLDB(QObject::tr("SQLite Database Files (*.db *.sqlite *.sqlite3 *.db3)"));
+
+// SQLite DB Project File Extensions
+static const QString FILE_FILTER_SQLPRJ(QObject::tr("DB Browser for SQLite Project Files (*.sqbpro)"));
+static const QString FILE_EXT_SQLPRJ_DEFAULT(".sqbpro");
+
+// SQL File Extensions Filter
+static const QString FILE_FILTER_SQL(QObject::tr("SQL Files (*.sql)"));
+static const QString FILE_EXT_SQL_DEFAULT(".sql");
+
+// All Files Extensions Filter
+static const QString FILE_FILTER_ALL(QObject::tr("All Files (*)"));
+
+// Text Files Extensions Filter
+static const QString FILE_FILTER_TXT(QObject::tr("Text Files (*.txt)"));
+
+// Comma,Tab,or Delimiter-Separated Values File Extensions Filter
+static const QString FILE_FILTER_CSV(QObject::tr("Comma-Separated Values Files (*.csv)"));
+static const QString FILE_EXT_CSV_DEFAULT(".csv");
+static const QString FILE_FILTER_TSV(QObject::tr("Tab-Separated Values Files (*.tsv)"));
+static const QString FILE_FILTER_DSV(QObject::tr("Delimiter-Separated Values Files (*.dsv)"));
+
+// JSON File Extensions Filter
+static const QString FILE_FILTER_JSON(QObject::tr("JSON Files (*.json *.js)"));
+static const QString FILE_EXT_JSON_DEFAULT(".json");
+
+// XML File Extensions Filter
+static const QString FILE_FILTER_XML(QObject::tr("XML Files (*.xml)"));
+
+// Binary File Extensions Filter
+static const QString FILE_FILTER_BIN(QObject::tr("Binary Files (*.bin *.dat)"));
+
+// Scalar Vector Graphics File Extensions Filter
+static const QString FILE_FILTER_SVG(QObject::tr("SVG Files (*.svg)"));
+
+// Hex-Dump File Extension Filter
+static const QString FILE_FILTER_HEX(QObject::tr("Hex Dump Files (*.dat *.bin)"));
+
+// Dynamic/Shared Objects File Extension Filter
+static const QString FILE_FILTER_DYN(QObject::tr("Extensions (*.so *.dylib *.dll)"));
+
 enum FileDialogTypes {
     NoSpecificType,
 

--- a/src/ImportCsvDialog.cpp
+++ b/src/ImportCsvDialog.cpp
@@ -215,7 +215,6 @@ void ImportCsvDialog::accept()
         importCsv(csvFilenames.first());
     }
 
-    QMessageBox::information(this, QApplication::applicationName(), tr("Import completed"));
     QApplication::restoreOverrideCursor();  // restore original cursor
     QDialog::accept();
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1639,11 +1639,18 @@ void MainWindow::mainTabSelected(int /*tabindex*/)
 
 void MainWindow::importTableFromCSV()
 {
+    QStringList file_filter;
+    file_filter << FILE_FILTER_CSV
+                << FILE_FILTER_TSV
+                << FILE_FILTER_DSV
+                << FILE_FILTER_TXT
+                << FILE_FILTER_ALL;
+
     QStringList wFiles = FileDialog::getOpenFileNames(
                              OpenCSVFile,
                              this,
                              tr("Choose text files"),
-                             tr("Text files(*.csv *.txt);;All files(*)"));
+                             file_filter.join(";;"));
 
     QStringList validFiles;
     for(const auto& file : wFiles) {
@@ -1747,18 +1754,24 @@ void MainWindow::exportDatabaseToSQL()
 
 void MainWindow::importDatabaseFromSQL()
 {
+    QStringList file_filter;
+    file_filter << FILE_FILTER_SQL
+                << FILE_FILTER_TXT
+                << FILE_FILTER_ALL;
+
     // Get file name to import
     QString fileName = FileDialog::getOpenFileName(
                 OpenSQLFile,
                 this,
                 tr("Choose a file to import"),
-                tr("Text files(*.sql *.txt);;All files(*)"));
+                file_filter.join(";;"));
 
     // Cancel when file doesn't exist
     if(!QFile::exists(fileName))
         return;
 
-    // If there is already a database file opened ask the user whether to import into this one or a new one. If no DB is opened just ask for a DB name directly
+    // If there is already a database file opened ask the user whether to import into
+    // this one or a new one. If no DB is opened just ask for a DB name directly
     QString newDbFile;
     if((db.isOpen() && QMessageBox::question(this,
                                             QApplication::applicationName(),
@@ -1909,7 +1922,7 @@ void MainWindow::updateRecentFileActions()
     // Get recent files list from settings
     QStringList files = Settings::getValue("General", "recentFileList").toStringList();
 
-    // Check if files still exist and remove any non-existant file
+    // Check if files still exist and remove any non-existent file
     for(int i=0;i<files.size();i++)
     {
         QFileInfo fi(files.at(i));
@@ -2381,11 +2394,15 @@ void MainWindow::saveSqlFileAs()
     if(!sqlarea)
         return;
 
+    QStringList file_filter;
+    file_filter << FILE_FILTER_SQL
+                << FILE_FILTER_TXT
+                << FILE_FILTER_ALL;
     QString file = FileDialog::getSaveFileName(
                 CreateSQLFile,
                 this,
                 tr("Select file name"),
-                tr("Text files(*.sql *.txt);;All files(*)"));
+                file_filter.join(";;"));
 
     if(!file.isEmpty())
     {
@@ -2408,11 +2425,15 @@ void MainWindow::saveSqlResultsAsView()
 
 void MainWindow::loadExtension()
 {
+    QStringList file_filter;
+    file_filter << FILE_FILTER_DYN
+                << FILE_FILTER_ALL;
+
     QString file = FileDialog::getOpenFileName(
                 OpenExtensionFile,
                 this,
                 tr("Select extension file"),
-                tr("Extensions(*.so *.dylib *.dll);;All files(*)"));
+                file_filter.join(";;"));
 
     if(file.isEmpty())
         return;
@@ -3055,7 +3076,7 @@ QString MainWindow::saveProject(const QString& currentFilename)
                            CreateProjectFile,
                            this,
                            tr("Choose a filename to save under"),
-                           tr("DB Browser for SQLite project file (*.sqbpro)"),
+                           FILE_FILTER_SQLPRJ,
                            basePathName);
     } else
         filename = currentFilename;
@@ -3063,8 +3084,8 @@ QString MainWindow::saveProject(const QString& currentFilename)
     if(!filename.isEmpty())
     {
         // Make sure the file has got a .sqbpro ending
-        if(!filename.endsWith(".sqbpro", Qt::CaseInsensitive))
-            filename.append(".sqbpro");
+        if(!filename.endsWith(FILE_EXT_SQLPRJ_DEFAULT, Qt::CaseInsensitive))
+            filename.append(FILE_EXT_SQLPRJ_DEFAULT);
 
         QFile file(filename);
         bool opened = file.open(QFile::WriteOnly | QFile::Text);


### PR DESCRIPTION
Matter came up WRT #1880. In reviewing, several other instances
were found where same file filter string literal was repeated several times.
This commit centralizes these file filters to one location. Filters are
declared `static const` to prevent accidental modification.

Also applied is a fix to #1881. QMessage at end of Import CSV is removed.