### PR TITLE
Restore QTextEdit widget for RTL text in the Cell Editor

### DIFF
--- a/src/Data.cpp
+++ b/src/Data.cpp
@@ -43,6 +43,21 @@ bool isTextOnly(QByteArray data, const QString& encoding, bool quickTest)
     }
 }
 
+bool containsRightToLeft(const QString& text) {
+
+    for(QChar ch : text) {
+        switch(ch.direction()) {
+        case QChar::DirR:
+        case QChar::DirAL:
+        case QChar::DirRLE:
+        case QChar::DirRLO:
+        case QChar::DirRLI:
+            return true;
+        }
+    }
+    return false;
+}
+
 bool startsWithBom(const QByteArray& data)
 {
     if(data.startsWith(bom3) ||

--- a/src/Data.h
+++ b/src/Data.h
@@ -10,6 +10,9 @@
 // text but makes it less reliable
 bool isTextOnly(QByteArray data, const QString& encoding = QString(), bool quickTest = false);
 
+// This returns true if text contains some character whose direction is right-to-left.
+bool containsRightToLeft(const QString& text);
+
 // This function returns true if the data in the data parameter starts with a Unicode BOM. Otherwise it returns false.
 bool startsWithBom(const QByteArray& data);
 

--- a/src/EditDialog.cpp
+++ b/src/EditDialog.cpp
@@ -816,7 +816,7 @@ void EditDialog::editTextChanged()
 
             // Switch to the Qt Editor if we detect right-to-left text,
             // since the QScintilla editor does not support it.
-            if (sciEdit->text().isRightToLeft())
+            if (containsRightToLeft(sciEdit->text()))
                 ui->comboMode->setCurrentIndex(RtlTextEditor);
         }
 
@@ -871,7 +871,7 @@ int EditDialog::checkDataType(const QByteArray& bArrdata)
         if(!json::parse(cellData, nullptr, false).is_discarded())
             return JSON;
         else {
-            if (QString::fromUtf8(cellData).isRightToLeft())
+            if (containsRightToLeft(QString::fromUtf8(cellData)))
                 return RtlText;
             else
                 return Text;

--- a/src/EditDialog.h
+++ b/src/EditDialog.h
@@ -63,6 +63,7 @@ private:
     QByteArray removedBom;
 
     enum DataSources {
+        QtBuffer,
         HexBuffer,
         SciBuffer
     };
@@ -75,18 +76,22 @@ private:
         Text,
         JSON,
         SVG,
-        XML
+        XML,
+        RtlText
     };
 
     // Edit modes and editor stack (this must be aligned with the UI).
     // Note that text modes (plain, JSON and XML) share the Scintilla widget,
     // Consequently the editor stack range is TextEditor..ImageViewer.
     enum EditModes {
+        // Modes with their own widget in the stack:
         TextEditor = 0,
-        HexEditor = 1,
-        ImageViewer = 2,
-        JsonEditor = 3,
-        XmlEditor = 4
+        RtlTextEditor = 1,
+        HexEditor = 2,
+        ImageViewer = 3,
+        // Modes in the Scintilla editor:
+        JsonEditor = 4,
+        XmlEditor = 5
     };
 
     int checkDataType(const QByteArray& bArrdata);

--- a/src/EditDialog.ui
+++ b/src/EditDialog.ui
@@ -53,6 +53,11 @@
        </item>
        <item>
         <property name="text">
+         <string>RTL Text</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
          <string>Binary</string>
         </property>
        </item>
@@ -137,6 +142,25 @@
 Errors are indicated with a red squiggle underline.</string>
       </property>
      </widget>
+     <widget class="QWidget" name="rtlVerticalLayout">
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QTextEdit" name="qtEdit">
+         <property name="font">
+          <font>
+           <family>Monospace</family>
+          </font>
+         </property>
+         <property name="whatsThis">
+          <string>This Qt editor is used for right-to-left scripts, which are not supported by the default Text editor. The presence of right-to-left characters is detected and this editor mode is automatically selected.</string>
+         </property>
+         <property name="acceptRichText">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
      <widget class="QWidget" name="editorBinary">
       <property name="contextMenuPolicy">
        <enum>Qt::ActionsContextMenu</enum>
@@ -151,8 +175,8 @@ Errors are indicated with a red squiggle underline.</string>
         <rect>
          <x>0</x>
          <y>0</y>
-         <width>85</width>
-         <height>35</height>
+         <width>598</width>
+         <height>264</height>
         </rect>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -417,6 +441,22 @@ Errors are indicated with a red squiggle underline.</string>
     <hint type="destinationlabel">
      <x>201</x>
      <y>431</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>qtEdit</sender>
+   <signal>textChanged()</signal>
+   <receiver>EditDialog</receiver>
+   <slot>editTextChanged()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>279</x>
+     <y>191</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>339</x>
+     <y>335</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This restores the Qt text widget that was replaced by a QScintilla one in
45c1e2abfd9dd95c8a744c24406b09dff5502e71

QScintilla does not support right-to-left scripts like Arabic, so QTextEdit
is still needed for these languages. Since the QScintilla editor has other
advantages already explained, it is preserved for general text edition.

RTL texts are detected when data is loaded and the Qt editor is
automatically selected. This is done both when loading data from the cell
and when interactively typing RTL characters in the Cell Editor.

All these changes can be undone if a new QScintilla editor supports RTL
texts.

See comments in issue #1793