### PR TITLE
Completed implementing a secondary Y axis -  Fix for #2026

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2351,7 +2351,7 @@ static void loadBrowseDataTableSettings(BrowseDataTableSettings& settings, QXmlS
                 QString y2AxisName;
                 PlotDock::PlotSettings y1AxisSettings;
                 PlotDock::PlotSettings y2AxisSettings;
-                if (xml.name() == "y1_axis") {
+                if (xml.name() == "y_axis") {
                     y1AxisName = xml.attributes().value("name").toString();
                     y1AxisSettings.lineStyle = xml.attributes().value("line_style").toInt();
                     y1AxisSettings.pointShape = xml.attributes().value("point_shape").toInt();
@@ -2359,6 +2359,7 @@ static void loadBrowseDataTableSettings(BrowseDataTableSettings& settings, QXmlS
                     y1AxisSettings.active = xml.attributes().value("active").toInt();
                     xml.skipCurrentElement();
                 }
+                settings.plotY1Axes[y1AxisName] = y1AxisSettings;
                 if (xml.name() == "y2_axis") {
                   y2AxisName = xml.attributes().value("name").toString();
                   y2AxisSettings.lineStyle = xml.attributes().value("line_style").toInt();
@@ -2367,7 +2368,6 @@ static void loadBrowseDataTableSettings(BrowseDataTableSettings& settings, QXmlS
                   y2AxisSettings.active = xml.attributes().value("active").toInt();
                   xml.skipCurrentElement();
                 }
-                settings.plotY1Axes[y1AxisName] = y1AxisSettings;
                 settings.plotY2Axes[y2AxisName] = y2AxisSettings;
             }
         } else if(xml.name() == "global_filter") {
@@ -2707,10 +2707,10 @@ static void saveBrowseDataTableSettings(const BrowseDataTableSettings& object, Q
         xml.writeEndElement();
     }
     xml.writeEndElement();
-    xml.writeStartElement("plot_y1_axes");
+    xml.writeStartElement("plot_y_axes");
     for(auto iter=object.plotY1Axes.constBegin(); iter!=object.plotY1Axes.constEnd(); ++iter) {
         PlotDock::PlotSettings plotSettings = iter.value();
-        xml.writeStartElement("y2_axis");
+        xml.writeStartElement("y_axis");
         xml.writeAttribute("name", iter.key());
         xml.writeAttribute("line_style", QString::number(plotSettings.lineStyle));
         xml.writeAttribute("point_shape", QString::number(plotSettings.pointShape));
@@ -2718,8 +2718,6 @@ static void saveBrowseDataTableSettings(const BrowseDataTableSettings& object, Q
         xml.writeAttribute("active", QString::number(plotSettings.active));
         xml.writeEndElement();
     }
-    xml.writeEndElement();
-    xml.writeStartElement("plot_y2_axes");
     for(auto iter=object.plotY2Axes.constBegin(); iter!=object.plotY2Axes.constEnd(); ++iter) {
       PlotDock::PlotSettings plotSettings = iter.value();
       xml.writeStartElement("y2_axis");

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2359,7 +2359,7 @@ static void loadBrowseDataTableSettings(BrowseDataTableSettings& settings, QXmlS
                     y1AxisSettings.active = xml.attributes().value("active").toInt();
                     xml.skipCurrentElement();
                 }
-                settings.plotY1Axes[y1AxisName] = y1AxisSettings;
+                settings.plotYAxes[0][y1AxisName] = y1AxisSettings;
                 if (xml.name() == "y2_axis") {
                   y2AxisName = xml.attributes().value("name").toString();
                   y2AxisSettings.lineStyle = xml.attributes().value("line_style").toInt();
@@ -2368,7 +2368,7 @@ static void loadBrowseDataTableSettings(BrowseDataTableSettings& settings, QXmlS
                   y2AxisSettings.active = xml.attributes().value("active").toInt();
                   xml.skipCurrentElement();
                 }
-                settings.plotY2Axes[y2AxisName] = y2AxisSettings;
+                settings.plotYAxes[1][y2AxisName] = y2AxisSettings;
             }
         } else if(xml.name() == "global_filter") {
             while(xml.readNext() != QXmlStreamReader::EndElement && xml.name() != "global_filter")
@@ -2708,7 +2708,7 @@ static void saveBrowseDataTableSettings(const BrowseDataTableSettings& object, Q
     }
     xml.writeEndElement();
     xml.writeStartElement("plot_y_axes");
-    for(auto iter=object.plotY1Axes.constBegin(); iter!=object.plotY1Axes.constEnd(); ++iter) {
+    for(auto iter=object.plotYAxes[0].constBegin(); iter!=object.plotYAxes[0].constEnd(); ++iter) {
         PlotDock::PlotSettings plotSettings = iter.value();
         xml.writeStartElement("y_axis");
         xml.writeAttribute("name", iter.key());
@@ -2718,7 +2718,7 @@ static void saveBrowseDataTableSettings(const BrowseDataTableSettings& object, Q
         xml.writeAttribute("active", QString::number(plotSettings.active));
         xml.writeEndElement();
     }
-    for(auto iter=object.plotY2Axes.constBegin(); iter!=object.plotY2Axes.constEnd(); ++iter) {
+    for(auto iter=object.plotYAxes[1].constBegin(); iter!=object.plotYAxes[1].constEnd(); ++iter) {
       PlotDock::PlotSettings plotSettings = iter.value();
       xml.writeStartElement("y2_axis");
       xml.writeAttribute("name", iter.key());

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2347,17 +2347,28 @@ static void loadBrowseDataTableSettings(BrowseDataTableSettings& settings, QXmlS
             }
         } else if(xml.name() == "plot_y_axes") {
             while(xml.readNext() != QXmlStreamReader::EndElement && xml.name() != "plot_y_axes") {
-                QString yAxisName;
-                PlotDock::PlotSettings yAxisSettings;
-                if (xml.name() == "y_axis") {
-                    yAxisName = xml.attributes().value("name").toString();
-                    yAxisSettings.lineStyle = xml.attributes().value("line_style").toInt();
-                    yAxisSettings.pointShape = xml.attributes().value("point_shape").toInt();
-                    yAxisSettings.colour = QColor (xml.attributes().value("colour").toString());
-                    yAxisSettings.active = xml.attributes().value("active").toInt();
+                QString y1AxisName;
+                QString y2AxisName;
+                PlotDock::PlotSettings y1AxisSettings;
+                PlotDock::PlotSettings y2AxisSettings;
+                if (xml.name() == "y1_axis") {
+                    y1AxisName = xml.attributes().value("name").toString();
+                    y1AxisSettings.lineStyle = xml.attributes().value("line_style").toInt();
+                    y1AxisSettings.pointShape = xml.attributes().value("point_shape").toInt();
+                    y1AxisSettings.colour = QColor (xml.attributes().value("colour").toString());
+                    y1AxisSettings.active = xml.attributes().value("active").toInt();
                     xml.skipCurrentElement();
                 }
-                settings.plotYAxes[yAxisName] = yAxisSettings;
+                if (xml.name() == "y2_axis") {
+                  y2AxisName = xml.attributes().value("name").toString();
+                  y2AxisSettings.lineStyle = xml.attributes().value("line_style").toInt();
+                  y2AxisSettings.pointShape = xml.attributes().value("point_shape").toInt();
+                  y2AxisSettings.colour = QColor (xml.attributes().value("colour").toString());
+                  y2AxisSettings.active = xml.attributes().value("active").toInt();
+                  xml.skipCurrentElement();
+                }
+                settings.plotY1Axes[y1AxisName] = y1AxisSettings;
+                settings.plotY2Axes[y2AxisName] = y2AxisSettings;
             }
         } else if(xml.name() == "global_filter") {
             while(xml.readNext() != QXmlStreamReader::EndElement && xml.name() != "global_filter")
@@ -2696,16 +2707,28 @@ static void saveBrowseDataTableSettings(const BrowseDataTableSettings& object, Q
         xml.writeEndElement();
     }
     xml.writeEndElement();
-    xml.writeStartElement("plot_y_axes");
-    for(auto iter=object.plotYAxes.constBegin(); iter!=object.plotYAxes.constEnd(); ++iter) {
+    xml.writeStartElement("plot_y1_axes");
+    for(auto iter=object.plotY1Axes.constBegin(); iter!=object.plotY1Axes.constEnd(); ++iter) {
         PlotDock::PlotSettings plotSettings = iter.value();
-        xml.writeStartElement("y_axis");
+        xml.writeStartElement("y2_axis");
         xml.writeAttribute("name", iter.key());
         xml.writeAttribute("line_style", QString::number(plotSettings.lineStyle));
         xml.writeAttribute("point_shape", QString::number(plotSettings.pointShape));
         xml.writeAttribute("colour", plotSettings.colour.name());
         xml.writeAttribute("active", QString::number(plotSettings.active));
         xml.writeEndElement();
+    }
+    xml.writeEndElement();
+    xml.writeStartElement("plot_y2_axes");
+    for(auto iter=object.plotY2Axes.constBegin(); iter!=object.plotY2Axes.constEnd(); ++iter) {
+      PlotDock::PlotSettings plotSettings = iter.value();
+      xml.writeStartElement("y2_axis");
+      xml.writeAttribute("name", iter.key());
+      xml.writeAttribute("line_style", QString::number(plotSettings.lineStyle));
+      xml.writeAttribute("point_shape", QString::number(plotSettings.pointShape));
+      xml.writeAttribute("colour", plotSettings.colour.name());
+      xml.writeAttribute("active", QString::number(plotSettings.active));
+      xml.writeEndElement();
     }
     xml.writeEndElement();
     xml.writeStartElement("global_filter");

--- a/src/PlotDock.cpp
+++ b/src/PlotDock.cpp
@@ -492,6 +492,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                         // set some graph styles not supported by the abstract plottable
                         graph->setLineStyle(static_cast<QCPGraph::LineStyle>(ui->comboLineType->currentIndex()));
                         graph->setScatterStyle(scatterStyle);
+                        plottable->setPen(QPen(item->backgroundColor(PlotColumnY1)));
                       }
                       if(y2ItemBool){
                         QCPGraph* graph = ui->plotWidget->addGraph(ui->plotWidget->xAxis, ui->plotWidget->yAxis2);
@@ -500,6 +501,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                         // set some graph styles not supported by the abstract plottable
                         graph->setLineStyle(static_cast<QCPGraph::LineStyle>(ui->comboLineType->currentIndex()));
                         graph->setScatterStyle(scatterStyle);
+                        plottable->setPen(QPen(item->backgroundColor(PlotColumnY2)));
                       }
                     } else {
                       if(y1ItemBool){
@@ -512,6 +514,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                         else
                             curve->setLineStyle(QCPCurve::lsLine);
                         curve->setScatterStyle(scatterStyle);
+                        plottable->setPen(QPen(item->backgroundColor(PlotColumnY1)));
                       }
                       if(y2ItemBool){
                         QCPCurve* curve = new QCPCurve(ui->plotWidget->xAxis, ui->plotWidget->yAxis2);
@@ -523,12 +526,9 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                         else
                           curve->setLineStyle(QCPCurve::lsLine);
                         curve->setScatterStyle(scatterStyle);
+                        plottable->setPen(QPen(item->backgroundColor(PlotColumnY2)));
                       }
                     }
-                    if(y1ItemBool)
-                      plottable->setPen(QPen(item->backgroundColor(PlotColumnY1)));
-                    else
-                      plottable->setPen(QPen(item->backgroundColor(PlotColumnY2)));
                 }
 
                 plottable->setSelectable(QCP::stDataRange);

--- a/src/PlotDock.h
+++ b/src/PlotDock.h
@@ -9,6 +9,7 @@
 class QMenu;
 class QPrinter;
 class QTreeWidgetItem;
+class QCPAxis;
 
 class SqliteTableModel;
 struct BrowseDataTableSettings;
@@ -94,6 +95,8 @@ private:
     bool m_showLegend;
     bool m_stackedBars;
     Palette m_graphPalette;
+    QList<QCPAxis *> yAxes;
+    QList<int> PlotColumnY;
 
     /*!
      * \brief guessdatatype try to parse the first 10 rows and decide the datatype

--- a/src/PlotDock.h
+++ b/src/PlotDock.h
@@ -81,8 +81,9 @@ private:
     {
         PlotColumnField = 0,
         PlotColumnX = 1,
-        PlotColumnY = 2,
-        PlotColumnType = 3,
+        PlotColumnY1 = 2,
+        PlotColumnY2 = 3,
+        PlotColumnType = 4,
     };
 
     Ui::PlotDock* ui;

--- a/src/PlotDock.ui
+++ b/src/PlotDock.ui
@@ -33,7 +33,7 @@
        <bool>true</bool>
       </property>
       <property name="columnCount">
-       <number>4</number>
+       <number>5</number>
       </property>
       <attribute name="headerDefaultSectionSize">
        <number>100</number>
@@ -53,7 +53,12 @@
       </column>
       <column>
        <property name="text">
-        <string>Y</string>
+        <string>Y1</string>
+       </property>
+      </column>
+      <column>
+       <property name="text">
+        <string>Y2</string>
        </property>
       </column>
       <column>

--- a/src/TableBrowser.h
+++ b/src/TableBrowser.h
@@ -65,10 +65,7 @@ struct BrowseDataTableSettings
         if(stream.atEnd())
             return stream;
         stream >> object.plotXAxis;
-        stream >> object.plotY1Axes;
-        stream >> object.plotY2Axes;
         stream >> object.plotYAxes[0];
-        stream >> object.plotYAxes[1];
         stream >> object.unlockViewPk;
 
         // Project files from versions before 3.11.0 didn't have these fields

--- a/src/TableBrowser.h
+++ b/src/TableBrowser.h
@@ -35,8 +35,7 @@ struct BrowseDataTableSettings
     bool showRowid;
     QString encoding;
     QString plotXAxis;
-    QMap<QString, PlotDock::PlotSettings> plotY1Axes;
-    QMap<QString, PlotDock::PlotSettings> plotY2Axes;
+    QList<QMap<QString, PlotDock::PlotSettings>> plotYAxes;
     QString unlockViewPk;
     QMap<int, bool> hiddenColumns;
     std::vector<QString> globalFilters;
@@ -45,6 +44,7 @@ struct BrowseDataTableSettings
         showRowid(false),
         unlockViewPk("_rowid_")
     {
+      plotYAxes = {QMap<QString, PlotDock::PlotSettings>(), QMap<QString, PlotDock::PlotSettings>()};
     }
 
     friend QDataStream& operator>>(QDataStream& stream, BrowseDataTableSettings& object)
@@ -67,6 +67,8 @@ struct BrowseDataTableSettings
         stream >> object.plotXAxis;
         stream >> object.plotY1Axes;
         stream >> object.plotY2Axes;
+        stream >> object.plotYAxes[0];
+        stream >> object.plotYAxes[1];
         stream >> object.unlockViewPk;
 
         // Project files from versions before 3.11.0 didn't have these fields

--- a/src/TableBrowser.h
+++ b/src/TableBrowser.h
@@ -35,7 +35,8 @@ struct BrowseDataTableSettings
     bool showRowid;
     QString encoding;
     QString plotXAxis;
-    QMap<QString, PlotDock::PlotSettings> plotYAxes;
+    QMap<QString, PlotDock::PlotSettings> plotY1Axes;
+    QMap<QString, PlotDock::PlotSettings> plotY2Axes;
     QString unlockViewPk;
     QMap<int, bool> hiddenColumns;
     std::vector<QString> globalFilters;
@@ -64,7 +65,8 @@ struct BrowseDataTableSettings
         if(stream.atEnd())
             return stream;
         stream >> object.plotXAxis;
-        stream >> object.plotYAxes;
+        stream >> object.plotY1Axes;
+        stream >> object.plotY2Axes;
         stream >> object.unlockViewPk;
 
         // Project files from versions before 3.11.0 didn't have these fields


### PR DESCRIPTION
# Secondary Y axis

When analysing datasets with multiple correlated columns, it would be very comfortable to view the graphical relationship of two parameters without having to manually scale the parameters. A secondary y axis helps achieve this and makes it very easy to comprehend relationship between two columns in the dataset.

![db_browser_2yaxes](https://user-images.githubusercontent.com/12043949/74595252-55d28380-5065-11ea-89ad-994a61f0156c.png)
