### PR TITLE
Install the AppStream file to the canonical location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -497,7 +497,7 @@ if(UNIX)
 		DESTINATION share/applications/)
 
 	install(FILES distri/${PROJECT_NAME}.desktop.appdata.xml
-		DESTINATION share/appdata/)
+		DESTINATION share/metainfo/)
 endif(UNIX)
 
 if(WIN32 AND MSVC)

--- a/src/src.pro
+++ b/src/src.pro
@@ -287,7 +287,7 @@ unix {
     desktop.path = $$DATADIR/applications/
     desktop.files = ../distri/sqlitebrowser.desktop
     INSTALLS += desktop
-    appdata.path = $$DATADIR/appdata/
+    appdata.path = $$DATADIR/metainfo/
     appdata.files = ../distri/sqlitebrowser.desktop.appdata.xml
     INSTALLS += appdata
 }


### PR DESCRIPTION
The canonical location for AppStream XML files has been changed to `/usr/share/metainfo` four years ago at least, with `/usr/share/appdata` left as legacy location. It is time to switch to the right location.