### PR TITLE
Changed grade level of snap package

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,7 @@
             SQLite Database Browser is not a visual shell for the sqlite command line tool. It does not require familiarity with SQL commands.
           confinement:            strict  # use "strict" to enforce system access only via declared interfaces
 
-          grade:                  devel
+          grade:                  stable
           icon:                   images/logo.svg
           type:                   app
           apps:


### PR DESCRIPTION
Changed grade level of snap package, so that we can promote stable builds to beta or stable channels on snapcraft