### PR TITLE
Qt Function Obsolescence

### DIFF
--- a/src/CondFormatManager.cpp
+++ b/src/CondFormatManager.cpp
@@ -216,8 +216,8 @@ void CondFormatManager::itemClicked(QTreeWidgetItem* item, int column)
     case ColumnBackground: {
         QColor color = QColorDialog::getColor(item->background(column).color(), this);
         if(color.isValid()) {
-            item->setTextColor(column, color);
-            item->setBackgroundColor(column, color);
+            item->setForeground(column, color);
+            item->setBackground(column, color);
         }
         break;
     }

--- a/src/ImportCsvDialog.cpp
+++ b/src/ImportCsvDialog.cpp
@@ -353,7 +353,7 @@ void ImportCsvDialog::matchSimilar()
                                              });
             if (matchingHeader) {
                 item->setCheckState(Qt::Checked);
-                item->setBackgroundColor(Qt::green);
+                item->setBackground(Qt::green);
             }
         }
         else

--- a/src/PlotDock.cpp
+++ b/src/PlotDock.cpp
@@ -151,8 +151,10 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
 
                 for(size_t y_ind = 0; y_ind < 2; y_ind++)
                   if(item->checkState(PlotColumnY[y_ind]) == Qt::Checked)
-                    mapItemsY[y_ind][item->text(PlotColumnField)] = PlotSettings(0, 0, item->backgroundColor(PlotColumnY[y_ind]), item->checkState(PlotColumnY[y_ind]) == Qt::Checked);
-
+                    mapItemsY[y_ind][item->text(PlotColumnField)] = PlotSettings(
+                        0, 0,
+                        item->background(PlotColumnY[y_ind]).color(),
+                        item->checkState(PlotColumnY[y_ind]) == Qt::Checked);
             }
         } else {
             // Get the plot columns to select from the stored browse table information
@@ -206,7 +208,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                         if(contains(mapItemsY[y_ind], columnitem->text(PlotColumnField)))
                         {
                           columnitem->setCheckState(PlotColumnY[y_ind], mapItemsY[y_ind][columnitem->text(PlotColumnField)].active ? Qt::Checked : Qt::Unchecked);
-                          columnitem->setBackgroundColor(PlotColumnY[y_ind], mapItemsY[y_ind][columnitem->text(PlotColumnField)].colour);
+                          columnitem->setBackground(PlotColumnY[y_ind], mapItemsY[y_ind][columnitem->text(PlotColumnField)].colour);
                         } else {
                         if (columntype == QVariant::Double)
                           columnitem->setCheckState(PlotColumnY[y_ind], Qt::Unchecked);
@@ -239,7 +241,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                     if(contains(mapItemsY[y_ind], columnitem->text(PlotColumnField)))
                     {
                       columnitem->setCheckState(PlotColumnY[y_ind], mapItemsY[y_ind][columnitem->text(PlotColumnField)].active ? Qt::Checked : Qt::Unchecked);
-                      columnitem->setBackgroundColor(PlotColumnY[y_ind], mapItemsY[y_ind][columnitem->text(PlotColumnField)].colour);
+                      columnitem->setBackground(PlotColumnY[y_ind], mapItemsY[y_ind][columnitem->text(PlotColumnField)].colour);
                     } else {
                     columnitem->setCheckState(PlotColumnY[y_ind], Qt::Unchecked);
                     }
@@ -450,7 +452,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                                 ticker->addTicks(xdata, labels);
                                 ui->plotWidget->xAxis->setTicker(ticker);
                             }
-                            QColor color = item->backgroundColor(PlotColumnY[y_ind]);
+                            QColor color = item->background(PlotColumnY[y_ind]).color();
                             bars->setBrush(color);
                             plottable->setPen(QPen(color.darker(150)));
                         }
@@ -467,7 +469,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                                 // set some graph styles not supported by the abstract plottable
                                 graph->setLineStyle(static_cast<QCPGraph::LineStyle>(ui->comboLineType->currentIndex()));
                                 graph->setScatterStyle(scatterStyle);
-                                plottable->setPen(QPen(item->backgroundColor(PlotColumnY[y_ind])));
+                                plottable->setPen(QPen(item->background(PlotColumnY[y_ind]).color()));
                             }
                         }
                     } else {
@@ -484,7 +486,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
                                 else
                                     curve->setLineStyle(QCPCurve::lsLine);
                                 curve->setScatterStyle(scatterStyle);
-                                plottable->setPen(QPen(item->backgroundColor(PlotColumnY[y_ind])));
+                                plottable->setPen(QPen(item->background(PlotColumnY[y_ind]).color()));
                             }
                         }
                     }
@@ -593,12 +595,12 @@ void PlotDock::on_treePlotColumns_itemChanged(QTreeWidgetItem* changeitem, int c
                 if(changeitem->checkState(column) == Qt::Checked)
                 {
                     // Generate a default colour if none isn't set yet
-                    QColor colour = changeitem->backgroundColor(column);
+                    QColor colour = changeitem->background(column).color();
                     if(!colour.isValid())
                         colour = m_graphPalette.nextSerialColor(true);
 
                     // Set colour
-                    changeitem->setBackgroundColor(column, colour);
+                    changeitem->setBackground(column, colour);
 
                     // Save settings for this table
                     if(m_currentTableSettings)
@@ -632,13 +634,13 @@ void PlotDock::on_treePlotColumns_itemDoubleClicked(QTreeWidgetItem* item, int c
         {
             // On double click open the colordialog
             QColorDialog colordialog(this);
-            QColor curbkcolor = item->backgroundColor(column);
+            QColor curbkcolor = item->background(column).color();
             QColor precolor = !curbkcolor.isValid() ? static_cast<Qt::GlobalColor>(random_number(5, 13)) : curbkcolor;
             QColor color = colordialog.getColor(precolor, this, tr("Choose an axis color"));
             if(color.isValid())
             {
                 item->setCheckState(column, Qt::Checked);
-                item->setBackgroundColor(column, color);
+                item->setBackground(column, color);
 
                 // Save settings for this table
                 if(m_currentTableSettings)

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -119,8 +119,8 @@ void PreferencesDialog::loadSettings()
         std::string name = ui->treeSyntaxHighlighting->topLevelItem(i)->text(0).toStdString();
         QString colorname = Settings::getValue("syntaxhighlighter", name + "_colour").toString();
         QColor color = QColor(colorname);
-        ui->treeSyntaxHighlighting->topLevelItem(i)->setTextColor(2, color);
-        ui->treeSyntaxHighlighting->topLevelItem(i)->setBackgroundColor(2, color);
+        ui->treeSyntaxHighlighting->topLevelItem(i)->setForeground(2, color);
+        ui->treeSyntaxHighlighting->topLevelItem(i)->setBackground(2, color);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setText(2, colorname);
         if (name != "null" && name != "currentline"  && name != "background" && name != "foreground") {
             ui->treeSyntaxHighlighting->topLevelItem(i)->setCheckState(3, Settings::getValue("syntaxhighlighter", name + "_bold").toBool() ? Qt::Checked : Qt::Unchecked);
@@ -346,8 +346,8 @@ void PreferencesDialog::showColourDialog(QTreeWidgetItem* item, int column)
     QColor colour = QColorDialog::getColor(QColor(item->text(column)), this);
     if(colour.isValid())
     {
-        item->setTextColor(column, colour);
-        item->setBackgroundColor(column, colour);
+        item->setForeground(column, colour);
+        item->setBackground(column, colour);
         item->setText(column, colour.name());
     }
 }
@@ -545,8 +545,8 @@ void PreferencesDialog::adjustColorsToStyle(int style)
     {
         std::string name = ui->treeSyntaxHighlighting->topLevelItem(i)->text(0).toStdString();
         QColor color = Settings::getDefaultColorValue("syntaxhighlighter", name + "_colour", appStyle);
-        ui->treeSyntaxHighlighting->topLevelItem(i)->setTextColor(2, color);
-        ui->treeSyntaxHighlighting->topLevelItem(i)->setBackgroundColor(2, color);
+        ui->treeSyntaxHighlighting->topLevelItem(i)->setForeground(2, color);
+        ui->treeSyntaxHighlighting->topLevelItem(i)->setBackground(2, color);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setText(2, color.name());
     }
 }


### PR DESCRIPTION
During a build with all warnings enabled, compiler reported numerous
Qt Functions as being obsolete. Review of the used functions, these
functions have been marked as obsolete as far back as Qt-5.12.x series.

Obsolete functions involved the use of Foreground/Background colour setting.

API description showing obsolete functions:
https://doc.qt.io/qt-5/qlistwidgetitem-obsolete.html
https://doc.qt.io/qt-5/qtreewidgetitem-obsolete.html