### PR TITLE
Update BUILDING.md for macOS (Fix #2338)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -125,9 +125,10 @@ Building an .app bundle version takes a bit more effort, but isn't too hard.
 It requires SQLite and Qt 5.x to be installed first.  These are the
 [Homebrew](http://brew.sh) steps, though other package managers should work:
 
-    $ brew install sqlite --with-functions --with-json1 --without-readline
+    $ brew tap sqlitebrowser/sqlite3
+    $ brew install sqlitefts5
     $ brew install qt
-    $ brew link sqlite3 --force
+    $ brew link sqlitefts5 --force
 
 Then it's just a matter of getting the source:
 
@@ -141,7 +142,7 @@ And compiling it:
     $ cd sqlitebrowser
     $ qmake
     $ make
-    $ brew unlink sqlite3
+    $ brew unlink sqlitefts5
     $ mv src/DB\ Browser\ for\ SQLite.app /Applications/
 
 An icon for "DB Browser for SQLite" should now be in your main OSX Applications


### PR DESCRIPTION
Update [BUILDING.md](https://github.com/sqlitebrowser/sqlitebrowser/blob/master/BUILDING.md) for macOS.
This pull request is based on the advice from the #2338 issue.

Test Environment
------------------
- macOS Catalina 10.15.6
- Homebrew 2.4.8