### PR TITLE
Fix cmake build on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-project(sqlitebrowser)
 cmake_minimum_required(VERSION 2.8.12.2)
+project(sqlitebrowser)
 
 # BUILD_VERSION is the current date in YYYYMMDD format. It is only
 # used by the nightly version to add the date of the build.


### PR DESCRIPTION
Cmake build fails on macOS with:
```sh
...
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
CMake Error in CMakeLists.txt:
  No known features for CXX compiler

  "Clang"

  version 5.0.2.


CMake Generate step failed.  Build files cannot be regenerated correctly.
```
Root cause is the same as https://trac.macports.org/ticket/57700#comment:6 (TLDR: cmake_minimum_required() should be before project()).