### PR TITLE
Move recent files item to new context menu and add clear recent file function

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3438,8 +3438,8 @@ void MainWindow::moveDocksTo(Qt::DockWidgetArea area)
 
 void MainWindow::clearRecentFiles()
 {
-  Settings::clearValue("General", "recentFileList");
+    Settings::clearValue("General", "recentFileList");
 
-  for (int i =0; i < MaxRecentFiles; ++i) 
-    ui->fileRecentFiles->removeAction(recentFileActs[i]);
+    for(int i=0; i < MaxRecentFiles; ++i)
+        recentFileActs[i]->setVisible(false);
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3438,7 +3438,7 @@ void MainWindow::moveDocksTo(Qt::DockWidgetArea area)
 
 void MainWindow::clearRecentFiles()
 {
-  Settings::clearRecentFiles();
+  Settings::clearRecentFiles("General", "recentFileList");
 
   for (int i =0; i < MaxRecentFiles; ++i) 
     ui->fileRecentFiles->removeAction(recentFileActs[i]);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3438,7 +3438,7 @@ void MainWindow::moveDocksTo(Qt::DockWidgetArea area)
 
 void MainWindow::clearRecentFiles()
 {
-  Settings::clearRecentFiles();
+  Settings::clearValue("General", "recentFileList");
 
   for (int i =0; i < MaxRecentFiles; ++i) 
     ui->fileRecentFiles->removeAction(recentFileActs[i]);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3438,7 +3438,7 @@ void MainWindow::moveDocksTo(Qt::DockWidgetArea area)
 
 void MainWindow::clearRecentFiles()
 {
-  Settings::clearRecentFiles("General", "recentFileList");
+  Settings::clearRecentFiles();
 
   for (int i =0; i < MaxRecentFiles; ++i) 
     ui->fileRecentFiles->removeAction(recentFileActs[i]);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -231,8 +231,11 @@ void MainWindow::init()
         connect(recentFileActs[i], &QAction::triggered, this, &MainWindow::openRecentFile);
     }
     for(int i = 0; i < MaxRecentFiles; ++i)
-        ui->fileMenu->insertAction(ui->fileExitAction, recentFileActs[i]);
-    recentSeparatorAct = ui->fileMenu->insertSeparator(ui->fileExitAction);
+        ui->fileRecentFiles->insertAction(ui->fileExitAction, recentFileActs[i]);
+
+    QAction *clearRecentFilesAction = ui->fileRecentFiles->addAction(tr("Clear Menu"));
+    ui->fileRecentFiles->insertAction(ui->fileExitAction, clearRecentFilesAction);
+    connect(clearRecentFilesAction, &QAction::triggered, this, &MainWindow::clearRecentFiles);
 
     // Create popup menus
     popupTableMenu = new QMenu(this);
@@ -1624,8 +1627,6 @@ void MainWindow::updateRecentFileActions()
     }
     for (int j = numRecentFiles; j < MaxRecentFiles; ++j)
         recentFileActs[j]->setVisible(false);
-
-    recentSeparatorAct->setVisible(numRecentFiles > 0);
 }
 
 void MainWindow::setCurrentFile(const QString &fileName)
@@ -3433,4 +3434,12 @@ void MainWindow::moveDocksTo(Qt::DockWidgetArea area)
     tabifyDockWidget(ui->dockLog, ui->dockPlot);
     tabifyDockWidget(ui->dockLog, ui->dockSchema);
     tabifyDockWidget(ui->dockLog, ui->dockRemote);
+}
+
+void MainWindow::clearRecentFiles()
+{
+  Settings::clearRecentFiles();
+
+  for (int i =0; i < MaxRecentFiles; ++i) 
+    ui->fileRecentFiles->removeAction(recentFileActs[i]);
 }

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -233,7 +233,7 @@ void MainWindow::init()
     for(int i = 0; i < MaxRecentFiles; ++i)
         ui->fileRecentFiles->insertAction(ui->fileExitAction, recentFileActs[i]);
 
-    QAction *clearRecentFilesAction = ui->fileRecentFiles->addAction(tr("Clear Menu"));
+    QAction *clearRecentFilesAction = ui->fileRecentFiles->addAction(tr("Clear List"));
     ui->fileRecentFiles->insertAction(ui->fileExitAction, clearRecentFilesAction);
     connect(clearRecentFilesAction, &QAction::triggered, this, &MainWindow::clearRecentFiles);
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -82,7 +82,6 @@ private:
 
     static const int MaxRecentFiles = 5;
     QAction *recentFileActs[MaxRecentFiles];
-    QAction *recentSeparatorAct;
 
     EditDialog* editDock;
     PlotDock* plotDock;
@@ -101,6 +100,7 @@ private:
     void clearCompleterModelsFields();
 
     void updateRecentFileActions();
+    void clearRecentFiles();
     void setCurrentFile(const QString& fileName);
     void addToRecentFilesMenu(const QString& filename, bool read_only = false);
     void activateFields(bool enable = true);

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -174,8 +174,8 @@ You can drag SQL statements from an object row and drop them into other applicat
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>641</width>
-             <height>544</height>
+             <width>639</width>
+             <height>574</height>
             </rect>
            </property>
            <layout class="QFormLayout" name="formLayout">
@@ -744,7 +744,7 @@ You can drag SQL statements from an object row and drop them into other applicat
      <x>0</x>
      <y>0</y>
      <width>1037</width>
-     <height>23</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="fileMenu">
@@ -766,11 +766,17 @@ You can drag SQL statements from an object row and drop them into other applicat
      <addaction name="fileExportCSVAction"/>
      <addaction name="fileExportJsonAction"/>
     </widget>
+    <widget class="QMenu" name="fileRecentFiles">
+     <property name="title">
+      <string>Recent Files</string>
+     </property>
+    </widget>
     <addaction name="fileNewAction"/>
     <addaction name="fileNewInMemoryDatabaseAction"/>
     <addaction name="fileOpenAction"/>
     <addaction name="fileOpenReadOnlyAction"/>
     <addaction name="fileAttachAction"/>
+    <addaction name="fileRecentFiles"/>
     <addaction name="fileCloseAction"/>
     <addaction name="separator"/>
     <addaction name="fileSaveAction"/>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -489,12 +489,12 @@ QColor Settings::getDefaultColorValue(const std::string& group, const std::strin
     return QColor();
 }
 
-void Settings::clearRecentFiles ()
+void Settings::clearValue(const std::string& group, const std::string& name)
 {
-  QSettings settings(QApplication::organizationName(), QApplication::organizationName());
-  settings.beginGroup("General");
-  settings.remove("recentFileList");
-  settings.endGroup();
+    QSettings settings(QApplication::organizationName(), QApplication::organizationName());
+    settings.beginGroup(QString::fromStdString(group));
+    settings.remove(QString::fromStdString(name));
+    settings.endGroup();
 }
 
 void Settings::restoreDefaults ()

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -495,6 +495,7 @@ void Settings::clearValue(const std::string& group, const std::string& name)
     settings.beginGroup(QString::fromStdString(group));
     settings.remove(QString::fromStdString(name));
     settings.endGroup();
+    m_hCache.clear();
 }
 
 void Settings::restoreDefaults ()

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -489,12 +489,12 @@ QColor Settings::getDefaultColorValue(const std::string& group, const std::strin
     return QColor();
 }
 
-void Settings::clearValue(const std::string& group, const std::string& name)
+void Settings::clearRecentFiles ()
 {
-    QSettings settings(QApplication::organizationName(), QApplication::organizationName());
-    settings.beginGroup(QString::fromStdString(group));
-    settings.remove(QString::fromStdString(name));
-    settings.endGroup();
+  QSettings settings(QApplication::organizationName(), QApplication::organizationName());
+  settings.beginGroup("General");
+  settings.remove("recentFileList");
+  settings.endGroup();
 }
 
 void Settings::restoreDefaults ()

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -489,6 +489,14 @@ QColor Settings::getDefaultColorValue(const std::string& group, const std::strin
     return QColor();
 }
 
+void Settings::clearRecentFiles ()
+{
+  QSettings settings(QApplication::organizationName(), QApplication::organizationName());
+  settings.beginGroup("General");
+  settings.remove("recentFileList");
+  settings.endGroup();
+}
+
 void Settings::restoreDefaults ()
 {
     QSettings settings(QApplication::organizationName(), QApplication::organizationName());

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -16,6 +16,7 @@ public:
     };
     static QVariant getValue(const std::string& group, const std::string& name);
     static void setValue(const std::string& group, const std::string& name, const QVariant& value, bool dont_save_to_disk = false);
+    static void clearRecentFiles();
     static void restoreDefaults();
 
     static void rememberDefaultFontSize(int size) { m_defaultFontSize = size; }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -16,7 +16,7 @@ public:
     };
     static QVariant getValue(const std::string& group, const std::string& name);
     static void setValue(const std::string& group, const std::string& name, const QVariant& value, bool dont_save_to_disk = false);
-    static void clearValue(const std::string& group, const std::string& name);
+    static void clearRecentFiles();
     static void restoreDefaults();
 
     static void rememberDefaultFontSize(int size) { m_defaultFontSize = size; }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -16,7 +16,7 @@ public:
     };
     static QVariant getValue(const std::string& group, const std::string& name);
     static void setValue(const std::string& group, const std::string& name, const QVariant& value, bool dont_save_to_disk = false);
-    static void clearRecentFiles();
+    static void clearValue(const std::string& group, const std::string& name);
     static void restoreDefaults();
 
     static void rememberDefaultFontSize(int size) { m_defaultFontSize = size; }


### PR DESCRIPTION
Recently used files in DB4S were previously displayed at the bottom of the file menu.
However, I've implemented this idea because I thought it would be better to create a menu called Recent Files in the File menu, and access the recent files in it and delete the list if necessary.

and also, I'm ready to listen to any advice. This is because I'm NOT sure about the QT framework and I'm afraid about requesting this PR without knowing the atmosphere of the DB4S team to see if it is okay to send a contribution to the implementation of the function. I wait for your valuable advice or feedback. Thanks!

Known bugs
-------------
- After opening the file, it is not added to the recent files list (but added normally when the DB4S is restarted)
- I cross-validated with the nightly build (release on July 27, 2020) to confirm that is is a problem in my code.
    - MD5 : e1d4952fd91625403c7a57ca7be3e252
    - SHA256 : 53739c57b44c02fea06758eb6e95be12598c54da5f9700c52d48ff64d8ca90ba

Test Environment
-----------------
  - macOS Catalina 10.15.6
  - Homebrew 2.4.9