### PR TITLE
Rename Mac OS X to macOS in code and documents

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -236,7 +236,7 @@ databases.
 Before compiling make sure you have the necessary SQLCipher development files
 installed. On Linux this can usually be accomplished by just installing the
 correct package (e.g. 'libsqlcipher-dev' on Debian-based distributions). On
-MacOS X the easiest way is to install it via Homebrew ('brew install
+macOS the easiest way is to install it via Homebrew ('brew install
 sqlcipher'). On Windows unfortunately it's a bit more difficult: You'll have
 to download and compile the code as described on the
 [SQLCipher website](https://www.zetetic.net/sqlcipher/) before you can proceed.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,7 @@ else()
 	set(LPTHREAD pthread)
 endif(WIN32)
 
-#enable version check for MacOS
+#enable version check for macOS
 if(APPLE)
 	add_definitions(-DCHECKNEWVERSION)
 endif(APPLE)

--- a/README.md
+++ b/README.md
@@ -61,17 +61,17 @@ Download Windows releases here:
 (e.g. gives an error), try a nightly build.  Nightly builds often fix bugs
 reported after the last release. :D
 
-## MacOS X / macOS
+## macOS
 
-DB Browser for SQLite works well on MacOS X / macOS.
+DB Browser for SQLite works well on macOS.
 
-* OSX 10.12 (Sierra) - 10.15 (Catalina) are tested and known to work
+* macOS 10.12 (Sierra) - 10.15 (Catalina) are tested and known to work
 
-Download OSX releases here:
+Download macOS releases here:
 
 * https://sqlitebrowser.org/dl/#macos
 
-The latest OSX binary can be installed via [Homebrew Cask](https://caskroom.github.io/ "Homebrew Cask"):
+The latest macOS binary can be installed via [Homebrew Cask](https://caskroom.github.io/ "Homebrew Cask"):
 
 ```
 brew cask install db-browser-for-sqlite

--- a/src/EditDialog.cpp
+++ b/src/EditDialog.cpp
@@ -386,7 +386,7 @@ void EditDialog::importData(bool asLink)
                 OpenDataFile,
                 this,
                 tr("Choose a file to import")
-#ifndef Q_OS_MAC // Filters on OS X are buggy
+#ifndef Q_OS_MAC // Filters on macOS are buggy
                 , filters.join(";;")
                 , &selectedFilter
 #endif

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -268,7 +268,7 @@ QVariant Settings::getDefaultValue(const std::string& group, const std::string& 
     // editor/fontsize or log/fontsize?
     if((group == "editor" || group == "log") && name == "fontsize")
 #ifdef Q_OS_MAC
-       // Use 12 pt size as the default on OSX
+       // Use 12 pt size as the default on macOS
         return 12;
 #else
         return 9;

--- a/src/extensions/extension-functions.c
+++ b/src/extensions/extension-functions.c
@@ -20,7 +20,7 @@ Compilation instructions:
  Compile this C source file into a dynamic library as follows:
  * Linux:
    gcc -fPIC -lm -shared extension-functions.c -o libsqlitefunctions.so
- * Mac OS X:
+ * macOS:
    gcc -fno-common -dynamiclib extension-functions.c -o libsqlitefunctions.dylib
  (You may need to add flags
   -I /opt/local/include/ -L/opt/local/lib -lsqlite3


### PR DESCRIPTION
I was see DB4S does not support older version os Mac OS X currently. (#2361)
DB4S support macOS 10.12 up to 10.15 for now. but I was found some code and documents still describe to 'Mac OS X'

Apple was renamed from Mac OS X to macOS starting in macOS 10.12. [Apple previews major update with macOS Sierra](https://www.apple.com/newsroom/2016/06/apple-previews-major-update-with-macos-sierra/)
Therefore, I suggest this patch, in the opinion that the code and document in the project should be modified accordingly.