### PR TITLE
Allow the user can change MaxRecentFiles

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -226,6 +226,7 @@ void MainWindow::init()
     for(int i = 0; i < MaxRecentFiles; ++i)
         ui->fileRecentFiles->insertAction(ui->fileExitAction, recentFileActs[i]);
 
+    recentSeparatorAct = ui->fileRecentFiles->insertSeparator(ui->fileExitAction);
     clearRecentFilesAction = ui->fileRecentFiles->addAction(tr("Clear List"));
     ui->fileRecentFiles->insertAction(ui->fileExitAction, clearRecentFilesAction);
     connect(clearRecentFilesAction, &QAction::triggered, this, &MainWindow::clearRecentFiles);
@@ -2175,6 +2176,7 @@ void MainWindow::reloadSettings()
         for(int i = 0; i < newMaxRecentFiles; ++i)
             ui->fileRecentFiles->insertAction(ui->fileExitAction, recentFileActs[i]);
 
+        ui->fileRecentFiles->insertSeparator(ui->fileExitAction);
         ui->fileRecentFiles->insertAction(ui->fileExitAction, clearRecentFilesAction);
 
         MaxRecentFiles = newMaxRecentFiles;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -80,8 +80,9 @@ private:
 
     DbStructureModel* dbStructureModel;
 
-    static const int MaxRecentFiles = 5;
-    QAction *recentFileActs[MaxRecentFiles];
+    static int MaxRecentFiles;
+    QVector<QAction*> recentFileActs;
+    QAction* clearRecentFilesAction;
 
     EditDialog* editDock;
     PlotDock* plotDock;

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -83,6 +83,7 @@ private:
     static int MaxRecentFiles;
     QVector<QAction*> recentFileActs;
     QAction* clearRecentFilesAction;
+    QAction* recentSeparatorAct;
 
     EditDialog* editDock;
     PlotDock* plotDock;

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -206,6 +206,7 @@ void PreferencesDialog::loadSettings()
     ui->toolbarStyleComboSql->setCurrentIndex(Settings::getValue("General", "toolbarStyleSql").toInt());
     ui->toolbarStyleComboEditCell->setCurrentIndex(Settings::getValue("General", "toolbarStyleEditCell").toInt());
     ui->spinGeneralFontSize->setValue(Settings::getValue("General", "fontsize").toInt());
+    ui->spinMaxRecentFiles->setValue(Settings::getValue("General", "maxRecentFiles").toInt());
 }
 
 void PreferencesDialog::saveSettings()
@@ -337,6 +338,7 @@ void PreferencesDialog::saveSettings()
     Settings::setValue("General", "toolbarStyleEditCell", ui->toolbarStyleComboEditCell->currentIndex());
     Settings::setValue("General", "DBFileExtensions", m_dbFileExtensions.join(";;") );
     Settings::setValue("General", "fontsize", ui->spinGeneralFontSize->value());
+    Settings::setValue("General", "maxRecentFiles", ui->spinMaxRecentFiles->value());
 
     m_proxyDialog->saveSettings();
 

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>755</width>
-    <height>618</height>
+    <height>625</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -122,7 +122,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="labelToolbarStyle">
          <property name="text">
           <string>Toolbar style</string>
@@ -132,7 +132,7 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
+       <item row="7" column="1">
         <widget class="QComboBox" name="toolbarStyleComboMain">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -182,7 +182,7 @@
          </item>
         </widget>
        </item>
-       <item row="7" column="1">
+       <item row="8" column="1">
         <widget class="QComboBox" name="toolbarStyleComboStructure">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -232,7 +232,7 @@
          </item>
         </widget>
        </item>
-       <item row="8" column="1">
+       <item row="9" column="1">
         <widget class="QComboBox" name="toolbarStyleComboBrowse">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -282,7 +282,7 @@
          </item>
         </widget>
        </item>
-       <item row="9" column="1">
+       <item row="10" column="1">
         <widget class="QComboBox" name="toolbarStyleComboSql">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -332,7 +332,7 @@
          </item>
         </widget>
        </item>
-       <item row="11" column="0">
+       <item row="12" column="0">
         <widget class="QLabel" name="labelUseRemotes">
          <property name="text">
           <string>Show remote options</string>
@@ -342,7 +342,7 @@
          </property>
         </widget>
        </item>
-       <item row="11" column="1">
+       <item row="12" column="1">
         <widget class="QCheckBox" name="checkUseRemotes">
          <property name="text">
           <string>enabled</string>
@@ -352,7 +352,7 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="0">
+       <item row="13" column="0">
         <widget class="QLabel" name="labelUpdates">
          <property name="text">
           <string>Automatic &amp;updates</string>
@@ -362,14 +362,14 @@
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="13" column="1">
         <widget class="QCheckBox" name="checkUpdates">
          <property name="text">
           <string>enabled</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
+       <item row="14" column="0">
         <widget class="QLabel" name="label_16">
          <property name="text">
           <string>DB file extensions</string>
@@ -379,14 +379,14 @@
          </property>
         </widget>
        </item>
-       <item row="13" column="1">
+       <item row="14" column="1">
         <widget class="QPushButton" name="buttonManageFileExtension">
          <property name="text">
           <string>Manage</string>
          </property>
         </widget>
        </item>
-       <item row="6" column="0">
+       <item row="7" column="0">
         <widget class="QLabel" name="labelMainToolBar">
          <property name="text">
           <string>Main Window</string>
@@ -399,7 +399,7 @@
          </property>
         </widget>
        </item>
-       <item row="7" column="0">
+       <item row="8" column="0">
         <widget class="QLabel" name="labelStructureToolBar">
          <property name="text">
           <string>Database Structure</string>
@@ -412,7 +412,7 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0">
+       <item row="9" column="0">
         <widget class="QLabel" name="labelBrowseToolBar">
          <property name="text">
           <string>Browse Data</string>
@@ -425,7 +425,7 @@
          </property>
         </widget>
        </item>
-       <item row="9" column="0">
+       <item row="10" column="0">
         <widget class="QLabel" name="labelSqlToolBar">
          <property name="text">
           <string>Execute SQL</string>
@@ -438,7 +438,7 @@
          </property>
         </widget>
        </item>
-       <item row="10" column="1">
+       <item row="11" column="1">
         <widget class="QComboBox" name="toolbarStyleComboEditCell">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -488,7 +488,7 @@
          </item>
         </widget>
        </item>
-       <item row="10" column="0">
+       <item row="11" column="0">
         <widget class="QLabel" name="labelEditCellToolBar">
          <property name="text">
           <string>Edit Database Cell</string>
@@ -564,6 +564,23 @@
        </item>
        <item row="3" column="1">
         <widget class="QSpinBox" name="spinGeneralFontSize"/>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="labelMaxRecentFiles">
+         <property name="text">
+          <string>Max Recent Files</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QSpinBox" name="spinMaxRecentFiles">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>40</number>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -160,6 +160,10 @@ QVariant Settings::getDefaultValue(const std::string& group, const std::string& 
     if(group == "General" && name == "recentFileList")
         return QStringList();
 
+    // General/maxRecentFiles?
+    if(group == "General" && name == "maxRecentFiles")
+        return 5;
+
     // General/language?
     if(group == "General" && name == "language")
         return QLocale::system().name();


### PR DESCRIPTION
I recently made a pull request(#2347) to move the recent file list to a sub-menu and
received a [suggestion](https://github.com/sqlitebrowser/sqlitebrowser/pull/2347#issuecomment-667553581) to change the value of MaxRecentFiles during the review process.

Accordingly, I modified the code to allow the user to change the value of MaxRecentFiles.
In addition, I re-added the separator that was lost according to the existing patch.

Thank you.

## Test Environment
- macOS Catalina (10.15.6, 19G2021)