### PR TITLE
src/translations/sqlb_fr.ts: fix typo in translation

### DIFF
--- a/src/translations/sqlb_fr.ts
+++ b/src/translations/sqlb_fr.ts
@@ -5252,7 +5252,7 @@ Are you sure?</source>
     <message>
         <location filename="../MainWindow.cpp" line="2394"/>
         <source>Choose a project file to open</source>
-        <translation>Coisir un fichier de projet à ouvrir</translation>
+        <translation>Choisir un fichier de projet à ouvrir</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="2526"/>


### PR DESCRIPTION
"Choose a project file to open" translation had a typo