### PR TITLE
Add the ability to support custom config files

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -45,9 +45,6 @@ Application::Application(int& argc, char** argv) :
     setOrganizationName("sqlitebrowser");
     setApplicationName("DB Browser for SQLite");
 
-    // Create a QSettings class object
-    Settings::setSettingsObject();
-
     // Set character encoding to UTF8
     QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
 
@@ -158,10 +155,7 @@ Application::Application(int& argc, char** argv) :
             // This option has already been handled above
             // For here, only print the error when no parameter value is given
             if(++i >= arguments().size())
-            {
-                qWarning() << qPrintable(tr("The -c/--config option requires an argument"));
-                qWarning() << qPrintable(tr("So the -c/--config option is ignored and run application"));
-            }
+                qWarning() << qPrintable(tr("The -c/--config option requires an argument. The option is ignored."));
         } else if(arguments().at(i) == "-o" || arguments().at(i) == "--option" ||
                   arguments().at(i) == "-O" || arguments().at(i) == "--save-option") {
             const QString optionWarning = tr("The -o/--option and -O/--save-option options require an argument in the form group/setting=value");

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -18,6 +18,32 @@
 Application::Application(int& argc, char** argv) :
     QApplication(argc, argv)
 {
+    // Check 'DB4S_CONFIG_FILE environment variable exists
+    const char* env = getenv("DB4S_CONFIG_FILE");
+
+    // If 'DB4S_CONFIG_FILE' environment variable exists
+    if(env)
+    {
+        Settings::userConfiguration = true;
+        Settings::userConfigurationDir = QString::fromStdString(env);
+    }
+
+    for(int i=1;i<arguments().size();i++)
+    {
+        if(arguments().at(i) == "-c" || arguments().at(i) == "--config")
+        {
+            if(++i >= arguments().size())
+            {
+                qWarning() << qPrintable(tr("The -c/--config option requires an argument"));
+            } else {
+                if (env)
+                    qWarning() << qPrintable(tr("The user configuration file location is replaced with the argument value instead of the environment variable value."));
+                Settings::userConfiguration = true;
+                Settings::userConfigurationDir = arguments().at(i);
+            }
+        }
+    }
+
     // Set organisation and application names
     setOrganizationName("sqlitebrowser");
     setApplicationName("DB Browser for SQLite");
@@ -98,6 +124,8 @@ Application::Application(int& argc, char** argv) :
             qWarning() << qPrintable(tr("  -s, --sql <file>    Execute this SQL file after opening the DB"));
             qWarning() << qPrintable(tr("  -t, --table <table> Browse this table after opening the DB"));
             qWarning() << qPrintable(tr("  -R, --read-only     Open database in read-only mode"));
+            qWarning() << qPrintable(tr("  -c, --config <config_file>"));
+            qWarning() << qPrintable(tr("                      Run application based on this configuration file"));
             qWarning() << qPrintable(tr("  -o, --option <group>/<setting>=<value>"));
             qWarning() << qPrintable(tr("                      Run application with this setting temporarily set to value"));
             qWarning() << qPrintable(tr("  -O, --save-option <group>/<setting>=<value>"));
@@ -126,6 +154,10 @@ Application::Application(int& argc, char** argv) :
             m_dontShowMainWindow = true;
         } else if(arguments().at(i) == "-R" || arguments().at(i) == "--read-only") {
             readOnly = true;
+        } else if(arguments().at(i) == "-c" || arguments().at(i) == "--config") {
+            // This option has already been handled above
+            // Also since this option was required one more argument(configuration file), it skips one argument
+            i++;
         } else if(arguments().at(i) == "-o" || arguments().at(i) == "--option" ||
                   arguments().at(i) == "-O" || arguments().at(i) == "--save-option") {
             const QString optionWarning = tr("The -o/--option and -O/--save-option options require an argument in the form group/setting=value");

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -104,11 +104,11 @@ void Settings::setValue(const std::string& group, const std::string& name, const
         settings->beginGroup(QString::fromStdString(group));
         settings->setValue(QString::fromStdString(name), value);
         settings->endGroup();
+        delete settings;
     }
 
     // Also change it in the cache
     m_hCache[group + name] = value;
-    delete settings;
 }
 
 QVariant Settings::getDefaultValue(const std::string& group, const std::string& name)

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -27,6 +27,10 @@ void Settings::setUserConfigurationFile(const QString userConfigurationFileArg)
 
 void Settings::setSettingsObject()
 {
+    // If an object has already been created, it is terminated to reduce overhead
+    if(settings)
+        return;
+
     /*
     Variable that stores whether or not the configuration file requested by the user is a normal configuration file
     If the file does not exist and is newly created, the if statement below is not executed, so the default value is set to true
@@ -88,7 +92,6 @@ QVariant Settings::getValue(const std::string& group, const std::string& name)
 
         // Store this value in the cache for further usage and return it afterwards
         m_hCache.insert({group + name, value});
-        delete settings;
         return value;
     }
 }
@@ -104,7 +107,6 @@ void Settings::setValue(const std::string& group, const std::string& name, const
         settings->beginGroup(QString::fromStdString(group));
         settings->setValue(QString::fromStdString(name), value);
         settings->endGroup();
-        delete settings;
     }
 
     // Also change it in the cache
@@ -559,7 +561,6 @@ void Settings::clearValue(const std::string& group, const std::string& name)
     settings->remove(QString::fromStdString(name));
     settings->endGroup();
     m_hCache.clear();
-    delete settings;
 }
 
 void Settings::restoreDefaults ()
@@ -567,5 +568,4 @@ void Settings::restoreDefaults ()
     setSettingsObject();
     settings->clear();
     m_hCache.clear();
-    delete settings;
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -2,6 +2,7 @@
 #define SETTINGS_H
 
 #include <unordered_map>
+#include <QSettings>
 #include <QVariant>
 
 class Settings
@@ -15,7 +16,6 @@ public:
     };
 
     static void setUserConfigurationFile(const QString userConfigurationFileArg);
-    static void setSettingsObject();
     static QVariant getValue(const std::string& group, const std::string& name);
     static void setValue(const std::string& group, const std::string& name, const QVariant& value, bool dont_save_to_disk = false);
     static void clearValue(const std::string& group, const std::string& name);
@@ -35,6 +35,12 @@ private:
 
     // User configuration file path
     static QString userConfigurationFile;
+
+    // QSettings object
+    static QSettings* settings;
+
+    // This works initialize QSettings object
+    static void setSettingsObject();
 
     // Cache for storing the settings to avoid repeatedly reading the settings file all the time
     static std::unordered_map<std::string, QVariant> m_hCache;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -10,6 +10,9 @@ class Settings
 
 public:
 
+    static bool userConfiguration;
+    static QString userConfigurationDir;
+
     enum AppStyle {
         FollowDesktopStyle,
         DarkStyle

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -9,14 +9,13 @@ class Settings
     friend class PreferencesDialog;
 
 public:
-
-    static bool userConfiguration;
-    static QString userConfigurationDir;
-
     enum AppStyle {
         FollowDesktopStyle,
         DarkStyle
     };
+
+    static void setUserConfigurationFile(const QString userConfigurationFileArg);
+    static void setSettingsObject();
     static QVariant getValue(const std::string& group, const std::string& name);
     static void setValue(const std::string& group, const std::string& name, const QVariant& value, bool dont_save_to_disk = false);
     static void clearValue(const std::string& group, const std::string& name);
@@ -33,6 +32,9 @@ private:
     // This works similar to getDefaultValue but returns the default color value based on the passed application style
     // instead of the current palette.
     static QColor getDefaultColorValue(const std::string& group, const std::string& name, AppStyle style);
+
+    // User configuration file path
+    static QString userConfigurationFile;
 
     // Cache for storing the settings to avoid repeatedly reading the settings file all the time
     static std::unordered_map<std::string, QVariant> m_hCache;


### PR DESCRIPTION
This patch changes to support custom configuration file. This PR is related to issue #2317

Two options are added for the command line:
- `-c [config_file]`
- `--config [config_file]`

We can also use environment variables without using options on the command line.
`export DB4S_CONFIG_FILE=[config_file]`

If there is an environment variable and use the `-c` or `--config` option, the environment variable is ignored.

Usage
------
```
$ ./DB\ Browser\ for\ SQLite -c db4sconfig
$ ./DB\ Browser\ for\ SQLite --config db4sconfig
```

```
$ export DB4S_CONFIG_FILE=db4sconfig
$ ./DB\ Browser\ for\ SQLite
```

Possible problem
-----------------
~~The database file may be **overwritten** if the user enters only the value of the database file to be open without specifying a configuration file parameter when using this option. -> `$ ./DB\ Browser\ for\ SQLite --config veryImportantDB.db`~~
Solved through this commit(60ddbdd6bd7b9f4ed098da6cd8614bcc0fa2e8c9).

Known Bugs
------------
If you specify an environment variable on macOS and run it with the following command, the config file is not saved anywhere.
`open ./DB\ Browser\ for\ SQLite.app/`
However, if you specify as follows, it is saved normally.
`./DB\ Browser\ for\ SQLite.app/Contents/MacOS/DB\ Browser\ for\ SQLite`

Test Environment
-----------------
- macOS Catalina (10.15.6, 19G2021)