### PR TITLE
Allow users to export or import user-settings file in a GUI environment

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -18,25 +18,25 @@
 Application::Application(int& argc, char** argv) :
     QApplication(argc, argv)
 {
-    // Get 'DB4S_PREFERENCES_FILE' environment variable
-    const char* env = getenv("DB4S_PREFERENCES_FILE");
+    // Get 'DB4S_SETTINGS_FILE' environment variable
+    const char* env = getenv("DB4S_SETTINGS_FILE");
 
-    // If 'DB4S_PREFERENCES_FILE' environment variable exists
+    // If 'DB4S_SETTINGS_FILE' environment variable exists
     if(env)
-        Settings::setUserPreferencesFile(QString::fromStdString(env));
+        Settings::setUserSettingsFile(QString::fromStdString(env));
 
     for(int i=1;i<arguments().size();i++)
     {
-        if(arguments().at(i) == "-p" || arguments().at(i) == "--preferences")
+        if(arguments().at(i) == "-S" || arguments().at(i) == "--settings")
         {
             if(++i < arguments().size())
             {
                 if(env)
                 {
-                    qWarning() << qPrintable(tr("The user preferences file location is replaced with the argument value instead of the environment variable value."));
-                    qWarning() << qPrintable(tr("Ignored environment variable(DB4S_PREFERENCES_FILE) value : ") + QString::fromStdString(env));
+                    qWarning() << qPrintable(tr("The user settings file location is replaced with the argument value instead of the environment variable value."));
+                    qWarning() << qPrintable(tr("Ignored environment variable(DB4S_SETTINGS_FILE) value : ") + QString::fromStdString(env));
                 }
-                Settings::setUserPreferencesFile(arguments().at(i));
+                Settings::setUserSettingsFile(arguments().at(i));
             }
         }
     }
@@ -121,8 +121,8 @@ Application::Application(int& argc, char** argv) :
             qWarning() << qPrintable(tr("  -s, --sql <file>    Execute this SQL file after opening the DB"));
             qWarning() << qPrintable(tr("  -t, --table <table> Browse this table after opening the DB"));
             qWarning() << qPrintable(tr("  -R, --read-only     Open database in read-only mode"));
-            qWarning() << qPrintable(tr("  -p, --preferences <preferences_file>"));
-            qWarning() << qPrintable(tr("                      Run application based on this preferences file"));
+            qWarning() << qPrintable(tr("  -S, --settings <settings_file>"));
+            qWarning() << qPrintable(tr("                      Run application based on this settings file"));
             qWarning() << qPrintable(tr("  -o, --option <group>/<setting>=<value>"));
             qWarning() << qPrintable(tr("                      Run application with this setting temporarily set to value"));
             qWarning() << qPrintable(tr("  -O, --save-option <group>/<setting>=<value>"));
@@ -151,11 +151,11 @@ Application::Application(int& argc, char** argv) :
             m_dontShowMainWindow = true;
         } else if(arguments().at(i) == "-R" || arguments().at(i) == "--read-only") {
             readOnly = true;
-        } else if(arguments().at(i) == "-p" || arguments().at(i) == "--preferences") {
+        } else if(arguments().at(i) == "-S" || arguments().at(i) == "--settings") {
             // This option has already been handled above
             // For here, only print the error when no parameter value is given
             if(++i >= arguments().size())
-                qWarning() << qPrintable(tr("The -p/--preferences option requires an argument. The option is ignored."));
+                qWarning() << qPrintable(tr("The -S/--settings option requires an argument. The option is ignored."));
         } else if(arguments().at(i) == "-o" || arguments().at(i) == "--option" ||
                   arguments().at(i) == "-O" || arguments().at(i) == "--save-option") {
             const QString optionWarning = tr("The -o/--option and -O/--save-option options require an argument in the form group/setting=value");

--- a/src/FileDialog.h
+++ b/src/FileDialog.h
@@ -56,6 +56,9 @@ static const QString FILE_FILTER_HEX(QObject::tr("Hex Dump Files (*.dat *.bin)")
 // Dynamic/Shared Objects File Extension Filter
 static const QString FILE_FILTER_DYN(QObject::tr("Extensions (*.so *.dylib *.dll)"));
 
+// Initialization File Extension Filter
+static const QString FILE_FILTER_INI(QObject::tr("Initialization File (*.ini)"));
+
 enum FileDialogTypes {
     NoSpecificType,
 
@@ -74,7 +77,10 @@ enum FileDialogTypes {
     OpenDataFile,
 
     OpenExtensionFile,
-    OpenCertificateFile
+    OpenCertificateFile,
+
+    CreateSettingsFile,
+    OpenSettingsFile
 };
 
 class FileDialog : public QFileDialog

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -705,7 +705,7 @@ void PreferencesDialog::exportSettings()
     if(!fileName.isEmpty())
     {
         Settings::exportSettings(fileName);
-        QMessageBox::information(this, QApplication::applicationName(), (tr("The settings file has been saved in location : ") + fileName));
+        QMessageBox::information(this, QApplication::applicationName(), (tr("The settings file has been saved in location :\n") + fileName));
     }
 }
 
@@ -714,8 +714,11 @@ void PreferencesDialog::importSettings()
     const QString fileName = FileDialog::getOpenFileName(OpenSettingsFile, this, tr("Open Settings File"), tr("Initialization File (*.ini)"));
     if(!fileName.isEmpty())
     {
-        Settings::importSettings(fileName);
-        QMessageBox::information(this, QApplication::applicationName(), tr("Rerun the program to apply the settings."));
+        if(Settings::importSettings(fileName))
+            QMessageBox::warning(this, QApplication::applicationName(), tr("Rerun the program to apply the settings."));
+        else
+            QMessageBox::critical(this, QApplication::applicationName(), tr("The selected settings file is not a normal settings file.\nPlease check again."));
+
         PreferencesDialog::close();
     }
 }

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -49,6 +49,12 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, Tabs tab)
 
     // Set current tab
     ui->tabWidget->setCurrentIndex(tab);
+
+    // Add 'Export Settings' and 'Import Settings' buttons
+    QPushButton* exportSettings = ui->buttonBox->addButton(tr("Export Settings"), QDialogButtonBox::ActionRole);
+    connect(exportSettings, &QPushButton::clicked, this, &PreferencesDialog::exportSettings);
+    QPushButton* importSettings = ui->buttonBox->addButton(tr("Import Settings"), QDialogButtonBox::ActionRole);
+    connect(importSettings, &QPushButton::clicked, this, &PreferencesDialog::importSettings);
 }
 
 /*
@@ -691,4 +697,25 @@ void PreferencesDialog::on_buttonBox_clicked(QAbstractButton* button)
 void PreferencesDialog::configureProxy()
 {
     m_proxyDialog->show();
+}
+
+void PreferencesDialog::exportSettings()
+{
+    const QString fileName = FileDialog::getSaveFileName(CreateSettingsFile, this, tr("Save Settings File"), tr("Initialization File (*.ini)"));
+    if(!fileName.isEmpty())
+    {
+        // TODO: Implement export settings function
+        QMessageBox::information(this, QApplication::applicationName(), (tr("The settings file has been saved in location : ") + fileName));
+    }
+}
+
+void PreferencesDialog::importSettings()
+{
+    const QString fileName = FileDialog::getOpenFileName(OpenSettingsFile, this, tr("Open Settings File"), tr("Initialization File (*.ini)"));
+    if(!fileName.isEmpty())
+    {
+        // TODO: Implement import settings function
+        QMessageBox::information(this, QApplication::applicationName(), tr("Rerun the program to apply the settings."));
+        PreferencesDialog::close();
+    }
 }

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -51,9 +51,9 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, Tabs tab)
     ui->tabWidget->setCurrentIndex(tab);
 
     // Add 'Export Settings' and 'Import Settings' buttons
-    QPushButton* exportSettings = ui->buttonBox->addButton(tr("Export Settings"), QDialogButtonBox::ActionRole);
+    const QPushButton* exportSettings = ui->buttonBox->addButton(tr("Export Settings"), QDialogButtonBox::ActionRole);
     connect(exportSettings, &QPushButton::clicked, this, &PreferencesDialog::exportSettings);
-    QPushButton* importSettings = ui->buttonBox->addButton(tr("Import Settings"), QDialogButtonBox::ActionRole);
+    const QPushButton* importSettings = ui->buttonBox->addButton(tr("Import Settings"), QDialogButtonBox::ActionRole);
     connect(importSettings, &QPushButton::clicked, this, &PreferencesDialog::importSettings);
 }
 

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -704,7 +704,7 @@ void PreferencesDialog::exportSettings()
     const QString fileName = FileDialog::getSaveFileName(CreateSettingsFile, this, tr("Save Settings File"), tr("Initialization File (*.ini)"));
     if(!fileName.isEmpty())
     {
-        // TODO: Implement export settings function
+        Settings::exportSettings(fileName);
         QMessageBox::information(this, QApplication::applicationName(), (tr("The settings file has been saved in location : ") + fileName));
     }
 }
@@ -714,7 +714,7 @@ void PreferencesDialog::importSettings()
     const QString fileName = FileDialog::getOpenFileName(OpenSettingsFile, this, tr("Open Settings File"), tr("Initialization File (*.ini)"));
     if(!fileName.isEmpty())
     {
-        // TODO: Implement import settings function
+        Settings::importSettings(fileName);
         QMessageBox::information(this, QApplication::applicationName(), tr("Rerun the program to apply the settings."));
         PreferencesDialog::close();
     }

--- a/src/PreferencesDialog.h
+++ b/src/PreferencesDialog.h
@@ -63,6 +63,8 @@ private:
     void setColorSetting(QFrame* frame, const QColor &color);
     void saveColorSetting(QFrame* frame, const std::string& name);
     void addClientCertToTable(const QString& path, const QSslCertificate& cert);
+    void exportSettings();
+    void importSettings();
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event) override;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -569,3 +569,42 @@ void Settings::restoreDefaults ()
     settings->clear();
     m_hCache.clear();
 }
+
+void Settings::exportSettings(const QString fileName)
+{
+    QSettings* exportSettings = new QSettings(fileName, QSettings::IniFormat);
+
+    const QStringList groups = settings->childGroups();
+    foreach(QString currentGroup, groups)
+    {
+        settings->beginGroup(currentGroup);
+        const QStringList keys = settings->childKeys();
+        foreach(QString currentKey, keys)
+        {
+            exportSettings->beginGroup(currentGroup);
+            exportSettings->setValue(currentKey, getValue((currentGroup.toStdString()), (currentKey.toStdString())));
+            exportSettings->endGroup();
+        }
+        settings->endGroup();
+    }
+}
+
+void Settings::importSettings(const QString fileName)
+{
+    // TODO: Validate whether the target file is a normal file
+    QSettings* importSettings = new QSettings(fileName, QSettings::IniFormat);
+
+    const QStringList groups = importSettings->childGroups();
+    foreach(QString currentGroup, groups)
+    {
+        importSettings->beginGroup(currentGroup);
+        const QStringList keys = importSettings->childKeys();
+        foreach(QString currentKey, keys)
+        {
+            settings->beginGroup(currentGroup);
+            setting->setValue(currentKey, importSettings->value(currentKey));
+            settings->endGroup();
+        }
+        importSettings->endGroup();
+    }
+}

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -602,7 +602,7 @@ void Settings::importSettings(const QString fileName)
         foreach(QString currentKey, keys)
         {
             settings->beginGroup(currentGroup);
-            setting->setValue(currentKey, importSettings->value(currentKey));
+            settings->setValue(currentKey, importSettings->value(currentKey));
             settings->endGroup();
         }
         importSettings->endGroup();

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -25,7 +25,7 @@ void Settings::setUserSettingsFile(const QString userSettingsFileArg)
     userSettingsFile = userSettingsFileArg;
 }
 
-bool Settings::verifyUserSettingsFile(const QString userSettingsFile)
+bool Settings::isVaildSettingsFile(const QString userSettingsFile)
 {
     /*
     Variable that stores whether or not the settings file requested by the user is a normal settings file
@@ -59,7 +59,7 @@ void Settings::setSettingsObject()
     if(settings)
         return;
 
-    const bool isNormalUserSettingsFile = verifyUserSettingsFile(userSettingsFile);
+    const bool isNormalUserSettingsFile = isVaildSettingsFile(userSettingsFile);
 
     if(userSettingsFile == nullptr)
     {
@@ -599,17 +599,17 @@ void Settings::exportSettings(const QString fileName)
 
 bool Settings::importSettings(const QString fileName)
 {
-    if(!verifyUserSettingsFile(fileName))
+    if(!isVaildSettingsFile(fileName))
         return false;
 
     QSettings* importSettings = new QSettings(fileName, QSettings::IniFormat);
 
     const QStringList groups = importSettings->childGroups();
-    foreach(QString currentGroup, groups)
+    for(const QString currentGroup : groups)
     {
         importSettings->beginGroup(currentGroup);
         const QStringList keys = importSettings->childKeys();
-        foreach(QString currentKey, keys)
+        for(const QString currentKey : keys)
         {
             settings->beginGroup(currentGroup);
             settings->setValue(currentKey, importSettings->value(currentKey));

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -25,16 +25,13 @@ void Settings::setUserSettingsFile(const QString userSettingsFileArg)
     userSettingsFile = userSettingsFileArg;
 }
 
-void Settings::setSettingsObject()
+bool Settings::verifyUserSettingsFile(const QString userSettingsFile)
 {
-    // If an object has already been created, it is terminated to reduce overhead
-    if(settings)
-        return;
-
     /*
     Variable that stores whether or not the settings file requested by the user is a normal settings file
     If the file does not exist and is newly created, the if statement below is not executed, so the default value is set to true
     */
+
     bool isNormalUserSettingsFile = true;
 
     // Code that verifies that the settings file requested by the user is a normal settings file
@@ -52,6 +49,17 @@ void Settings::setSettingsObject()
 
         file->close();
     }
+
+    return isNormalUserSettingsFile;
+}
+
+void Settings::setSettingsObject()
+{
+    // If an object has already been created, it is terminated to reduce overhead
+    if(settings)
+        return;
+
+    bool isNormalUserSettingsFile = verifyUserSettingsFile(userSettingsFile);
 
     if(userSettingsFile == nullptr)
     {
@@ -589,9 +597,11 @@ void Settings::exportSettings(const QString fileName)
     }
 }
 
-void Settings::importSettings(const QString fileName)
+bool Settings::importSettings(const QString fileName)
 {
-    // TODO: Validate whether the target file is a normal file
+    if(!verifyUserSettingsFile(fileName))
+        return false;
+
     QSettings* importSettings = new QSettings(fileName, QSettings::IniFormat);
 
     const QStringList groups = importSettings->childGroups();
@@ -607,4 +617,6 @@ void Settings::importSettings(const QString fileName)
         }
         importSettings->endGroup();
     }
+
+    return true;
 }

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -59,7 +59,7 @@ void Settings::setSettingsObject()
     if(settings)
         return;
 
-    bool isNormalUserSettingsFile = verifyUserSettingsFile(userSettingsFile);
+    const bool isNormalUserSettingsFile = verifyUserSettingsFile(userSettingsFile);
 
     if(userSettingsFile == nullptr)
     {

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -10,7 +10,7 @@
 #include <QStandardPaths>
 #include <QPalette>
 
-QString Settings::userPreferencesFile;
+QString Settings::userSettingsFile;
 QSettings* Settings::settings;
 std::unordered_map<std::string, QVariant> Settings::m_hCache;
 int Settings::m_defaultFontSize;
@@ -20,9 +20,9 @@ static bool ends_with(const std::string& str, const std::string& with)
     return str.rfind(with) == str.size() - with.size();
 }
 
-void Settings::setUserPreferencesFile(const QString userPreferencesFileArg)
+void Settings::setUserSettingsFile(const QString userSettingsFileArg)
 {
-    userPreferencesFile = userPreferencesFileArg;
+    userSettingsFile = userSettingsFileArg;
 }
 
 void Settings::setSettingsObject()
@@ -32,47 +32,47 @@ void Settings::setSettingsObject()
         return;
 
     /*
-    Variable that stores whether or not the preferences file requested by the user is a normal preferences file
+    Variable that stores whether or not the settings file requested by the user is a normal settings file
     If the file does not exist and is newly created, the if statement below is not executed, so the default value is set to true
     */
-    bool isNormalUserPreferencesFile = true;
+    bool isNormalUserSettingsFile = true;
 
-    // Code that verifies that the preferences file requested by the user is a normal preferences file
-    if(userPreferencesFile != nullptr)
+    // Code that verifies that the settings file requested by the user is a normal settings file
+    if(userSettingsFile != nullptr)
     {
         QFile *file = new QFile;
-        file->setFileName(userPreferencesFile);
+        file->setFileName(userSettingsFile);
 
         if(file->open(QIODevice::ReadOnly))
         {
             if(file->exists() &&
               QString::compare(QString::fromStdString("[%General]\n"), file->readLine(), Qt::CaseInsensitive) != 0)
-                isNormalUserPreferencesFile = false;
+                isNormalUserSettingsFile = false;
         }
 
         file->close();
     }
 
-    if(userPreferencesFile == nullptr)
+    if(userSettingsFile == nullptr)
     {
         settings = new QSettings(QCoreApplication::organizationName(), QCoreApplication::organizationName());
     } else {
-        if(isNormalUserPreferencesFile)
+        if(isNormalUserSettingsFile)
         {
-            settings = new QSettings(userPreferencesFile, QSettings::IniFormat);
+            settings = new QSettings(userSettingsFile, QSettings::IniFormat);
 
-            // Code to verify that the user does not have access to the requested preferences file
+            // Code to verify that the user does not have access to the requested settings file
             if(settings->status() == QSettings::AccessError) {
-                qWarning() << qPrintable("The given preferences file can NOT access. Please check the permission for the file.");
-                qWarning() << qPrintable("So, the -p/--preferences option is ignored.");
+                qWarning() << qPrintable("The given settings file can NOT access. Please check the permission for the file.");
+                qWarning() << qPrintable("So, the -S/--settings option is ignored.");
 
                 // Since you do not have permission to the file, delete the existing assignment and assign the standard
                 delete settings;
                 settings = new QSettings(QCoreApplication::organizationName(), QCoreApplication::organizationName());
             }
         } else {
-            qWarning() << qPrintable("The given preferences file is not a normal preferences file. Please check again.");
-            qWarning() << qPrintable("So, the -p/--preferences option is ignored.");
+            qWarning() << qPrintable("The given settings file is not a normal settings file. Please check again.");
+            qWarning() << qPrintable("So, the -S/--settings option is ignored.");
             settings = new QSettings(QCoreApplication::organizationName(), QCoreApplication::organizationName());
         }
     }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -23,7 +23,7 @@ public:
 
     static void rememberDefaultFontSize(int size) { m_defaultFontSize = size; }
     static void exportSettings(const QString fileName);
-    static void importSettings(const QString fileName);
+    static bool importSettings(const QString fileName);
 
 private:
     Settings() = delete;    // class is fully static
@@ -40,6 +40,9 @@ private:
 
     // QSettings object
     static QSettings* settings;
+
+    // This works verify that the settings file provided by the user is a normal settings file
+    static bool verifyUserSettingsFile(const QString userSettingsFile);
 
     // This works initialize QSettings object
     static void setSettingsObject();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -42,7 +42,7 @@ private:
     static QSettings* settings;
 
     // This works verify that the settings file provided by the user is a normal settings file
-    static bool verifyUserSettingsFile(const QString userSettingsFile);
+    static bool isVaildSettingsFile(const QString userSettingsFile);
 
     // This works initialize QSettings object
     static void setSettingsObject();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -22,6 +22,8 @@ public:
     static void restoreDefaults();
 
     static void rememberDefaultFontSize(int size) { m_defaultFontSize = size; }
+    static void exportSettings(const QString fileName);
+    static void importSettings(const QString fileName);
 
 private:
     Settings() = delete;    // class is fully static

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -15,7 +15,7 @@ public:
         DarkStyle
     };
 
-    static void setUserPreferencesFile(const QString userPreferencesFileArg);
+    static void setUserSettingsFile(const QString userSettingsFileArg);
     static QVariant getValue(const std::string& group, const std::string& name);
     static void setValue(const std::string& group, const std::string& name, const QVariant& value, bool dont_save_to_disk = false);
     static void clearValue(const std::string& group, const std::string& name);
@@ -33,8 +33,8 @@ private:
     // instead of the current palette.
     static QColor getDefaultColorValue(const std::string& group, const std::string& name, AppStyle style);
 
-    // User configuration file path
-    static QString userPreferencesFile;
+    // User settings file path
+    static QString userSettingsFile;
 
     // QSettings object
     static QSettings* settings;


### PR DESCRIPTION
This patch changes to allow users to export or import user-settings file in a GUI environment.
This PR is related to issue #2393.

Detailed Changes
--------------------
1. There was an opinion that the expression 'Settings' is more appropriate than 'Configuration' or 'Preferences'
So it is be changed to 'Settings' and also, the following two command line options change accordingly:
    - `-p [preferences_file]` -> `-S [settings_file]`
    - `--preferences [preferences_file]` -> `--settings [settings_file]`
2. Add the following two buttons to the 'PreferencesDialog'
    - Export Settings
    - Import Settings

Need Help
------------
![Screenshot from 2020-09-13 20-44-11](https://user-images.githubusercontent.com/64626662/93017217-eecc7b80-f601-11ea-9f19-ea9e35b4a133.png)
In issue #2393, @chrisjlocke showed a prototype of a new buttons to the left of the existing 'Restore Defaults` button.
I thought this is better, so I tried but failed due to my lack of ability. May I get any advice on this part?

Test Environment
-------------------
- macOS Catalina (10.15.6, 19G2021)
- Ubuntu Desktop 20.04.1

Thank you.