### PR TITLE
Install SVG logo as hicolor scalable icon

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,10 @@ if(UNIX)
 	install(FILES src/icons/${PROJECT_NAME}.png
 		DESTINATION share/icons/hicolor/256x256/apps/)
 
+	install(FILES images/logo.svg
+		DESTINATION share/icons/hicolor/scalable/apps/
+		RENAME ${PROJECT_NAME}.svg)
+
 	install(FILES distri/${PROJECT_NAME}.desktop
 		DESTINATION share/applications/)
 


### PR DESCRIPTION
Install the SVG logo as scalable icon in the global hicolor icon theme: this way, application launchers/browsers that show icons bigger than 256 pixels can show a good-looking icon from the SVG logo instead of upscaling the 256px PNG icon.