### PR TITLE
Fix to 'Window Layout' options work properly

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -306,11 +306,10 @@ void MainWindow::init()
     // they are updated accordingly.
     connect(ui->mainTab, &QTabWidget::tabCloseRequested, this, &MainWindow::closeTab);
 
-    QAction* viewMenuPragmas = nullptr;
-
     // Add entries for toggling the visibility of main tabs
     for (QWidget* widget : {ui->structure, ui->browser, ui->pragmas, ui->query}) {
         QAction* action = ui->viewMenu->addAction(QIcon(":/icons/open_sql"), widget->accessibleName());
+        action->setObjectName(widget->accessibleName());
         action->setCheckable(true);
         action->setChecked(ui->mainTab->indexOf(widget) != -1);
         connect(action, &QAction::toggled, [=](bool show) { toggleTabVisible(widget, show); });
@@ -320,9 +319,6 @@ void MainWindow::init()
         connect(ui->mainTab, &QTabWidget::tabCloseRequested, [=](int /*index*/) {
                 action->setChecked(ui->mainTab->indexOf(widget) != -1);
             });
-
-        if (widget == ui->pragmas)
-            viewMenuPragmas = action;
     }
 
     ui->viewMenu->addSeparator();
@@ -342,8 +338,7 @@ void MainWindow::init()
     QAction* simplifyLayoutAction = layoutMenu->addAction(tr("Simplify Window Layout"));
     simplifyLayoutAction->setShortcut(QKeySequence(tr("Shift+Alt+0")));
     connect(simplifyLayoutAction, &QAction::triggered, [=]() {
-            toggleTabVisible(ui->pragmas, false);
-            viewMenuPragmas->setChecked(false);
+            ui->viewMenu->findChild<QAction *>(ui->pragmas->accessibleName())->activate(QAction::Trigger);
             ui->dockLog->hide();
             ui->dockPlot->hide();
             ui->dockSchema->hide();

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -306,6 +306,8 @@ void MainWindow::init()
     // they are updated accordingly.
     connect(ui->mainTab, &QTabWidget::tabCloseRequested, this, &MainWindow::closeTab);
 
+    QAction* viewMenuPragmas = nullptr;
+
     // Add entries for toggling the visibility of main tabs
     for (QWidget* widget : {ui->structure, ui->browser, ui->pragmas, ui->query}) {
         QAction* action = ui->viewMenu->addAction(QIcon(":/icons/open_sql"), widget->accessibleName());
@@ -318,6 +320,9 @@ void MainWindow::init()
         connect(ui->mainTab, &QTabWidget::tabCloseRequested, [=](int /*index*/) {
                 action->setChecked(ui->mainTab->indexOf(widget) != -1);
             });
+
+        if (widget == ui->pragmas)
+            viewMenuPragmas = action;
     }
 
     ui->viewMenu->addSeparator();
@@ -330,11 +335,15 @@ void MainWindow::init()
     connect(resetLayoutAction, &QAction::triggered, [=]() {
             restoreState(defaultWindowState);
             restoreOpenTabs(defaultOpenTabs);
+            ui->viewDBToolbarAction->setChecked(!ui->toolbarDB->isHidden());
+            ui->viewExtraDBToolbarAction->setChecked(!ui->toolbarExtraDB->isHidden());
+            ui->viewProjectToolbarAction->setChecked(!ui->toolbarProject->isHidden());
         });
     QAction* simplifyLayoutAction = layoutMenu->addAction(tr("Simplify Window Layout"));
     simplifyLayoutAction->setShortcut(QKeySequence(tr("Shift+Alt+0")));
     connect(simplifyLayoutAction, &QAction::triggered, [=]() {
             toggleTabVisible(ui->pragmas, false);
+            viewMenuPragmas->setChecked(false);
             ui->dockLog->hide();
             ui->dockPlot->hide();
             ui->dockSchema->hide();


### PR DESCRIPTION
This patch fixes issue #2434.

```cpp
QAction* viewMenuPragmas = nullptr;

    // Add entries for toggling the visibility of main tabs
    for (QWidget* widget : {ui->structure, ui->browser, ui->pragmas, ui->query}) {
        QAction* action = ui->viewMenu->addAction(QIcon(":/icons/open_sql"), widget->accessibleName());
        action->setCheckable(true);
        // A few lines below are hidden because they are not needed for the review process.

        if (widget == ui->pragmas)
            viewMenuPragmas = action;
    }
```
I think it would be good to send the 'QTabWidget::tabCloseRequested' signal to the 'Edit Pragmas' tab for the above code, but after a few days of searching and finding out, I can't seem to do that. Therefore, when QAction is initalized, I modified the code to create and access a pointer variable pointing to QAction for 'Edit Pragmas'.

@mgrojo Please review the code if you possible. Thanks! :smile: 