### PR TITLE
Fix to user can configure foreign key correctly

### DIFF
--- a/src/EditTableDialog.h
+++ b/src/EditTableDialog.h
@@ -47,7 +47,8 @@ private:
         kConstraintColumns = 0,
         kConstraintType = 1,
         kConstraintName = 2,
-        kConstraintSql = 3
+        kConstraintReference = 3,
+        kConstraintSql = 4
     };
 
     enum MoveFieldDirection

--- a/src/EditTableDialog.ui
+++ b/src/EditTableDialog.ui
@@ -99,7 +99,7 @@
      </property>
      <widget class="QTabWidget" name="groupDefinition">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="groupFieldsPage1">
        <attribute name="title">
@@ -427,6 +427,11 @@
           <column>
            <property name="text">
             <string>Name</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Reference</string>
            </property>
           </column>
           <column>


### PR DESCRIPTION
This patch changes to user can configure foreign key constraints correctly.
This PR is related to issue #2444.

Detailed Changes
------------------
1. Add new column that named 'Reference' to the `tableConstraints` in `EditTableDialog`
2. The new column mentioned earlier works by `m_fkEditor`(src/ForeignKeyEditorDelegate.cpp)

Need Help 🙏 
---------------
1. When editing a table with an existing foreign key constraint set, the field for the foreign key does not appear immediately in the newly added Reference column. (If you double-click to activate the delegate, it is selected normally)
2. The UI element displayed by the `m_fkEditor` delegate is larger than the space for the newly added column.
This can be complicated for the user to see. Tried `clauseEdit` and `m_btnReset` to make it invisible but couldn't fix it.

Known bugs
-------------
1. When editing constraints other than foreign keys, `m_fkEditor` in the Reference column is can working.
(It will be modified within a few days.)

Test Environment
------------------
- macOS Catalina (10.15.7, 19H15)
- [Belfast Bikes Docking Stations Database](https://nightlies.sqlitebrowser.org/example_datasets/Belfast%20Bikes%20Docking%20Stations/)

Screenshot
------------
![Screen Shot 2020-12-16 at 3 30 22](https://user-images.githubusercontent.com/64626662/102256700-098af500-3f4f-11eb-9ae3-fa2b4ad9f495.png)

I waiting for advice on my code. Thank you! 😄 