### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Download macOS releases here:
 The latest macOS binary can be installed via [Homebrew Cask](https://caskroom.github.io/ "Homebrew Cask"):
 
 ```
-brew cask install db-browser-for-sqlite
+brew install --cask db-browser-for-sqlite
 ```
 
 #### Nightly builds


### PR DESCRIPTION
Adapt to new Homebrew api. 

The current command `brew cask install db-browser-for-sqlite` returns an error:

```
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
```

See: https://github.com/Homebrew/discussions/discussions/340