### PR TITLE
Fix issue: save MainWindow geometry, windowState, etc. on exit

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -755,6 +755,8 @@ void MainWindow::closeEvent( QCloseEvent* event )
 
         SqlExecutionArea::saveState();
 
+        Settings::sync();
+
         QMainWindow::closeEvent(event);
     } else {
         event->ignore();

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -627,3 +627,8 @@ bool Settings::importSettings(const QString fileName)
     m_hCache.clear();
     return true;
 }
+
+void Settings::sync()
+{
+    settings->sync();
+}

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -24,6 +24,7 @@ public:
     static void rememberDefaultFontSize(int size) { m_defaultFontSize = size; }
     static void exportSettings(const QString fileName);
     static bool importSettings(const QString fileName);
+    static void sync();
 
 private:
     Settings() = delete;    // class is fully static


### PR DESCRIPTION
In MainWindow::closeEvent() now it calls Settings::sync() to call
QSettings->sync(). Qt documentation
(https://doc.qt.io/qt-5/qsettings.html#sync) says:

"This function is called automatically from QSettings's destructor and
by the event loop at regular intervals, so you normally don't need to
call it yourself."

On my Linux machine QSettings was not syncing to the
~/.config/sqlitebrowser/sqlitebrowser.conf (e.g. if I was doing View ->
Window Layout -> Simplify Window Layout and then close quickly was not
saved). Other settings recently changed before exiting would have been
the same.

Note that Settings is fully static so this seems to be an easy fix.