### PR TITLE
Fixed C++14 requirement in BUILDING.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -3,9 +3,12 @@
 DB Browser for SQLite requires Qt as well as SQLite. For more information on Qt
 please consult http://www.qt.io and for SQLite please see https://sqlite.org/.
 
-Please note that all versions after 3.9.1 will require:
-* Qt 5.5 or later, however we advise you to use 5.7 or later
+Please note that all versions after 3.12.1 will require:
 * A C++ compiler with support for C++14 or later
+
+All versions after 3.9.1 will require:
+* Qt 5.5 or later, however we advise you to use 5.7 or later
+* A C++ compiler with support for C++11 or later
 
 Without these or with older versions you won't be able to compile DB Browser for
 Sqlite anymore. This applies to all platforms. However, most likely you won't


### PR DESCRIPTION
I fixed C++14 requirement from version 3.12.1 instead of 3.9.1. 

I have just checked it out building and installing versions 3.9.10 and 3.12.1 in CentOS 7 with gcc 4.8.5 which supports C++11 but not C++14, and reading the BUILDING.md file of those versions and the current one in the master branch.

By the way, versions 3.9.0 and 3.9.1 fail to compile in CentOS 7 build.make:1620: *** missing separator, but that is a different issue.