### PR TITLE
Update appdata to pass validation

### DIFF
--- a/distri/sqlitebrowser.desktop.appdata.xml
+++ b/distri/sqlitebrowser.desktop.appdata.xml
@@ -22,6 +22,7 @@
       <li>Examine a log of all SQL commands issued by the application</li>
     </ul>
   </description>
+  <content_rating type="oars-1.1" />
   <screenshots>
     <screenshot type="default">
       <image>https://raw.githubusercontent.com/sqlitebrowser/db4s-screenshots/master/v3.3/gnome3_2-execute.png</image>
@@ -42,4 +43,7 @@
   </screenshots>
   <url type="homepage">https://sqlitebrowser.org/</url>
   <url type="bugtracker">https://github.com/sqlitebrowser/sqlitebrowser/issues</url>
+  <releases>
+    <release version="3.12.1" date="2020-11-09" />
+  </releases>
 </component>


### PR DESCRIPTION
The current appdata file is missing the tags `<content_rating>` and `<release>` which causes it to fail the validation run with 

`flatpak run org.freedesktop.appstream-glib validate distri/sqlitebrowser.desktop.appdata.xml` 

This MR just adds in those tags and gets the validation to pass (An empty content_rating tag just confirms there is nothing age restricted in the package). This MR is the only change required to the sqlite browser repo to close https://github.com/sqlitebrowser/sqlitebrowser/issues/2103. If this is merged I can submit the app to flathub as it has been tested and works great with the config linked in the same thread.