### PR TITLE
update plotwindow's selection in tablebrowser

### DIFF
--- a/src/TableBrowser.cpp
+++ b/src/TableBrowser.cpp
@@ -515,6 +515,7 @@ void TableBrowser::refresh()
    applyModelSettings(storedData, buildQuery(storedData, tablename));
    applyViewportSettings(storedData, tablename);
    updateRecordsetLabel();
+   emit updatePlot(ui->dataTable, m_model, &m_settings[tablename], true);
 }
 
 void TableBrowser::clearFilters()


### PR DESCRIPTION
Selections made in plot window are presently not shown in the table browser. This is a feature that was present in earlier versions but was broken after 834e6508bf16bb7ece3a1caf8847ae02e5ad207c. 

