### PR TITLE
Update sqlb_fr.ts

### DIFF
--- a/src/translations/sqlb_fr.ts
+++ b/src/translations/sqlb_fr.ts
@@ -5347,7 +5347,7 @@ Toutes vos préférences seront perdues et les valeurs par défaut seront utilis
     <message>
         <location filename="../RemoteDock.ui" line="143"/>
         <source>Current Database</source>
-        <translation>Bzse de DOnnées en cours</translation>
+        <translation>Base de Données en cours</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="174"/>


### PR DESCRIPTION
FR: correction d'une faute de frappe dans une chaîne (Bzse au lieu de Base)
EN: mispelling in French Translation : Bzse instead of Base