### PR TITLE
Workaround for WindowsVista style (qwindowsvistastyle plugin)

### DIFF
--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -281,18 +281,13 @@ Application::Application(int& argc, char** argv) :
         return;
     }
 
+    // Set StyleProxy
+    QScreen *screen = primaryScreen();
+    setStyle(new DB4SProxyStyle(18, screen != nullptr ? screen->logicalDotsPerInch() : 96, style()));
+
     // Show main window
     m_mainWindow = new MainWindow();
     m_mainWindow->show();
-    QScreen *screen = nullptr;
-    QList<QScreen *> screen_list = screens();
-    if (!screen_list.isEmpty()) {
-        int sn = desktop()->screenNumber(m_mainWindow);
-        screen = sn != -1 ? screen_list.at(sn) : screen_list.at(0);
-    }
-    // Set StyleProxy
-    setStyle(new DB4SProxyStyle(18, screen != nullptr ? screen->logicalDotsPerInch() : 96, style()));
-
     connect(this, &Application::lastWindowClosed, this, &Application::quit);
 
     // Open database if one was specified

--- a/src/TableBrowserDock.cpp
+++ b/src/TableBrowserDock.cpp
@@ -50,9 +50,17 @@ void TableBrowserDock::setFocusStyle(bool on)
 {
     // Highlight title bar when dock widget is active
     if(on)
-        setStyleSheet("QDockWidget::title {background:palette(highlight);}");
+        setStyleSheet(QStringLiteral(
+            "QDockWidget::title {"
+                "background:palette(AlternateBase);"
+                "text-align: center;"
+                "border-bottom: 2px solid palette(highlight);"
+            "}"));
     else
-        setStyleSheet(QString());
+        setStyleSheet(QStringLiteral(
+            "QDockWidget::title {"
+                "text-align: center;"
+            "}"));
 }
 
 void TableBrowserDock::showContextMenuTableBrowserTabBar(const QPoint& pos)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,6 @@
 #include "Application.h"
 #include "sqlite.h"
 #include <QMessageBox>
-#include <QProxyStyle>
 
 static QString message = QString();
 
@@ -28,36 +27,15 @@ void boxMessageOutput(QtMsgType, const QMessageLogContext &, const QString &msg)
     message += msg + "\n";
 }
 
-class DB4SProxyStyle final : public QProxyStyle {
-public:
-    DB4SProxyStyle(int toolBarIconSize)
-        : QProxyStyle(nullptr), toolBarIconSize_(toolBarIconSize) {}
-
-    int pixelMetric(QStyle::PixelMetric metric,
-                    const QStyleOption *option = nullptr,
-                    const QWidget *widget = nullptr) const override {
-
-        if (metric == QStyle::PM_ToolBarIconSize) {
-            return toolBarIconSize_;
-        }
-
-        return QProxyStyle::pixelMetric(metric, option, widget);
-    }
-
-private:
-    int toolBarIconSize_;
-};
-
 int main( int argc, char ** argv )
 {
-
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
-    QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
 #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-    QGuiApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
+    QApplication::setHighDpiScaleFactorRoundingPolicy(Qt::HighDpiScaleFactorRoundingPolicy::PassThrough);
 #endif
 #endif
-    QGuiApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 #ifdef Q_OS_WIN
     // In Windows, there is no output to terminal for a graphical application, so we install
     // the output to message box, until the main window is shown or the application exits.
@@ -66,9 +44,6 @@ int main( int argc, char ** argv )
 
     // Create application object. All the initialisation stuff happens in there
     Application a(argc, argv);
-
-    // Set default QToolbar->iconSize via StyleProxy
-    a.setStyle(new DB4SProxyStyle(16));
 
     // If there has been invocations to the message handler, show it to user in a message box.
     if(!message.isEmpty()) {


### PR DESCRIPTION
There is some strange bug on windows with the system styles (windows and windowsvista).
When styleproxy is used and QDockWidget has a custom stylesheet applied to the widget title, close-button and float-button are rendered huge.

See #2485