### PR TITLE
Fix #2583: quote identifiers, not expressions

### DIFF
--- a/src/sql/Query.h
+++ b/src/sql/Query.h
@@ -32,9 +32,9 @@ struct OrderBy
     std::string toSql() const
     {
         if(is_expression)
-            return sqlb::escapeIdentifier(expr) + (direction == Ascending ? " ASC" : " DESC");
-        else
             return expr + (direction == Ascending ? " ASC" : " DESC");
+        else
+            return sqlb::escapeIdentifier(expr) + (direction == Ascending ? " ASC" : " DESC");
     }
 
     std::string expr;


### PR DESCRIPTION
 94023a5 switched to storing OrderBy terms by column name or expression instead of by column index, and includes a test to ensure that  identifiers are quoted and raw expressions are not; unfortunately it seems to have gotten the logic backwards. See #2583.