### PR TITLE
Refresh all new table browser tabs

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -3825,6 +3825,8 @@ TableBrowserDock* MainWindow::newTableBrowserTab(const sqlb::ObjectIdentifier& t
     d->activateWindow();
     changeTableBrowserTab(d);
 
+    d->tableBrowser()->refresh();
+
     return d;
 }
 


### PR DESCRIPTION
The new multi-tab layout post-3.12.2 has the "Browse Table" context menu option for tables in the Database Structure browser create a new tab for the table, but it does not refresh the newly-created TableBrowser object (outside its constructor, where it doesn't have its model set yet) before it's displayed.
This means the user sees a blank table, and has to manually refresh the view. Since it appears as though the table's empty, this can be confusing, especially if the database happens to have the occasional genuinely-empty table in it. I'm not sure of the correct way to fix this, but this patch certainly works for me.