### PR TITLE
Fix Returning support

### DIFF
--- a/src/RowLoader.cpp
+++ b/src/RowLoader.cpp
@@ -203,7 +203,11 @@ void RowLoader::run ()
 void RowLoader::process (Task & t)
 {
     QString sLimitQuery;
-    if(query.startsWith("PRAGMA", Qt::CaseInsensitive) || query.startsWith("EXPLAIN", Qt::CaseInsensitive))
+    if(query.startsWith("PRAGMA", Qt::CaseInsensitive) || query.startsWith("EXPLAIN", Qt::CaseInsensitive) || 
+        // With RETURNING keyword DELETE,INSERT,UPDATE can return rows
+        // https://www.sqlite.org/lang_returning.html
+        query.startsWith("DELETE", Qt::CaseInsensitive) || query.startsWith("INSERT", Qt::CaseInsensitive) ||
+        query.startsWith("UPDATE", Qt::CaseInsensitive))
     {
         sLimitQuery = query;
     } else {

--- a/src/RunSql.cpp
+++ b/src/RunSql.cpp
@@ -190,13 +190,14 @@ bool RunSql::executeNextStatement()
         case SQLITE_ROW:
         {
             // If we get here, the SQL statement returns some sort of data. So hand it over to the model for display. Don't set the modified flag
-            // because statements that display data don't change data as well.
+            // because statements that display data don't change data as well, except if the statement are one of INSERT/UPDATE/DELETE that could
+            // return datas with the RETURNING keyword.
 
             releaseDbAccess();
 
             lk.lock();
 
-            // in case of usage of RETURNING keyword with INSERT/UPDATE/DELETE
+            // Set the modified flag to true if the statement was one of INSERT/UPDATE/DELETE triggered by a possible RETURNING keyword.
             if (query_part_type == StatementType::InsertStatement || query_part_type == StatementType::UpdateStatement || 
                 query_part_type == StatementType::DeleteStatement)
                 modified = true;

--- a/src/RunSql.cpp
+++ b/src/RunSql.cpp
@@ -195,6 +195,12 @@ bool RunSql::executeNextStatement()
             releaseDbAccess();
 
             lk.lock();
+
+            // in case of usage of RETURNING keyword with INSERT/UPDATE/DELETE
+            if (query_part_type == StatementType::InsertStatement || query_part_type == StatementType::UpdateStatement || 
+                query_part_type == StatementType::DeleteStatement)
+                modified = true;
+
             may_continue_with_execution = false;
 
             auto time_end = std::chrono::high_resolution_clock::now();


### PR DESCRIPTION
Hello 

This will fix #2720 
I tested it with the sample https://www.sqlite.org/lang_returning.html

```
CREATE TABLE t0(
  a INTEGER PRIMARY KEY,
  b DATE DEFAULT CURRENT_TIMESTAMP,
  c INTEGER
);
INSERT INTO t0(c) VALUES(random()) RETURNING *;
```

and with row:
```
INSERT INTO t0(c) VALUES(random()),(random()),(random()),(random()),(random()) RETURNING *;
```

The bug was in the row loader that try to append "LIMIT 49999 OFFSET 0" but it's not a SELECT
