### PR TITLE
Add gtk-common-themes to snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,19 @@
           grade:                  stable
           icon:                   images/logo.svg
           type:                   app
+          plugs:
+            gtk-3-themes:
+              interface: content
+              target: $SNAP/data-dir/themes
+              default-provider: gtk-common-themes:gtk-3-themes
+            sound-themes:
+              interface: content
+              target: $SNAP/data-dir/sounds
+              default-provider: gtk-common-themes:sound-themes
+            icon-themes:
+              interface: content
+              target: $SNAP/data-dir/icons
+              default-provider: gtk-common-themes:icon-themes
           apps:
             sqlitebrowser:
               command: usr/local/bin/sqlitebrowser


### PR DESCRIPTION
This PR adds common GTK themes to the snap that ensure the application is displayed properly under most default configurations. Previously, the snap would be missing the default theme for distros like Ubuntu (Yaru).

Appearance of the application in Ubuntu 20.04.3 LTS before and after this change:

![Before](https://user-images.githubusercontent.com/7153662/148693472-3d2dac50-0324-4e95-92f7-73438bc9b578.png)
<p align="center">Before</p>

![After](https://user-images.githubusercontent.com/7153662/148693534-66876a36-1c7d-48b7-b90d-aa03153ba446.png)
<p align="center">After</p>

Note how in the "before" picture, the cursor also appears much smaller than it should. This is due to fallback theme not respecting my Gnome screen scaling (1.25x).
