### PR TITLE
Add qt5-image-formats-plugins as a snap staging dependency

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -99,6 +99,7 @@
                 - ibus-gtk3
                 - libibus-1.0-5
                 - libgtk2.0-0
+                - qt5-image-formats-plugins
               dump:
                   source:         .
                   plugin:         dump


### PR DESCRIPTION
Allows MNG, TIFF and WEBP images to be decoded by the snap version. Previously, cells using any of the aforementioned formats would just be displayed as binary data.

<p align="center"><img src="https://user-images.githubusercontent.com/7153662/148695426-95c4522e-0c68-4fe0-8751-2bcc9bc346e3.png" width="70%" height="70%"></p>