### PR TITLE
Fix resource compilation for mingw

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,7 +387,7 @@ if(WIN32)
     if(MINGW)
         # resource compilation for MinGW
         add_custom_command(OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/sqlbicon.o"
-            COMMAND windres "-I${CMAKE_CURRENT_SOURCE_DIR}" "-i${CMAKE_CURRENT_SOURCE_DIR}/src/winapp.rc" -o "${CMAKE_CURRENT_BINARY_DIR}/sqlbicon.o" VERBATIM
+            COMMAND windres "-I${CMAKE_CURRENT_BINARY_DIR}" "-i${CMAKE_CURRENT_SOURCE_DIR}/src/winapp.rc" -o "${CMAKE_CURRENT_BINARY_DIR}/sqlbicon.o" VERBATIM
         )
         target_sources(${PROJECT_NAME} PRIVATE "${CMAKE_CURRENT_BINARY_DIR}/sqlbicon.o")
         set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-subsystem,windows")

--- a/src/version.h.in
+++ b/src/version.h.in
@@ -9,7 +9,7 @@
 
 // If it is defined by the compiler, then it is a nightly build, and in the YYYYMMDD format.
 #ifndef BUILD_VERSION
-    #define BUILD_VERSION 0
+    #define BUILD_VERSION "0"
 #endif
 
 #endif


### PR DESCRIPTION
* Include CMAKE_CURRENT_BINARY_DIR for version.h file in winapp.rc.
  Because version.h is now generated by cmake and put in build dir.
* Quote default BUILD_VERSION value, else windres shows syntax error.