### PR TITLE
Add copy column name to table viewer

### DIFF
--- a/src/TableBrowser.cpp
+++ b/src/TableBrowser.cpp
@@ -12,6 +12,7 @@
 #include "sqlitetablemodel.h"
 #include "ui_TableBrowser.h"
 
+#include <QClipboard>
 #include <QInputDialog>
 #include <QMenu>
 #include <QMessageBox>
@@ -67,6 +68,8 @@ TableBrowser::TableBrowser(DBBrowserDB* _db, QWidget* parent) :
     popupHeaderMenu->addSeparator();
     popupHeaderMenu->addAction(ui->actionSetTableEncoding);
     popupHeaderMenu->addAction(ui->actionSetAllTablesEncoding);
+    popupHeaderMenu->addSeparator();
+    popupHeaderMenu->addAction(ui->actionCopyColumnName);
 
     connect(ui->actionSelectColumn, &QAction::triggered, this, [this]() {
         ui->dataTable->selectColumn(ui->actionBrowseTableEditDisplayFormat->property("clicked_column").toInt());
@@ -1491,6 +1494,15 @@ void TableBrowser::setTableEncoding(bool forAllTables)
 void TableBrowser::setDefaultTableEncoding()
 {
     setTableEncoding(true);
+}
+
+void TableBrowser::copyColumnName(){
+    sqlb::ObjectIdentifier current_table = currentlyBrowsedTableName();
+    int col_index = ui->actionBrowseTableEditDisplayFormat->property("clicked_column").toInt();
+    QString field_name = QString::fromStdString(db->getTableByName(current_table)->fields.at(col_index - 1).name());
+
+    QClipboard *clipboard = QApplication::clipboard();
+    clipboard->setText(field_name);
 }
 
 void TableBrowser::jumpToRow(const sqlb::ObjectIdentifier& table, std::string column, const QByteArray& value)

--- a/src/TableBrowser.h
+++ b/src/TableBrowser.h
@@ -134,6 +134,7 @@ private slots:
     void saveFilterAsView();
     void setTableEncoding(bool forAllTables = false);
     void setDefaultTableEncoding();
+    void copyColumnName();
     void fetchedData();
 
 private:

--- a/src/TableBrowser.ui
+++ b/src/TableBrowser.ui
@@ -748,6 +748,14 @@
     <string>Change the default encoding assumed for all tables in the database</string>
    </property>
   </action>
+  <action name="actionCopyColumnName">
+   <property name="text">
+    <string>Copy column name</string>
+   </property>
+   <property name="toolTip">
+    <string>Copy the database table column name to your clipboard</string>
+   </property>
+  </action>
   <action name="actionClearFilters">
    <property name="icon">
     <iconset resource="icons/icons.qrc">


### PR DESCRIPTION
## Description

Hey wanted to see what you guys think of a copy column name feature.

Basically I find myself sometimes needing to copy column names from the browser. I'm sometimes worried about misspelling it and what not. 

This feature aims to ensure it is fast to copy and with 100% accuracy.

## Showcase

https://user-images.githubusercontent.com/24668318/170933015-b532884d-c0d8-4f6f-a58b-876535edabf6.mp4

### Final words
btw really thankful this software exists, so thank you for all your hard work.