### PR TITLE
Updated the packages to build on Ubuntu / Debian

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -57,8 +57,9 @@ The same process works for building the code in any platform supported by Qt
 ### Ubuntu / Debian Linux
 
 ```bash
-$ sudo apt install build-essential git-core cmake libsqlite3-dev qt5-default qttools5-dev-tools \
-    libsqlcipher-dev qtbase5-dev libqt5scintilla2-dev libqcustomplot-dev qttools5-dev
+$ sudo apt install build-essential git cmake libsqlite3-dev qtchooser qt5-qmake qtbase5-dev-tools\
+    qttools5-dev-tools libsqlcipher-dev qtbase5-dev libqt5scintilla2-dev libqcustomplot-dev\
+    qttools5-dev
 $ git clone https://github.com/sqlitebrowser/sqlitebrowser
 $ cd sqlitebrowser
 $ mkdir build


### PR DESCRIPTION
Updated the required package list to build successfully on recent Ubuntu / Debian versions - `qt5-default` was removed in the `qtbase-opensource-src` source package in Debian's version `5.15.1+dfsg-2`.