### PR TITLE
[Fix] Can't parse db name in .env file

### DIFF
--- a/src/DotenvFormat.cpp
+++ b/src/DotenvFormat.cpp
@@ -9,7 +9,7 @@ bool DotenvFormat::readEnvFile(QIODevice &device, QSettings::SettingsMap &map)
 
     QString line;
 
-    QRegularExpression keyValueRegex("^\\s*([\\w\\.\\-]+)\\s*=\\s*(.*)\\s*$");
+    QRegularExpression keyValueRegex("^\\s*([\\w\\.\\-\\@]+)\\s*=\\s*(.*)\\s*$");
 
     while (in.readLineInto(&line)) {
         QRegularExpressionMatch match = keyValueRegex.match(line);

--- a/src/DotenvFormat.cpp
+++ b/src/DotenvFormat.cpp
@@ -9,7 +9,7 @@ bool DotenvFormat::readEnvFile(QIODevice &device, QSettings::SettingsMap &map)
 
     QString line;
 
-    QRegularExpression keyValueRegex("^\\s*([\\w\\.\\-\\@]+)\\s*=\\s*(.*)\\s*$");
+    QRegularExpression keyValueRegex("^\\s*([^=]+)\\s*=\\s*(.*)\\s*$");
 
     while (in.readLineInto(&line)) {
         QRegularExpressionMatch match = keyValueRegex.match(line);


### PR DESCRIPTION
Can't parse db name in .env file when trying to bypass the password. Below is the detailed issue link.
https://github.com/sqlitebrowser/sqlitebrowser/issues/3081