### PR TITLE
Fix build failures on non-Mx-based Macs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,10 @@ if(APPLE AND EXISTS /usr/local/opt/qt5)
     # it is not in the default /usr/local prefix.
     list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
 endif()
+if(APPLE AND EXISTS /usr/local/Cellar/sqlitefts5)
+    execute_process(COMMAND bash "-c" "brew info sqlitefts5 | grep /usr | cut -f1 -d \" \" | tr  -d $\"\n\"" OUTPUT_VARIABLE SQLITEFTS5_PATH)
+    list(PREPEND CMAKE_PREFIX_PATH "${SQLITEFTS5_PATH}")
+endif()
 
 # For M1 Mac's
 if(APPLE AND EXISTS /opt/homebrew/opt/qt5)


### PR DESCRIPTION
## Background and AS-IS
When I try to build the project according to the [BUILDING.md](./BUILDING.md), the following error occurs.
` error: use of undeclared identifier 'sqlite3_enable_load_extension'`

This issue had already been raised in #3068 and resolved with the code below.
https://github.com/sqlitebrowser/sqlitebrowser/blob/420e712d4057b19275fd75140efcfe028ed427ee/CMakeLists.txt#L100-L102
However, on non-Mx-based Macs, Homebrew uses the `/usr/local/Cellar` path, not the `/opt/homebrew`.<sup>*</sup>
So the above code won't work on non-Mx-based Macs.

## TO-BE
Therefore, I changed the code like following flow.
- Check if the `/usr/local/Cellar/sqlitefts5` path exists
- Prepend sqlitefts5's path to `CMAKE_PREFIX_PATH`

## Something to think about 🤔 
The brew info command shows the following output.
```
==> sqlitebrowser/sqlite3/sqlitefts5: stable 3.39.4 (bottled)
Command-line interface for SQLite
https://sqlite.org
/usr/local/Cellar/sqlitefts5/3.39.4 (11 files, 4.3MB) *
  Poured from bottle on 2022-11-30 at 15:30:46
From: https://github.com/sqlitebrowser/homebrew-sqlite3/blob/HEAD/Formula/sqlitefts5.rb
```
From above, run the following command to extract only the path.
`$ brew info sqlitefts5 | grep /usr | cut -f1 -d " " | tr -d $"\n"`
- `brew info sqlitefts5`
    - get `sqlitefts5` formulae information.
- `grep /usr | cut -f1 -d " "`
    - cut string that starts with "/usr" until whitespace.
- `tr -d $"\n"`
    - remove new line escape character.

😞 The code is really messy. Can I get some advice?

## Test Environment
- macOS Catalina Version 10.15.7 (19H2026)
- macOS Monterey Version 12.6.1 (21G217)
- MacBook Pro 10,1 (2012 Mid)

> *: https://docs.brew.sh/Installation