### PR TITLE
docs: Add CHANGELOG.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# CHANGELOG for DB4S
+
+All notable changes to the **Database Browser for SQLite** -
+DB4S - project will be documented in this file.
+
+The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased - nightly] - 2023-05-01
+
+_Add bullet points to the subheadings below as you commit changes.
+When a new version is released, incorporate the changes
+into that version's description, and create a new
+"[Unreleased - nightly] - yyyy-mm-dd"
+entry at the head of this file._
+
+### Added
+- macOS ARM version
+- Indonesian translation
+- Refresh button to Database Structure tab
+- X & Y values shown when hovering over a plot
+
+### Fixed
+- Crash when removing the only index from a table
+- Fix "altering tables with generated 'as' columns"
+
+### Changed
+- Update to SQLite 3.41.1
+
+### Removed
+
+## [3.12.2] - 2021-05-17
+
+Release version of DB4S - DB Browser for SQLite.
+The basic features of the program are described in the
+[README.](https://github.com/sqlitebrowser/sqlitebrowser)
+Download release versions from
+[https://sqlitebrowser.org/dl/](https://sqlitebrowser.org/dl/)
+
+


### PR DESCRIPTION
As suggested in #3334, a CHANGELOG.md file makes it easy for newcomers and occasional users to see the status of the nightly builds versus the stable, released version.

My advice is that the CHANGELOG contain user-facing changes (updates to SQLite, new features, bug fixes, etc) but _not_ changes to the documentation, build process, etc. since they're not as interesting to casual users. Other developers can always check the PR logs to see exactly what has changed.

The beauty of keeping this file up to date is that when the time comes to release a new version, it's fairly straightforward to review and update the **Unreleased - nightly** section to produce the first cut of the announcement for the new version.