### PR TITLE
settings: Specify a default databrowser font

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -288,8 +288,11 @@ QVariant Settings::getDefaultValue(const std::string& group, const std::string& 
     // Data Browser/NULL Fields
     if(group == "databrowser")
     {
-        if(name == "font")
-            return QFont().defaultFamily();
+        if(name == "font") {
+            QFont font("Monospace");
+            font.setStyleHint(QFont::TypeWriter);
+            return QFontInfo(font).family();
+        }
         if(name == "fontsize")
             return 10;
         if(name == "symbol_limit")


### PR DESCRIPTION
This copies the default font from `editor/font` below for `databrowser/font`. Leaving this unset causes odd font issues on macOS when the unset value is read back in.

Fixes #3296