### PR TITLE
ci(macos): Avoid Homebrew return non-zero value issue

### DIFF
--- a/.github/workflows/cppcmake.yml
+++ b/.github/workflows/cppcmake.yml
@@ -78,7 +78,7 @@ jobs:
         uses: actions/checkout@v3
       - name: Install dependencies
         run : |
-          brew update
+          unset HOMEBREW_NO_INSTALL_FROM_API; brew untap homebrew/core; brew update
           brew tap sqlitebrowser/sqlite3
           brew install cmake qt@5 sqlitefts5
           if [ "${{ matrix.sqlcipher }}" = "1" ]; then


### PR DESCRIPTION
This commit is a temporary fix for an issue with the recent `brew update`.
It can be reverted at a later date when the cause of the issue is resolved.

Refer: https://github.com/sqlitebrowser/sqlitebrowser/pull/3393
Refer: https://github.com/orgs/Homebrew/discussions/4612