### PR TITLE
Redirect users to ask questions in the Discussions forum

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: GitHub Community Support
+    url: https://github.com/sqlitebrowser/sqlitebrowser/discussions
+    about: Please ask and answer questions here.


### PR DESCRIPTION
So we have a cleaner Issues list, hopefully, only for feature requests and bug reports.