### PR TITLE
Settings Clean Up

### DIFF
--- a/src/AddRecordDialog.cpp
+++ b/src/AddRecordDialog.cpp
@@ -26,7 +26,7 @@ public:
         if (value) {
             clear();
             setStyleSheet("QLineEdit{ font-style: italic; }");
-            setPlaceholderText(Settings::getValue("databrowser", "null_text").toString());
+            setPlaceholderText(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_TEXT).toString());
             setModified(false);
         } else {
             setStyleSheet("");
@@ -88,7 +88,7 @@ public:
         NullLineEdit* lineEditor = static_cast<NullLineEdit*>(editor);
         // Set the editor in the null state (unless the user has actually written NULL)
         if (index.model()->data(index, Qt::UserRole).isNull() &&
-            index.model()->data(index, Qt::DisplayRole) == Settings::getValue("databrowser", "null_text"))
+            index.model()->data(index, Qt::DisplayRole) == Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_TEXT))
             lineEditor->setNull(true);
         else {
             QStyledItemDelegate::setEditorData(editor, index);
@@ -100,7 +100,7 @@ public:
         NullLineEdit* lineEditor = static_cast<NullLineEdit*>(editor);
         // Restore NULL text (unless the user has already modified the value)
         if (lineEditor->isNull() && !lineEditor->isModified()) {
-            model->setData(index, Settings::getValue("databrowser", "null_text"), Qt::DisplayRole);
+            model->setData(index, Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_TEXT), Qt::DisplayRole);
             model->setData(index, QVariant(), Qt::UserRole);
         } else {
             // Get isModified flag before calling setModelData
@@ -163,8 +163,8 @@ void AddRecordDialog::setDefaultsStyle(QTreeWidgetItem* item)
     QFont font;
     font.setItalic(true);
     item->setData(kValue, Qt::FontRole, font);
-    item->setData(kValue, Qt::BackgroundRole, QColor(Settings::getValue("databrowser", "null_bg_colour").toString()));
-    item->setData(kValue, Qt::ForegroundRole, QColor(Settings::getValue("databrowser", "null_fg_colour").toString()));
+    item->setData(kValue, Qt::BackgroundRole, QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_BG_COLOUR).toString()));
+    item->setData(kValue, Qt::ForegroundRole, QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_FG_COLOUR).toString()));
 }
 
 void AddRecordDialog::populateFields()
@@ -257,7 +257,7 @@ void AddRecordDialog::populateFields()
             tbitem->setData(kValue, Qt::DisplayRole, defaultValue);
             toolTip.append(tr("Default value:\t %1\n").arg(defaultValue));
         } else
-            tbitem->setData(kValue, Qt::DisplayRole, Settings::getValue("databrowser", "null_text"));
+            tbitem->setData(kValue, Qt::DisplayRole, Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_TEXT));
 
 
         if (!toolTip.isEmpty()) {

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -113,7 +113,7 @@ Application::Application(int& argc, char** argv) :
 
     // Load translations
     bool ok;
-    QString name = Settings::getValue("General", "language").toString();
+    QString name = Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_LANGUAGE).toString();
 
     // First of all try to load the application translation file.
     m_translatorApp = new QTranslator(this);
@@ -125,7 +125,7 @@ Application::Application(int& argc, char** argv) :
     }
 
     if (ok == true) {
-        Settings::setValue("General", "language", name);
+        Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_LANGUAGE, name);
         installTranslator(m_translatorApp);
 
         // The application translation file has been found and loaded.
@@ -145,7 +145,7 @@ Application::Application(int& argc, char** argv) :
         // Set the correct locale so that the program won't erroneously detect
         // a language change when the user toggles settings for the first time.
         // (it also prevents the program from always looking for a translation on launch)
-        Settings::setValue("General", "language", "en_US");
+        Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_LANGUAGE, "en_US");
 
         // Don't install a translator for Qt texts if no translator for DB4S texts could be loaded
         m_translatorQt = nullptr;
@@ -380,7 +380,7 @@ void Application::reloadSettings()
 
     // Font settings
     QFont f = font();
-    f.setPointSize(Settings::getValue("General", "fontsize").toInt());
+    f.setPointSize(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_FONTSIZE).toInt());
     setFont(f);
 }
 

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -4,7 +4,6 @@
 #include <QTextCodec>
 #include <QLibraryInfo>
 #include <QLocale>
-#include <QDebug>
 #include <QAction>
 #include <QFileInfo>
 #include <QProxyStyle>
@@ -81,6 +80,14 @@ void printArgument(const QString& argument, const QString& description)
 Application::Application(int& argc, char** argv) :
     QApplication(argc, argv)
 {
+    // Set organisation and application names
+    setOrganizationName("sqlitebrowser");
+    setApplicationName("DB Browser for SQLite");
+
+    // Initialize Settings Object
+    Settings::setSettingsObject();
+    Settings::debug_default();
+
     // Get 'DB4S_SETTINGS_FILE' environment variable
     const auto env = qgetenv("DB4S_SETTINGS_FILE");
 
@@ -103,10 +110,6 @@ Application::Application(int& argc, char** argv) :
             }
         }
     }
-
-    // Set organisation and application names
-    setOrganizationName("sqlitebrowser");
-    setApplicationName("DB Browser for SQLite");
 
     // Set character encoding to UTF8
     QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
@@ -160,9 +163,6 @@ Application::Application(int& argc, char** argv) :
     // Work around a bug in QNetworkAccessManager which sporadically causes high pings for Wifi connections
     // See https://bugreports.qt.io/browse/QTBUG-40332
     qputenv("QT_BEARER_POLL_TIMEOUT", QByteArray::number(INT_MAX));
-
-    // Remember default font size
-    Settings::rememberDefaultFontSize(font().pointSize());
 
     // Parse command line
     QString fileToOpen;

--- a/src/Application.cpp
+++ b/src/Application.cpp
@@ -84,16 +84,8 @@ Application::Application(int& argc, char** argv) :
     setOrganizationName("sqlitebrowser");
     setApplicationName("DB Browser for SQLite");
 
-    // Initialize Settings Object
-    Settings::setSettingsObject();
-    Settings::debug_default();
-
     // Get 'DB4S_SETTINGS_FILE' environment variable
-    const auto env = qgetenv("DB4S_SETTINGS_FILE");
-
-    // If 'DB4S_SETTINGS_FILE' environment variable exists
-    if(!env.isEmpty())
-        Settings::setUserSettingsFile(env);
+    QString envValue(qgetenv(szINI::ENV_SET_FILE.c_str()));
 
     for(int i=1;i<arguments().size();i++)
     {
@@ -101,15 +93,17 @@ Application::Application(int& argc, char** argv) :
         {
             if(++i < arguments().size())
             {
-                if(!env.isEmpty())
+                if(!envValue.isNull() || !envValue.isEmpty())
                 {
                     qWarning() << qPrintable(tr("The user settings file location is replaced with the argument value instead of the environment variable value."));
-                    qWarning() << qPrintable(tr("Ignored environment variable(DB4S_SETTINGS_FILE) value : ") + env);
+                    qWarning() << qPrintable(tr("Ignored environment variable(DB4S_SETTINGS_FILE) value : ") + envValue);
                 }
-                Settings::setUserSettingsFile(arguments().at(i));
+                envValue = QString(arguments().at(i));
             }
         }
     }
+    // Initialize Settings Object
+    Settings::Initialize(envValue);
 
     // Set character encoding to UTF8
     QTextCodec::setCodecForLocale(QTextCodec::codecForName("UTF-8"));
@@ -326,6 +320,8 @@ Application::Application(int& argc, char** argv) :
 
 Application::~Application()
 {
+    // Retain for debugging purposes
+    // Settings::debug_cache();
     if(m_mainWindow)
         delete m_mainWindow;
 }

--- a/src/CondFormat.cpp
+++ b/src/CondFormat.cpp
@@ -125,7 +125,7 @@ std::string CondFormat::filterToSqlCondition(const QString& value, const QString
             // Keep the default LIKE operator
 
             // Set the escape character if one has been specified in the settings dialog
-            QString escape_character = Settings::getValue("databrowser", "filter_escape").toString();
+            QString escape_character = Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FILTER_ESCAPE).toString();
             if(escape_character == "'") escape_character = "''";
             if(escape_character.length())
                 escape = QString("ESCAPE '%1'").arg(escape_character);

--- a/src/CondFormatManager.cpp
+++ b/src/CondFormatManager.cpp
@@ -77,10 +77,10 @@ void CondFormatManager::addNewItem()
     if (currentWidget != nullptr)
         currentWidget->clearFocus();
 
-    QFont font = QFont(Settings::getValue("databrowser", "font").toString());
-    font.setPointSize(Settings::getValue("databrowser", "fontsize").toInt());
+    QFont font = QFont(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT).toString());
+    font.setPointSize(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE).toInt());
 
-    CondFormat newCondFormat("", QColor(Settings::getValue("databrowser", "reg_fg_colour").toString()),
+    CondFormat newCondFormat("", QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_FG_COLOUR).toString()),
                              m_condFormatPalette.nextSerialColor(Palette::appHasDarkTheme()),
                              font,
                              CondFormat::AlignLeft,

--- a/src/DbStructureModel.cpp
+++ b/src/DbStructureModel.cpp
@@ -51,7 +51,7 @@ QVariant DbStructureModel::data(const QModelIndex& index, int role) const
         if(index.column() == ColumnName && item->parent() == browsablesRootItem)
             return QString::fromStdString(sqlb::ObjectIdentifier(item->text(ColumnSchema).toStdString(), item->text(ColumnName).toStdString()).toDisplayString());
         else
-            return Settings::getValue("db", "hideschemalinebreaks").toBool() ? item->text(index.column()).simplified() : item->text(index.column());
+            return Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_HIDE_SCHEMA_LINEBREAKS).toBool() ? item->text(index.column()).simplified() : item->text(index.column());
     case Qt::EditRole:
         return item->text(index.column());
     case Qt::ToolTipRole: {

--- a/src/DbStructureModel.cpp
+++ b/src/DbStructureModel.cpp
@@ -51,7 +51,10 @@ QVariant DbStructureModel::data(const QModelIndex& index, int role) const
         if(index.column() == ColumnName && item->parent() == browsablesRootItem)
             return QString::fromStdString(sqlb::ObjectIdentifier(item->text(ColumnSchema).toStdString(), item->text(ColumnName).toStdString()).toDisplayString());
         else
-            return Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_HIDE_SCHEMA_LINEBREAKS).toBool() ? item->text(index.column()).simplified() : item->text(index.column());
+        {
+            bool bLineBrakes = Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_HIDE_SCHEMA_LINEBREAKS).toBool();
+            return bLineBrakes ? item->text(index.column()).simplified() : item->text(index.column());
+        }
     case Qt::EditRole:
         return item->text(index.column());
     case Qt::ToolTipRole: {

--- a/src/EditDialog.cpp
+++ b/src/EditDialog.cpp
@@ -46,6 +46,9 @@ EditDialog::EditDialog(QWidget* parent)
 
     // Binary editor
     hexEdit = new QHexEdit(this);
+    QFont hexFont = QFont(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString());
+    hexFont.setPointSize(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONTSIZE).toInt());
+    hexEdit->setFont(hexFont);
     hexEdit->setOverwriteMode(false);
     hexEdit->setContextMenuPolicy(Qt::ActionsContextMenu);
     hexEdit->addAction(ui->actionPrint);

--- a/src/EditDialog.cpp
+++ b/src/EditDialog.cpp
@@ -95,11 +95,11 @@ EditDialog::EditDialog(QWidget* parent)
     });
     connect(ui->actionOpenInExternal, &QAction::triggered, this, &EditDialog::openDataWithExternal);
 
-    mustIndentAndCompact = Settings::getValue("databrowser", "indent_compact").toBool();
+    mustIndentAndCompact = Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_INDENT_COMPACT).toBool();
     ui->actionIndent->setChecked(mustIndentAndCompact);
 
-    ui->buttonAutoSwitchMode->setChecked(Settings::getValue("databrowser", "auto_switch_mode").toBool());
-    ui->actionWordWrap->setChecked(Settings::getValue("databrowser", "editor_word_wrap").toBool());
+    ui->buttonAutoSwitchMode->setChecked(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_AUTO_SWITCH_MODE).toBool());
+    ui->actionWordWrap->setChecked(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_EDITOR_WORD_WRAP).toBool());
     setWordWrapping(ui->actionWordWrap->isChecked());
 
     reloadSettings();
@@ -107,9 +107,9 @@ EditDialog::EditDialog(QWidget* parent)
 
 EditDialog::~EditDialog()
 {
-    Settings::setValue("databrowser", "indent_compact",  mustIndentAndCompact);
-    Settings::setValue("databrowser", "auto_switch_mode", ui->buttonAutoSwitchMode->isChecked());
-    Settings::setValue("databrowser", "editor_word_wrap", ui->actionWordWrap->isChecked());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_INDENT_COMPACT,  mustIndentAndCompact);
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_AUTO_SWITCH_MODE, ui->buttonAutoSwitchMode->isChecked());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_EDITOR_WORD_WRAP, ui->actionWordWrap->isChecked());
     delete ui;
 }
 
@@ -368,7 +368,7 @@ void EditDialog::loadData(const QByteArray& bArrdata)
             // Disable text editing, and use a warning message as the contents
             sciEdit->setText(QString(tr("Binary data can't be viewed in this mode.") % '\n' %
                                      tr("Try switching to Binary mode.")));
-            sciEdit->setTextInMargin(Settings::getValue("databrowser", "blob_text").toString());
+            sciEdit->setTextInMargin(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BLOB_TEXT).toString());
             sciEdit->setEnabled(false);
             break;
 
@@ -778,7 +778,7 @@ void EditDialog::setDataInBuffer(const QByteArray& bArrdata, DataSources source)
 
             if (mustIndentAndCompact && isValid) {
                 // Load indented XML into the XML editor
-                textData = xmlDoc.toString(Settings::getValue("editor", "tabsize").toInt());
+                textData = xmlDoc.toString(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_TABSIZE).toInt());
             } else {
                 // Fallback case. The data is not yet valid JSON or no auto-formatting applied.
                 textData = QString::fromUtf8(bArrdata.constData(), bArrdata.size());
@@ -1105,7 +1105,7 @@ void EditDialog::updateCellInfoAndMode(const QByteArray& bArrdata)
         ui->labelInfo->setText(tr("Type: NULL; Size: 0 bytes"));
 
         // Use margin to set the NULL text.
-        sciEdit->setTextInMargin(Settings::getValue("databrowser", "null_text").toString());
+        sciEdit->setTextInMargin(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_TEXT).toString());
         break;
     }
     case XML:
@@ -1139,17 +1139,17 @@ void EditDialog::reloadSettings()
     // Set the (SQL) editor font for hex editor, since it needs a
     // Monospace font and the databrowser font would be usually of
     // variable width.
-    QFont hexFont(Settings::getValue("editor", "font").toString());
-    hexFont.setPointSize(Settings::getValue("databrowser", "fontsize").toInt());
+    QFont hexFont(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString());
+    hexFont.setPointSize(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE).toInt());
     hexEdit->setFont(hexFont);
 
     // Set the databrowser font for the RTL text editor.
-    QFont textFont(Settings::getValue("databrowser", "font").toString());
-    textFont.setPointSize(Settings::getValue("databrowser", "fontsize").toInt());
+    QFont textFont(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT).toString());
+    textFont.setPointSize(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE).toInt());
     ui->qtEdit->setFont(textFont);
 
     ui->editCellToolbar->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>
-                                            (Settings::getValue("General", "toolbarStyleEditCell").toInt()));
+                                            (Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_EDIT_CELL).toInt()));
 
     sciEdit->reloadSettings();
 }

--- a/src/EditDialog.ui
+++ b/src/EditDialog.ui
@@ -167,11 +167,6 @@
       <number>0</number>
      </property>
      <widget class="QTextEdit" name="qtEdit">
-      <property name="font">
-       <font>
-        <family>Monospace</family>
-       </font>
-      </property>
       <property name="whatsThis">
        <string>This Qt editor is used for right-to-left scripts, which are not supported by the default Text editor. The presence of right-to-left characters is detected and this editor mode is automatically selected.</string>
       </property>

--- a/src/EditTableDialog.cpp
+++ b/src/EditTableDialog.cpp
@@ -979,7 +979,7 @@ void EditTableDialog::addField()
     typeBox->setEditable(!m_table.isStrict());  // Strict tables do not allow arbitrary types
     typeBox->addItems(m_table.isStrict() ? DBBrowserDB::DatatypesStrict : DBBrowserDB::Datatypes);
 
-    int defaultFieldTypeIndex = Settings::getValue("db", "defaultfieldtype").toInt();
+    int defaultFieldTypeIndex = Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_FIELD_TYPE).toInt();
 
     if (defaultFieldTypeIndex < DBBrowserDB::Datatypes.count())
     {

--- a/src/ExportDataDialog.cpp
+++ b/src/ExportDataDialog.cpp
@@ -32,11 +32,11 @@ ExportDataDialog::ExportDataDialog(DBBrowserDB& db, ExportFormats format, QWidge
     }
 
     // Retrieve the saved dialog preferences
-    ui->checkHeader->setChecked(Settings::getValue("exportcsv", "firstrowheader").toBool());
-    setSeparatorChar(Settings::getValue("exportcsv", "separator").toInt());
-    setQuoteChar(Settings::getValue("exportcsv", "quotecharacter").toInt());
-    setNewLineString(Settings::getValue("exportcsv", "newlinecharacters").toString());
-    ui->checkPrettyPrint->setChecked(Settings::getValue("exportjson", "prettyprint").toBool());
+    ui->checkHeader->setChecked(Settings::getValue(szINI::SEC_EXPORT_CSV, szINI::KEY_FIRST_ROW_HEADER).toBool());
+    setSeparatorChar(Settings::getValue(szINI::SEC_EXPORT_CSV, szINI::KEY_SEPARATOR).toInt());
+    setQuoteChar(Settings::getValue(szINI::SEC_EXPORT_CSV, szINI::KEY_QUOTE_CHARACTER).toInt());
+    setNewLineString(Settings::getValue(szINI::SEC_EXPORT_CSV, szINI::KEY_NEWLINE_CHARACTERS).toString());
+    ui->checkPrettyPrint->setChecked(Settings::getValue(szINI::SEC_EXPORT_JSON, szINI::KEY_PRETTY_PRINT).toBool());
 
     // Update the visible/hidden status of the "Other" line edit fields
     showCustomCharEdits();
@@ -407,11 +407,11 @@ void ExportDataDialog::accept()
     }
 
     // Save the dialog preferences for future use
-    Settings::setValue("exportcsv", "firstrowheader", ui->checkHeader->isChecked());
-    Settings::setValue("exportjson", "prettyprint", ui->checkPrettyPrint->isChecked());
-    Settings::setValue("exportcsv", "separator", currentSeparatorChar());
-    Settings::setValue("exportcsv", "quotecharacter", currentQuoteChar());
-    Settings::setValue("exportcsv", "newlinecharacters", currentNewLineString());
+    Settings::setValue(szINI::SEC_EXPORT_CSV, szINI::KEY_FIRST_ROW_HEADER, ui->checkHeader->isChecked());
+    Settings::setValue(szINI::SEC_EXPORT_JSON, szINI::KEY_PRETTY_PRINT, ui->checkPrettyPrint->isChecked());
+    Settings::setValue(szINI::SEC_EXPORT_CSV, szINI::KEY_SEPARATOR, currentSeparatorChar());
+    Settings::setValue(szINI::SEC_EXPORT_CSV, szINI::KEY_QUOTE_CHARACTER, currentQuoteChar());
+    Settings::setValue(szINI::SEC_EXPORT_CSV, szINI::KEY_NEWLINE_CHARACTERS, currentNewLineString());
 
     // Notify the user the export has completed
     if(success) {

--- a/src/ExportSqlDialog.cpp
+++ b/src/ExportSqlDialog.cpp
@@ -24,10 +24,10 @@ ExportSqlDialog::ExportSqlDialog(DBBrowserDB* db, QWidget* parent, const QString
     ui->setupUi(this);
 
     // Load settings
-    ui->checkColNames->setChecked(Settings::getValue("exportsql", "insertcolnames").toBool());
-    ui->checkMultiple->setChecked(Settings::getValue("exportsql", "insertmultiple").toBool());
-    ui->checkOriginal->setChecked(Settings::getValue("exportsql", "keeporiginal").toBool());
-    ui->comboOldSchema->setCurrentIndex(Settings::getValue("exportsql", "oldschema").toInt());
+    ui->checkColNames->setChecked(Settings::getValue(szINI::SEC_EXPORT_SQL, szINI::KEY_INSERT_COL_NAMES).toBool());
+    ui->checkMultiple->setChecked(Settings::getValue(szINI::SEC_EXPORT_SQL, szINI::KEY_INSERT_MULTIPLE).toBool());
+    ui->checkOriginal->setChecked(Settings::getValue(szINI::SEC_EXPORT_SQL, szINI::KEY_KEEP_ORIGINAL).toBool());
+    ui->comboOldSchema->setCurrentIndex(Settings::getValue(szINI::SEC_EXPORT_SQL, szINI::KEY_OLD_SCHEMA).toInt());
 
     // Get list of tables to export
     for(const auto& it : pdb->schemata["main"].tables)
@@ -93,10 +93,10 @@ void ExportSqlDialog::accept()
         return;
 
     // Save settings
-    Settings::setValue("exportsql", "insertcolnames", ui->checkColNames->isChecked());
-    Settings::setValue("exportsql", "insertmultiple", ui->checkMultiple->isChecked());
-    Settings::setValue("exportsql", "keeporiginal", ui->checkOriginal->isChecked());
-    Settings::setValue("exportsql", "oldschema", ui->comboOldSchema->currentIndex());
+    Settings::setValue(szINI::SEC_EXPORT_SQL, szINI::KEY_INSERT_COL_NAMES, ui->checkColNames->isChecked());
+    Settings::setValue(szINI::SEC_EXPORT_SQL, szINI::KEY_INSERT_MULTIPLE, ui->checkMultiple->isChecked());
+    Settings::setValue(szINI::SEC_EXPORT_SQL, szINI::KEY_KEEP_ORIGINAL, ui->checkOriginal->isChecked());
+    Settings::setValue(szINI::SEC_EXPORT_SQL, szINI::KEY_OLD_SCHEMA, ui->comboOldSchema->currentIndex());
 
     std::vector<std::string> tables;
     for(const QListWidgetItem* item : ui->listTables->selectedItems())

--- a/src/ExtendedScintilla.cpp
+++ b/src/ExtendedScintilla.cpp
@@ -111,13 +111,13 @@ void ExtendedScintilla::dropEvent(QDropEvent* e)
 
 void ExtendedScintilla::setupSyntaxHighlightingFormat(QsciLexer* lexer, const std::string& settings_name, int style)
 {
-    lexer->setColor(QColor(Settings::getValue("syntaxhighlighter", settings_name + "_colour").toString()), style);
+    lexer->setColor(QColor(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, settings_name + szINI::KEY_ANY_COLOUR).toString()), style);
 
-    QFont font(Settings::getValue("editor", "font").toString());
-    font.setPointSize(Settings::getValue("editor", "fontsize").toInt());
-    font.setBold(Settings::getValue("syntaxhighlighter", settings_name + "_bold").toBool());
-    font.setItalic(Settings::getValue("syntaxhighlighter", settings_name + "_italic").toBool());
-    font.setUnderline(Settings::getValue("syntaxhighlighter", settings_name + "_underline").toBool());
+    QFont font(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString());
+    font.setPointSize(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONTSIZE).toInt());
+    font.setBold(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, settings_name + szINI::KEY_ANY_BOLD).toBool());
+    font.setItalic(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, settings_name + szINI::KEY_ANY_ITALIC).toBool());
+    font.setUnderline(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, settings_name + szINI::KEY_ANY_UNDERLINE).toBool());
     lexer->setFont(font, style);
 }
 
@@ -133,7 +133,7 @@ void ExtendedScintilla::reloadCommonSettings()
 
     // Use desktop default colors for margins when following desktop
     // style, or the colors matching the dark style-sheet, otherwise.
-    switch (Settings::getValue("General", "appStyle").toInt()) {
+    switch (Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_APPSTYLE).toInt()) {
     case Settings::FollowDesktopStyle :
         setMarginsBackgroundColor(QPalette().color(QPalette::Active, QPalette::Window));
         setMarginsForegroundColor(QPalette().color(QPalette::Active, QPalette::WindowText));
@@ -147,13 +147,13 @@ void ExtendedScintilla::reloadCommonSettings()
         setMarginsForegroundColor(QColor(0x00, 0x00, 0x00));
         break;
     }
-    setPaper(Settings::getValue("syntaxhighlighter", "background_colour").toString());
-    setColor(Settings::getValue("syntaxhighlighter", "foreground_colour").toString());
-    setMatchedBraceBackgroundColor(Settings::getValue("syntaxhighlighter", "highlight_colour").toString());
+    setPaper(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_BG_COLOUR).toString());
+    setColor(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FG_COLOUR).toString());
+    setMatchedBraceBackgroundColor(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_HIGHLIGHT_COLOUR).toString());
 
-    setSelectionBackgroundColor(Settings::getValue("syntaxhighlighter", "selected_bg_colour").toString());
+    setSelectionBackgroundColor(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_BG_COLOUR).toString());
 
-    setSelectionForegroundColor(Settings::getValue("syntaxhighlighter", "selected_fg_colour").toString());
+    setSelectionForegroundColor(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_FG_COLOUR).toString());
 }
 
 void ExtendedScintilla::reloadKeywords()
@@ -169,12 +169,12 @@ void ExtendedScintilla::reloadSettings()
 }
 void ExtendedScintilla::reloadLexerSettings(QsciLexer *lexer)
 {
-    QColor foreground (Settings::getValue("syntaxhighlighter", "foreground_colour").toString());
-    QColor background (Settings::getValue("syntaxhighlighter", "background_colour").toString());
+    QColor foreground (Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FG_COLOUR).toString());
+    QColor background (Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_BG_COLOUR).toString());
 
-    QFont defaultfont(Settings::getValue("editor", "font").toString());
+    QFont defaultfont(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString());
     defaultfont.setStyleHint(QFont::TypeWriter);
-    defaultfont.setPointSize(Settings::getValue("editor", "fontsize").toInt());
+    defaultfont.setPointSize(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONTSIZE).toInt());
 
     // Set syntax highlighting settings
     if(lexer)
@@ -199,18 +199,18 @@ void ExtendedScintilla::reloadLexerSettings(QsciLexer *lexer)
 
     // Highlight current line
     setCaretLineVisible(true);
-    setCaretLineBackgroundColor(QColor(Settings::getValue("syntaxhighlighter", "currentline_colour").toString()));
+    setCaretLineBackgroundColor(QColor(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_CUR_LINE_COLOUR).toString()));
     setCaretForegroundColor(foreground);
 
     // Set tab settings
-    setTabWidth(Settings::getValue("editor", "tabsize").toInt());
-    setIndentationsUseTabs(Settings::getValue("editor", "indentation_use_tabs").toBool());
+    setTabWidth(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_TABSIZE).toInt());
+    setIndentationsUseTabs(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_INDENTATION_USE_TABS).toBool());
 
     if(lexer)
         lexer->refreshProperties();
 
     // Check if error indicators are enabled and clear them if they just got disabled
-    showErrorIndicators = Settings::getValue("editor", "error_indicators").toBool();
+    showErrorIndicators = Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_ERROR_INDICATORS).toBool();
     if(!showErrorIndicators)
         clearErrorIndicators();
 

--- a/src/ExtendedScintilla.cpp
+++ b/src/ExtendedScintilla.cpp
@@ -133,7 +133,8 @@ void ExtendedScintilla::reloadCommonSettings()
 
     // Use desktop default colors for margins when following desktop
     // style, or the colors matching the dark style-sheet, otherwise.
-    switch (Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_APPSTYLE).toInt()) {
+    switch (Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_APPSTYLE).toInt())
+    {
     case Settings::FollowDesktopStyle :
         setMarginsBackgroundColor(QPalette().color(QPalette::Active, QPalette::Window));
         setMarginsForegroundColor(QPalette().color(QPalette::Active, QPalette::WindowText));
@@ -173,7 +174,6 @@ void ExtendedScintilla::reloadLexerSettings(QsciLexer *lexer)
     QColor background (Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_BG_COLOUR).toString());
 
     QFont defaultfont(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString());
-    defaultfont.setStyleHint(QFont::TypeWriter);
     defaultfont.setPointSize(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONTSIZE).toInt());
 
     // Set syntax highlighting settings

--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -167,7 +167,7 @@ QWidget* ExtendedTableWidgetEditorDelegate::createEditor(QWidget* parent, const 
 
         QLineEdit* editor = new QLineEdit(parent);
         // If the row count is not greater than the complete threshold setting, set a completer of values based on current values in the column.
-        if (index.model()->rowCount() <= Settings::getValue("databrowser", "complete_threshold").toInt()) {
+        if (index.model()->rowCount() <= Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_COMPLETE_THRESHOLD).toInt()) {
             QCompleter* completer = new QCompleter(editor);
             UniqueFilterModel* completerFilter = new UniqueFilterModel(completer);
             // Provide a filter for the source model, so only unique and non-empty values are accepted.
@@ -494,8 +494,8 @@ void ExtendedTableWidget::setModel(QAbstractItemModel* item_model)
 void ExtendedTableWidget::reloadSettings()
 {
     // We only get the font here to get its metrics. The actual font for the view is set in the model
-    QFont dataBrowserFont(Settings::getValue("databrowser", "font").toString());
-    dataBrowserFont.setPointSize(Settings::getValue("databrowser", "fontsize").toInt());
+    QFont dataBrowserFont(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT).toString());
+    dataBrowserFont.setPointSize(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE).toInt());
 
     // Set new default row height depending on the font size
     QFontMetrics fontMetrics(dataBrowserFont);
@@ -871,7 +871,7 @@ void ExtendedTableWidget::useAsFilter(const QString& filterOperator, bool binary
     // When Containing filter is requested (empty operator) and the value starts with
     // an operator character, the character is escaped.
     if (filterOperator.isEmpty())
-        value.replace(QRegExp("^(<|>|=|/)"), Settings::getValue("databrowser", "filter_escape").toString() + QString("\\1"));
+        value.replace(QRegExp("^(<|>|=|/)"), Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FILTER_ESCAPE).toString() + QString("\\1"));
 
     // If binary operator, the cell data is used as first value and
     // the second value must be added by the user.

--- a/src/FileDialog.cpp
+++ b/src/FileDialog.cpp
@@ -46,8 +46,7 @@ QString FileDialog::getFileDialogPath(const FileDialogTypes dialogType)
     {
     case 0:     // Remember last location
     case 2: {   // Remember last location for current session only
-        QHash<QString, QVariant> lastLocations = Settings::getValue(szINI::SEC_DATABASE, "lastlocations").toHash();
-
+        QHash<QString, QVariant> lastLocations = Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_LAST_LOCATION).toHash();
         return lastLocations[QString(dialogType)].toString();
     }
     case 1:     // Always use this locations
@@ -60,17 +59,16 @@ QString FileDialog::getFileDialogPath(const FileDialogTypes dialogType)
 void FileDialog::setFileDialogPath(const FileDialogTypes dialogType, const QString& new_path)
 {
     QString dir = QFileInfo(new_path).absolutePath();
-    QHash<QString, QVariant> lastLocations = Settings::getValue(szINI::SEC_DATABASE, "lastlocations").toHash();
-
+    QHash<QString, QVariant> lastLocations = Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_LAST_LOCATION).toHash();
     lastLocations[QString(dialogType)] = dir;
 
     switch(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_SAVE_DEFAULT_LOCATION).toInt())
     {
     case 0:     // Remember last location
-        Settings::setValue(szINI::SEC_DATABASE, "lastlocations", lastLocations);
+        Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_LAST_LOCATION, lastLocations);
         break;
     case 2:     // Remember last location for current session only
-        Settings::setValue(szINI::SEC_DATABASE, "lastlocations", lastLocations, false);
+        Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_LAST_LOCATION, lastLocations, false);
         break;
     case 1:     // Always use this locations
         break;  // Do nothing

--- a/src/FileDialog.cpp
+++ b/src/FileDialog.cpp
@@ -42,16 +42,16 @@ QString FileDialog::getExistingDirectory(const FileDialogTypes dialogType, QWidg
 
 QString FileDialog::getFileDialogPath(const FileDialogTypes dialogType)
 {
-    switch(Settings::getValue("db", "savedefaultlocation").toInt())
+    switch(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_SAVE_DEFAULT_LOCATION).toInt())
     {
     case 0:     // Remember last location
     case 2: {   // Remember last location for current session only
-        QHash<QString, QVariant> lastLocations = Settings::getValue("db", "lastlocations").toHash();
+        QHash<QString, QVariant> lastLocations = Settings::getValue(szINI::SEC_DATABASE, "lastlocations").toHash();
 
         return lastLocations[QString(dialogType)].toString();
     }
     case 1:     // Always use this locations
-        return Settings::getValue("db", "defaultlocation").toString();
+        return Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_LOCATION).toString();
     default:
         return QString();
     }
@@ -60,17 +60,17 @@ QString FileDialog::getFileDialogPath(const FileDialogTypes dialogType)
 void FileDialog::setFileDialogPath(const FileDialogTypes dialogType, const QString& new_path)
 {
     QString dir = QFileInfo(new_path).absolutePath();
-    QHash<QString, QVariant> lastLocations = Settings::getValue("db", "lastlocations").toHash();
+    QHash<QString, QVariant> lastLocations = Settings::getValue(szINI::SEC_DATABASE, "lastlocations").toHash();
 
     lastLocations[QString(dialogType)] = dir;
 
-    switch(Settings::getValue("db", "savedefaultlocation").toInt())
+    switch(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_SAVE_DEFAULT_LOCATION).toInt())
     {
     case 0:     // Remember last location
-        Settings::setValue("db", "lastlocations", lastLocations);
+        Settings::setValue(szINI::SEC_DATABASE, "lastlocations", lastLocations);
         break;
     case 2:     // Remember last location for current session only
-        Settings::setValue("db", "lastlocations", lastLocations, false);
+        Settings::setValue(szINI::SEC_DATABASE, "lastlocations", lastLocations, false);
         break;
     case 1:     // Always use this locations
         break;  // Do nothing
@@ -79,5 +79,5 @@ void FileDialog::setFileDialogPath(const FileDialogTypes dialogType, const QStri
 
 QString FileDialog::getSqlDatabaseFileFilter()
 {
-    return Settings::getValue("General", "DBFileExtensions").toString() + ";;" + QObject::tr("All files (*)"); //Always add "All files (*)" to the available filters
+    return Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_DB_FILE_EXTS).toString() + ";;" + QObject::tr("All files (*)"); //Always add "All files (*)" to the available filters
 }

--- a/src/FilterLineEdit.cpp
+++ b/src/FilterLineEdit.cpp
@@ -22,7 +22,7 @@ FilterLineEdit::FilterLineEdit(QWidget* parent, std::vector<FilterLineEdit*>* fi
     // is (re)started. As soon as the user stops typing the timer has a chance to trigger and call the
     // delayedSignalTimerTriggered() method which then stops the timer and emits the delayed signal.
     delaySignalTimer = new QTimer(this);
-    delaySignalTimer->setInterval(Settings::getValue("databrowser", "filter_delay").toInt());  // This is the milliseconds of not-typing we want to wait before triggering
+    delaySignalTimer->setInterval(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FILTER_DELAY).toInt());  // This is the milliseconds of not-typing we want to wait before triggering
     connect(this, &FilterLineEdit::textChanged, delaySignalTimer, static_cast<void (QTimer::*)()>(&QTimer::start));
     connect(delaySignalTimer, &QTimer::timeout, this, &FilterLineEdit::delayedSignalTimerTriggered);
 

--- a/src/ImportCsvDialog.cpp
+++ b/src/ImportCsvDialog.cpp
@@ -72,13 +72,13 @@ ImportCsvDialog::ImportCsvDialog(const std::vector<QString>& filenames, DBBrowse
     ui->comboQuote->blockSignals(true);
     ui->comboEncoding->blockSignals(true);
 
-    ui->checkboxHeader->setChecked(Settings::getValue("importcsv", "firstrowheader").toBool());
-    ui->checkBoxTrimFields->setChecked(Settings::getValue("importcsv", "trimfields").toBool());
-    ui->checkBoxSeparateTables->setChecked(Settings::getValue("importcsv", "separatetables").toBool());
-    ui->checkLocalConventions->setChecked(Settings::getValue("importcsv", "localconventions").toBool());
-    setSeparatorChar(getSettingsChar("importcsv", "separator"));
-    setQuoteChar(getSettingsChar("importcsv", "quotecharacter"));
-    setEncoding(Settings::getValue("importcsv", "encoding").toString());
+    ui->checkboxHeader->setChecked(Settings::getValue(szINI::SEC_IMPORT_CSV, szINI::KEY_FIRST_ROW_HEADER).toBool());
+    ui->checkBoxTrimFields->setChecked(Settings::getValue(szINI::SEC_IMPORT_CSV, szINI::KEY_TRIM_FIELDS).toBool());
+    ui->checkBoxSeparateTables->setChecked(Settings::getValue(szINI::SEC_IMPORT_CSV, szINI::KEY_SEPARATE_TABLES).toBool());
+    ui->checkLocalConventions->setChecked(Settings::getValue(szINI::SEC_IMPORT_CSV, szINI::KEY_LOCAL_CONVENTIONS).toBool());
+    setSeparatorChar(getSettingsChar(szINI::SEC_IMPORT_CSV, szINI::KEY_SEPARATOR));
+    setQuoteChar(getSettingsChar(szINI::SEC_IMPORT_CSV, szINI::KEY_QUOTE_CHARACTER));
+    setEncoding(Settings::getValue(szINI::SEC_IMPORT_CSV, szINI::KEY_ENCODING).toString());
 
     ui->checkboxHeader->blockSignals(false);
     ui->checkBoxTrimFields->blockSignals(false);
@@ -183,13 +183,13 @@ private:
 void ImportCsvDialog::accept()
 {
     // Save settings
-    Settings::setValue("importcsv", "firstrowheader", ui->checkboxHeader->isChecked());
-    Settings::setValue("importcsv", "separator", currentSeparatorChar());
-    Settings::setValue("importcsv", "quotecharacter", currentQuoteChar());
-    Settings::setValue("importcsv", "trimfields", ui->checkBoxTrimFields->isChecked());
-    Settings::setValue("importcsv", "separatetables", ui->checkBoxSeparateTables->isChecked());
-    Settings::setValue("importcsv", "localconventions", ui->checkLocalConventions->isChecked());
-    Settings::setValue("importcsv", "encoding", currentEncoding());
+    Settings::setValue(szINI::SEC_IMPORT_CSV, szINI::KEY_FIRST_ROW_HEADER, ui->checkboxHeader->isChecked());
+    Settings::setValue(szINI::SEC_IMPORT_CSV, szINI::KEY_SEPARATOR, currentSeparatorChar());
+    Settings::setValue(szINI::SEC_IMPORT_CSV, szINI::KEY_QUOTE_CHARACTER, currentQuoteChar());
+    Settings::setValue(szINI::SEC_IMPORT_CSV, szINI::KEY_TRIM_FIELDS, ui->checkBoxTrimFields->isChecked());
+    Settings::setValue(szINI::SEC_IMPORT_CSV, szINI::KEY_SEPARATE_TABLES, ui->checkBoxSeparateTables->isChecked());
+    Settings::setValue(szINI::SEC_IMPORT_CSV, szINI::KEY_LOCAL_CONVENTIONS, ui->checkLocalConventions->isChecked());
+    Settings::setValue(szINI::SEC_IMPORT_CSV, szINI::KEY_ENCODING, currentEncoding());
 
     // Get all the selected files and start the import
     if (ui->filePickerBlock->isVisible())

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1590,7 +1590,11 @@ void MainWindow::openPreferences()
 {
     PreferencesDialog dialog(this);
     if(dialog.exec())
+    {
         reloadSettings();
+        Settings::debug_cache();
+    }
+
 }
 
 //** Db Tree Context Menu
@@ -2370,8 +2374,7 @@ void MainWindow::reloadSettings()
         qobject_cast<SqlExecutionArea*>(ui->tabSqlAreas->widget(i))->reloadSettings();
 
     // Prepare log font
-    QFont logfont("Monospace");
-    logfont.setStyleHint(QFont::TypeWriter);
+    QFont logfont(Settings::getValue(szINI::SEC_LOG, szINI::KEY_FONT).toString());
     logfont.setPointSize(Settings::getValue(szINI::SEC_LOG, szINI::KEY_FONTSIZE).toInt());
 
     // Set font for SQL logs and edit dialog

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -103,7 +103,7 @@ void MainWindow::init()
     // Automatic update check
 #ifdef CHECKNEWVERSION
     // Check for a new version if automatic update check aren't disabled in the settings dialog
-    if(Settings::getValue("checkversion", "enabled").toBool())
+    if(Settings::getValue(szINI::SEC_CHCK_VERSION, szINI::KEY_ENABLED).toBool())
     {
         RemoteNetwork::get().fetch(QUrl("https://download.sqlitebrowser.org/currentrelease"), RemoteNetwork::RequestTypeCustom,
                                    QString(), [this](const QByteArray& reply) {
@@ -162,18 +162,18 @@ void MainWindow::init()
     editDock->setReadOnly(true);
 
     // Restore window geometry
-    restoreGeometry(Settings::getValue("MainWindow", "geometry").toByteArray());
+    restoreGeometry(Settings::getValue(szINI::SEC_MAIN_WNDW, szINI::KEY_GEOMETRY).toByteArray());
 
     // Save default and restore window state
     defaultWindowState = saveState();
-    restoreState(Settings::getValue("MainWindow", "windowState").toByteArray());
+    restoreState(Settings::getValue(szINI::SEC_MAIN_WNDW, szINI::KEY_WINDOW_STATE).toByteArray());
 
     // Save default and restore open tab order if the openTabs setting is saved.
     defaultOpenTabs = saveOpenTabs();
-    restoreOpenTabs(Settings::getValue("MainWindow", "openTabs").toString());
+    restoreOpenTabs(Settings::getValue(szINI::SEC_MAIN_WNDW, szINI::KEY_OPEN_TABS).toString());
 
     // Restore dock state settings
-    ui->comboLogSubmittedBy->setCurrentIndex(ui->comboLogSubmittedBy->findText(Settings::getValue("SQLLogDock", "Log").toString()));
+    ui->comboLogSubmittedBy->setCurrentIndex(ui->comboLogSubmittedBy->findText(Settings::getValue(szINI::SEC_SQL_LOG_DOCK, szINI::KEY_LOG).toString()));
 
     // Add keyboard shortcuts
     QShortcut* shortcutBrowseRefreshF5 = new QShortcut(QKeySequence("F5"), this);
@@ -219,7 +219,7 @@ void MainWindow::init()
     connect(shortcutFocusEditor, &QShortcut::activated, this, &MainWindow::focusSqlEditor);
 
     // Get MaxRecentFiles value from QSettings.
-    MaxRecentFiles = Settings::getValue("General", "maxRecentFiles").toInt();
+    MaxRecentFiles = Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_MAX_RECENT_FILES).toInt();
     recentFileActs.resize(MaxRecentFiles);
 
     // Create the actions for the recently opened dbs list
@@ -427,9 +427,9 @@ void MainWindow::init()
     connect(ui->actionEnquoteNamesCheck, &QAction::toggled, dbStructureModel, &DbStructureModel::setDropEnquotedNames);
     connect(&db, &DBBrowserDB::databaseInUseChanged, this, &MainWindow::updateDatabaseBusyStatus);
 
-    ui->actionDropSelectQueryCheck->setChecked(Settings::getValue("SchemaDock", "dropSelectQuery").toBool());
-    ui->actionDropQualifiedCheck->setChecked(Settings::getValue("SchemaDock", "dropQualifiedNames").toBool());
-    ui->actionEnquoteNamesCheck->setChecked(Settings::getValue("SchemaDock", "dropEnquotedNames").toBool());
+    ui->actionDropSelectQueryCheck->setChecked(Settings::getValue(szINI::SEC_SCHEMA_DOCK, szINI::KEY_DROP_SELECT_QUERY).toBool());
+    ui->actionDropQualifiedCheck->setChecked(Settings::getValue(szINI::SEC_SCHEMA_DOCK, szINI::KEY_DROP_QUALIFIED_NAMES).toBool());
+    ui->actionEnquoteNamesCheck->setChecked(Settings::getValue(szINI::SEC_SCHEMA_DOCK, szINI::KEY_DROP_ENQUOTED_NAMES).toBool());
 
     connect(ui->actionSqlStop, &QAction::triggered, this, [this]() {
        if(execute_sql_worker && execute_sql_worker->isRunning())
@@ -548,7 +548,7 @@ bool MainWindow::fileOpen(const QString& fileName, bool openFromProject, bool re
                         closeSqlTab(i, true);
                 }
 
-                statusEncodingLabel->setText(db.getPragma("encoding"));
+                statusEncodingLabel->setText(db.getPragma(szINI::KEY_ENCODING));
                 statusEncryptionLabel->setVisible(db.encrypted());
                 statusReadOnlyLabel->setVisible(db.readOnly());
                 setCurrentFile(wFile);
@@ -592,7 +592,7 @@ void MainWindow::fileNew()
         db.create(fileName);
         setCurrentFile(fileName);
         addToRecentFilesMenu(fileName);
-        statusEncodingLabel->setText(db.getPragma("encoding"));
+        statusEncodingLabel->setText(db.getPragma(szINI::KEY_ENCODING));
         statusEncryptionLabel->setVisible(false);
         statusReadOnlyLabel->setVisible(false);
         refreshTableBrowsers();
@@ -609,7 +609,7 @@ void MainWindow::fileNewInMemoryDatabase(bool open_create_dialog)
     db.open(":memory:");
 
     setCurrentFile(tr("In-Memory database"));
-    statusEncodingLabel->setText(db.getPragma("encoding"));
+    statusEncodingLabel->setText(db.getPragma(szINI::KEY_ENCODING));
     statusEncryptionLabel->setVisible(false);
     statusReadOnlyLabel->setVisible(false);
     remoteDock->fileOpened(":memory:");
@@ -765,14 +765,14 @@ void MainWindow::closeEvent( QCloseEvent* event )
 {
     if(closeFiles())
     {
-        Settings::setValue("MainWindow", "geometry", saveGeometry());
-        Settings::setValue("MainWindow", "windowState", saveState());
-        Settings::setValue("MainWindow", "openTabs", saveOpenTabs());
+        Settings::setValue(szINI::SEC_MAIN_WNDW, szINI::KEY_GEOMETRY, saveGeometry());
+        Settings::setValue(szINI::SEC_MAIN_WNDW, szINI::KEY_WINDOW_STATE, saveState());
+        Settings::setValue(szINI::SEC_MAIN_WNDW, szINI::KEY_OPEN_TABS, saveOpenTabs());
 
-        Settings::setValue("SQLLogDock", "Log", ui->comboLogSubmittedBy->currentText());
-        Settings::setValue("SchemaDock", "dropSelectQuery", ui->actionDropSelectQueryCheck->isChecked());
-        Settings::setValue("SchemaDock", "dropQualifiedNames", ui->actionDropQualifiedCheck->isChecked());
-        Settings::setValue("SchemaDock", "dropEnquotedNames", ui->actionEnquoteNamesCheck->isChecked());
+        Settings::setValue(szINI::SEC_SQL_LOG_DOCK, szINI::KEY_LOG, ui->comboLogSubmittedBy->currentText());
+        Settings::setValue(szINI::SEC_SCHEMA_DOCK, szINI::KEY_DROP_SELECT_QUERY, ui->actionDropSelectQueryCheck->isChecked());
+        Settings::setValue(szINI::SEC_SCHEMA_DOCK, szINI::KEY_DROP_QUALIFIED_NAMES, ui->actionDropQualifiedCheck->isChecked());
+        Settings::setValue(szINI::SEC_SCHEMA_DOCK, szINI::KEY_DROP_ENQUOTED_NAMES, ui->actionEnquoteNamesCheck->isChecked());
 
         SqlExecutionArea::saveState();
 
@@ -1728,7 +1728,7 @@ void MainWindow::openRecentFile()
 void MainWindow::updateRecentFileActions()
 {
     // Get recent files list from settings
-    QStringList files = Settings::getValue("General", "recentFileList").toStringList();
+    QStringList files = Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_RECENT_FILE_LIST).toStringList();
 
     // Check if files still exist and remove any non-existent file
     for(int i=0;i<files.size();i++)
@@ -1746,7 +1746,7 @@ void MainWindow::updateRecentFileActions()
     }
 
     // Store updated list
-    Settings::setValue("General", "recentFileList", files);
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_RECENT_FILE_LIST, files);
 
     int numRecentFiles = qMin(files.size(), MaxRecentFiles);
 
@@ -1807,14 +1807,14 @@ void MainWindow::addToRecentFilesMenu(const QString& filename, bool read_only)
     if(read_only)
         path = "[ro]" + path;
 
-    QStringList files = Settings::getValue("General", "recentFileList").toStringList();
+    QStringList files = Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_RECENT_FILE_LIST).toStringList();
 
     files.removeAll(path);
     files.prepend(path);
     while (files.size() > MaxRecentFiles)
         files.removeLast();
 
-    Settings::setValue("General", "recentFileList", files);
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_RECENT_FILE_LIST, files);
 
     for(QWidget* widget : QApplication::topLevelWidgets()) {
         MainWindow *mainWin = qobject_cast<MainWindow *>(widget);
@@ -2027,7 +2027,7 @@ void MainWindow::logSql(const QString& sql, int msgtype)
 bool MainWindow::askSaveSqlTab(int index, bool& ignoreUnattachedBuffers)
 {
     SqlExecutionArea* sqlExecArea = qobject_cast<SqlExecutionArea*>(ui->tabSqlAreas->widget(index));
-    const bool isPromptSQLTabsInNewProject = Settings::getValue("General", "promptsqltabsinnewproject").toBool();
+    const bool isPromptSQLTabsInNewProject = Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_PROMPT_SQL_TABS_IN_NEWPRJ).toBool();
 
     if(sqlExecArea->getEditor()->isModified()) {
         if(sqlExecArea->fileName().isEmpty() && !ignoreUnattachedBuffers && isPromptSQLTabsInNewProject) {
@@ -2304,7 +2304,7 @@ void MainWindow::reloadSettings()
         d->tableBrowser()->reloadSettings();
 
     // Set max recent files
-    const int newMaxRecentFiles = Settings::getValue("General", "maxRecentFiles").toInt();
+    const int newMaxRecentFiles = Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_MAX_RECENT_FILES).toInt();
 
     if(MaxRecentFiles < newMaxRecentFiles) {
         // If user increase max recent files value.
@@ -2337,7 +2337,7 @@ void MainWindow::reloadSettings()
         updateRecentFileActions();
     }
 
-    Settings::AppStyle style = static_cast<Settings::AppStyle>(Settings::getValue("General", "appStyle").toInt());
+    Settings::AppStyle style = static_cast<Settings::AppStyle>(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_APPSTYLE).toInt());
 
     switch (style) {
     case Settings::FollowDesktopStyle :
@@ -2358,12 +2358,12 @@ void MainWindow::reloadSettings()
         break;
     }
 
-    ui->toolbarDB->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue("General", "toolbarStyle").toInt()));
-    ui->dbToolbar->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue("General", "toolbarStyleStructure").toInt()));
-    ui->toolbarSql->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue("General", "toolbarStyleSql").toInt()));
+    ui->toolbarDB->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_APP).toInt()));
+    ui->dbToolbar->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_STRUCTURE).toInt()));
+    ui->toolbarSql->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_SQL).toInt()));
     // Other toolbars will follow Main Window ToolBar Style
-    ui->toolbarExtraDB->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue("General", "toolbarStyle").toInt()));
-    ui->toolbarProject->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue("General", "toolbarStyle").toInt()));
+    ui->toolbarExtraDB->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_APP).toInt()));
+    ui->toolbarProject->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_APP).toInt()));
 
     // Set prefetch sizes for lazy population of table models
     for(int i=0;i<ui->tabSqlAreas->count();++i)
@@ -2372,7 +2372,7 @@ void MainWindow::reloadSettings()
     // Prepare log font
     QFont logfont("Monospace");
     logfont.setStyleHint(QFont::TypeWriter);
-    logfont.setPointSize(Settings::getValue("log", "fontsize").toInt());
+    logfont.setPointSize(Settings::getValue(szINI::SEC_LOG, szINI::KEY_FONTSIZE).toInt());
 
     // Set font for SQL logs and edit dialog
     ui->editLogApplication->reloadSettings();
@@ -2385,7 +2385,7 @@ void MainWindow::reloadSettings()
 
     // Set font for database structure views
     QFont structure_font = ui->dbTreeWidget->font();
-    structure_font.setPointSize(Settings::getValue("db", "fontsize").toInt());
+    structure_font.setPointSize(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_FONTSIZE).toInt());
     ui->dbTreeWidget->setFont(structure_font);
     ui->treeSchemaDock->setFont(structure_font);
 
@@ -2397,7 +2397,7 @@ void MainWindow::reloadSettings()
     refreshTableBrowsers();
 
     // Hide or show the remote dock as needed
-    bool showRemoteActions = Settings::getValue("remote", "active").toBool();
+    bool showRemoteActions = Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_ACTIVE).toBool();
     ui->viewMenu->actions().at(4)->setVisible(showRemoteActions);
     if(!showRemoteActions)
         ui->dockRemote->setHidden(true);
@@ -2405,9 +2405,9 @@ void MainWindow::reloadSettings()
     // Reload remote dock settings
     remoteDock->reloadSettings();
 
-    sqlb::setIdentifierQuoting(static_cast<sqlb::escapeQuoting>(Settings::getValue("editor", "identifier_quotes").toInt()));
+    sqlb::setIdentifierQuoting(static_cast<sqlb::escapeQuoting>(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_IDENTIFIER_QUOTES).toInt()));
 
-    ui->tabSqlAreas->setTabsClosable(Settings::getValue("editor", "close_button_on_tabs").toBool());
+    ui->tabSqlAreas->setTabsClosable(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_CLOSE_BUTTON_ON_TABS).toBool());
 }
 
 void MainWindow::checkNewVersion(const QString& versionstring, const QString& url)
@@ -2437,9 +2437,9 @@ void MainWindow::checkNewVersion(const QString& versionstring, const QString& ur
 
     if(newversion)
     {
-        int ignmajor = Settings::getValue("checkversion", "ignmajor").toInt();
-        int ignminor = Settings::getValue("checkversion", "ignminor").toInt();
-        int ignpatch = Settings::getValue("checkversion", "ignpatch").toInt();
+        int ignmajor = Settings::getValue(szINI::SEC_CHCK_VERSION, szINI::KEY_IGNMAJOR).toInt();
+        int ignminor = Settings::getValue(szINI::SEC_CHCK_VERSION, szINI::KEY_IGNMINOR).toInt();
+        int ignpatch = Settings::getValue(szINI::SEC_CHCK_VERSION, szINI::KEY_IGNPATCH).toInt();
 
         // check if the user doesn't care about the current update
         if(!(ignmajor == major && ignminor == minor && ignpatch == patch))
@@ -2457,9 +2457,9 @@ void MainWindow::checkNewVersion(const QString& versionstring, const QString& ur
             if(msgBox.clickedButton() == idontcarebutton)
             {
                 // save that the user don't want to get bothered about this update
-                Settings::setValue("checkversion", "ignmajor", major);
-                Settings::setValue("checkversion", "ignminor", minor);
-                Settings::setValue("checkversion", "ignpatch", patch);
+                Settings::setValue(szINI::SEC_CHCK_VERSION, szINI::KEY_IGNMAJOR, major);
+                Settings::setValue(szINI::SEC_CHCK_VERSION, szINI::KEY_IGNMINOR, minor);
+                Settings::setValue(szINI::SEC_CHCK_VERSION, szINI::KEY_IGNPATCH, patch);
             }
         }
     }
@@ -2552,7 +2552,7 @@ static void loadCondFormatMap(BrowseDataTableSettings::CondFormatMap& condFormat
                     if (xml.attributes().hasAttribute("font"))
                         font.fromString(xml.attributes().value("font").toString());
                     else
-                        Settings::getValue("databrowser", "font").toString();
+                        Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT).toString();
 
                     CondFormat::Alignment align;
                     if (xml.attributes().hasAttribute("align"))
@@ -2853,7 +2853,7 @@ MainWindow::LoadAttempResult MainWindow::loadProject(QString filename, bool read
                         } else if(xml.name() == "browsetable_info") {
                             // This tag is only found in old project files. In newer versions (>= 3.11) it is replaced by a new implementation.
                             // 3.12 is the last version to support loading this file format, so just show a warning here.
-                            if(!Settings::getValue("idontcare", "projectBrowseTable").toBool())
+                            if(!Settings::getValue(szINI::SEC_DONT_CARE, szINI::KEY_PROJECT_BROWSE_TABLE).toBool())
                             {
                                 QMessageBox msgBox;
                                 QPushButton* idontcarebutton = msgBox.addButton(tr("Don't show again"), QMessageBox::ActionRole);
@@ -2865,7 +2865,7 @@ MainWindow::LoadAttempResult MainWindow::loadProject(QString filename, bool read
                                                   "it completely, please use DB Browser for SQLite version 3.12 to convert it to the new file format."));
                                 msgBox.exec();
                                 if(msgBox.clickedButton() == idontcarebutton)
-                                    Settings::setValue("idontcare", "projectBrowseTable", false);
+                                    Settings::setValue(szINI::SEC_DONT_CARE, szINI::KEY_PROJECT_BROWSE_TABLE, false);
                             }
 
                             xml.skipCurrentElement();
@@ -3416,7 +3416,7 @@ void MainWindow::fileOpenReadOnly()
 void MainWindow::requestCollation(const QString& name, int eTextRep)
 {
     // Show message box
-    if(!Settings::getValue("db", "dont_ask_collation").toBool())
+    if(!Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_DONT_ASK_COLLATION).toBool())
     {
         QMessageBox msgbox;
         QPushButton* button_dont_ask_again = msgbox.addButton(tr("Yes. Don't ask again"), QMessageBox::ActionRole);
@@ -3434,7 +3434,7 @@ void MainWindow::requestCollation(const QString& name, int eTextRep)
         // Cancel here if the No button was clicked
         if(msgbox.clickedButton() == button_dont_ask_again)
         {
-            Settings::setValue("db", "dont_ask_collation", false);
+            Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_DONT_ASK_COLLATION, false);
         } else if(reply == QMessageBox::No) {
             return;
         }
@@ -3811,7 +3811,7 @@ void MainWindow::moveDocksTo(Qt::DockWidgetArea area)
 
 void MainWindow::clearRecentFiles()
 {
-    Settings::clearValue("General", "recentFileList");
+    Settings::clearValue(szINI::SEC_GENERAL, szINI::KEY_RECENT_FILE_LIST);
 
     for(int i=0; i < MaxRecentFiles; ++i)
         recentFileActs[i]->setVisible(false);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1592,7 +1592,7 @@ void MainWindow::openPreferences()
     if(dialog.exec())
     {
         reloadSettings();
-        Settings::debug_cache();
+        // Settings::debug_cache();
     }
 
 }

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -998,34 +998,16 @@ You can drag SQL statements from an object row and drop them into other applicat
         <number>0</number>
        </property>
        <widget class="SqlTextEdit" name="editLogUser">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <pointsize>8</pointsize>
-         </font>
-        </property>
         <property name="readOnly" stdset="0">
          <bool>true</bool>
         </property>
        </widget>
        <widget class="SqlTextEdit" name="editLogApplication">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <pointsize>8</pointsize>
-         </font>
-        </property>
         <property name="readOnly" stdset="0">
          <bool>true</bool>
         </property>
        </widget>
        <widget class="ExtendedScintilla" name="editLogErrorLog">
-        <property name="font">
-         <font>
-          <family>Monospace</family>
-          <pointsize>8</pointsize>
-         </font>
-        </property>
         <property name="readOnly">
          <bool>true</bool>
         </property>

--- a/src/PlotDock.cpp
+++ b/src/PlotDock.cpp
@@ -49,9 +49,9 @@ PlotDock::PlotDock(QWidget* parent)
     ui->treePlotColumns->setSelectionMode(QAbstractItemView::NoSelection);
 
     // Restore state
-    ui->splitterForPlot->restoreState(Settings::getValue("PlotDock", "splitterSize").toByteArray());
-    ui->comboLineType->setCurrentIndex(Settings::getValue("PlotDock", "lineType").toInt());
-    ui->comboPointShape->setCurrentIndex(Settings::getValue("PlotDock", "pointShape").toInt());
+    ui->splitterForPlot->restoreState(Settings::getValue(szINI::SEC_PLOT_DOCK, szINI::KEY_SPLITTER_SIZE).toByteArray());
+    ui->comboLineType->setCurrentIndex(Settings::getValue(szINI::SEC_PLOT_DOCK, szINI::KEY_LINE_TYPE).toInt());
+    ui->comboPointShape->setCurrentIndex(Settings::getValue(szINI::SEC_PLOT_DOCK, szINI::KEY_POINT_SHAPE).toInt());
 
     // Connect signals
     connect(ui->plotWidget, &QCustomPlot::selectionChangedByUser, this, &PlotDock::selectionChanged);
@@ -129,9 +129,9 @@ PlotDock::PlotDock(QWidget* parent)
 PlotDock::~PlotDock()
 {
     // Save state
-    Settings::setValue("PlotDock", "splitterSize", ui->splitterForPlot->saveState());
-    Settings::setValue("PlotDock", "lineType", ui->comboLineType->currentIndex());
-    Settings::setValue("PlotDock", "pointShape", ui->comboPointShape->currentIndex());
+    Settings::setValue(szINI::SEC_PLOT_DOCK, szINI::KEY_SPLITTER_SIZE, ui->splitterForPlot->saveState());
+    Settings::setValue(szINI::SEC_PLOT_DOCK, szINI::KEY_LINE_TYPE, ui->comboLineType->currentIndex());
+    Settings::setValue(szINI::SEC_PLOT_DOCK, szINI::KEY_POINT_SHAPE, ui->comboPointShape->currentIndex());
 
     // Finally, delete all widgets
     delete ui;

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -566,19 +566,19 @@ void PreferencesDialog::saveColorSetting(QFrame* frame, const std::string& setti
 void PreferencesDialog::adjustColorsToStyle(int style)
 {
     Settings::AppStyle appStyle = static_cast<Settings::AppStyle>(style);
-    setColorSetting(ui->fr_null_fg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_FG_COLOUR, appStyle));
-    setColorSetting(ui->fr_null_bg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_BG_COLOUR, appStyle));
-    setColorSetting(ui->fr_bin_fg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_FG_COLOUR, appStyle));
-    setColorSetting(ui->fr_bin_bg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_BG_COLOUR, appStyle));
-    setColorSetting(ui->fr_reg_fg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_FG_COLOUR, appStyle));
-    setColorSetting(ui->fr_reg_bg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_BG_COLOUR, appStyle));
-    setColorSetting(ui->fr_formatted_fg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_FG_COLOUR, appStyle));
-    setColorSetting(ui->fr_formatted_bg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_BG_COLOUR, appStyle));
+    setColorSetting(ui->fr_null_fg, Settings::getDefaultColourValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_FG_COLOUR, appStyle));
+    setColorSetting(ui->fr_null_bg, Settings::getDefaultColourValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_BG_COLOUR, appStyle));
+    setColorSetting(ui->fr_bin_fg, Settings::getDefaultColourValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_FG_COLOUR, appStyle));
+    setColorSetting(ui->fr_bin_bg, Settings::getDefaultColourValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_BG_COLOUR, appStyle));
+    setColorSetting(ui->fr_reg_fg, Settings::getDefaultColourValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_FG_COLOUR, appStyle));
+    setColorSetting(ui->fr_reg_bg, Settings::getDefaultColourValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_BG_COLOUR, appStyle));
+    setColorSetting(ui->fr_formatted_fg, Settings::getDefaultColourValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_FG_COLOUR, appStyle));
+    setColorSetting(ui->fr_formatted_bg, Settings::getDefaultColourValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_BG_COLOUR, appStyle));
 
     for(int i=0; i < ui->treeSyntaxHighlighting->topLevelItemCount(); ++i)
     {
         std::string name = ui->treeSyntaxHighlighting->topLevelItem(i)->text(0).toStdString();
-        QColor color = Settings::getDefaultColorValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_COLOUR, appStyle);
+        QColor color = Settings::getDefaultColourValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_COLOUR, appStyle);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setForeground(2, color);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setBackground(2, color);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setText(2, color.name());

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -19,7 +19,7 @@ PreferencesDialog::PreferencesDialog(QWidget* parent, Tabs tab)
     : QDialog(parent),
       ui(new Ui::PreferencesDialog),
       m_proxyDialog(new ProxyDialog(this)),
-      m_dbFileExtensions(Settings::getValue("General", "DBFileExtensions").toString().split(";;"))
+      m_dbFileExtensions(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_DB_FILE_EXTS).toString().split(";;"))
 {
     ui->setupUi(this);
     ui->treeSyntaxHighlighting->setColumnHidden(0, true);
@@ -79,57 +79,57 @@ void PreferencesDialog::chooseLocation()
 
 void PreferencesDialog::loadSettings()
 {
-    ui->encodingComboBox->setCurrentIndex(ui->encodingComboBox->findText(Settings::getValue("db", "defaultencoding").toString(), Qt::MatchFixedString));
-    ui->comboDefaultLocation->setCurrentIndex(Settings::getValue("db", "savedefaultlocation").toInt());
-    ui->locationEdit->setText(QDir::toNativeSeparators(Settings::getValue("db", "defaultlocation").toString()));
-    ui->checkPromptSQLTabsInNewProject->setChecked(Settings::getValue("General", "promptsqltabsinnewproject").toBool());
-    ui->checkUpdates->setChecked(Settings::getValue("checkversion", "enabled").toBool());
+    ui->encodingComboBox->setCurrentIndex(ui->encodingComboBox->findText(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_ENCODING).toString(), Qt::MatchFixedString));
+    ui->comboDefaultLocation->setCurrentIndex(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_SAVE_DEFAULT_LOCATION).toInt());
+    ui->locationEdit->setText(QDir::toNativeSeparators(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_LOCATION).toString()));
+    ui->checkPromptSQLTabsInNewProject->setChecked(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_PROMPT_SQL_TABS_IN_NEWPRJ).toBool());
+    ui->checkUpdates->setChecked(Settings::getValue(szINI::SEC_CHCK_VERSION, szINI::KEY_ENABLED).toBool());
 
-    ui->checkHideSchemaLinebreaks->setChecked(Settings::getValue("db", "hideschemalinebreaks").toBool());
-    ui->foreignKeysCheckBox->setChecked(Settings::getValue("db", "foreignkeys").toBool());
-    ui->spinPrefetchSize->setValue(Settings::getValue("db", "prefetchsize").toInt());
-    ui->editDatabaseDefaultSqlText->setText(Settings::getValue("db", "defaultsqltext").toString());
+    ui->checkHideSchemaLinebreaks->setChecked(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_HIDE_SCHEMA_LINEBREAKS).toBool());
+    ui->foreignKeysCheckBox->setChecked(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_FOREIGN_KEYS).toBool());
+    ui->spinPrefetchSize->setValue(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_PREFETCH_SIZE).toInt());
+    ui->editDatabaseDefaultSqlText->setText(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_SQL_TEXT).toString());
 
     ui->defaultFieldTypeComboBox->addItems(DBBrowserDB::Datatypes);
 
-    int defaultFieldTypeIndex = Settings::getValue("db", "defaultfieldtype").toInt();
+    int defaultFieldTypeIndex = Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_FIELD_TYPE).toInt();
     if (defaultFieldTypeIndex < DBBrowserDB::Datatypes.count())
     {
         ui->defaultFieldTypeComboBox->setCurrentIndex(defaultFieldTypeIndex);
     }
 
-    ui->spinStructureFontSize->setValue(Settings::getValue("db", "fontsize").toInt());
+    ui->spinStructureFontSize->setValue(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_FONTSIZE).toInt());
 
     // Gracefully handle the preferred Data Browser font not being available
-    int matchingFont = ui->comboDataBrowserFont->findText(Settings::getValue("databrowser", "font").toString(), Qt::MatchExactly);
+    int matchingFont = ui->comboDataBrowserFont->findText(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT).toString(), Qt::MatchExactly);
     if (matchingFont == -1)
-        matchingFont = ui->comboDataBrowserFont->findText(Settings::getDefaultValue("databrowser", "font").toString());
+        matchingFont = ui->comboDataBrowserFont->findText(Settings::getDefaultValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT).toString());
     ui->comboDataBrowserFont->setCurrentIndex(matchingFont);
 
-    ui->spinDataBrowserFontSize->setValue(Settings::getValue("databrowser", "fontsize").toInt());
-    loadColorSetting(ui->fr_null_fg, "null_fg");
-    loadColorSetting(ui->fr_null_bg, "null_bg");
-    loadColorSetting(ui->fr_bin_fg, "bin_fg");
-    loadColorSetting(ui->fr_bin_bg, "bin_bg");
-    loadColorSetting(ui->fr_reg_fg, "reg_fg");
-    loadColorSetting(ui->fr_reg_bg, "reg_bg");
-    loadColorSetting(ui->fr_formatted_fg, "formatted_fg");
-    loadColorSetting(ui->fr_formatted_bg, "formatted_bg");
+    ui->spinDataBrowserFontSize->setValue(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE).toInt());
+    loadColorSetting(ui->fr_null_fg, szINI::KEY_SHP_NULL_FG);
+    loadColorSetting(ui->fr_null_bg, szINI::KEY_SHP_NULL_BG);
+    loadColorSetting(ui->fr_bin_fg, szINI::KEY_SHP_BIN_FG);
+    loadColorSetting(ui->fr_bin_bg, szINI::KEY_SHP_BIN_BG);
+    loadColorSetting(ui->fr_reg_fg, szINI::KEY_SHP_REG_FG);
+    loadColorSetting(ui->fr_reg_bg, szINI::KEY_SHP_REG_BG);
+    loadColorSetting(ui->fr_formatted_fg, szINI::KEY_SHP_FMT_FG);
+    loadColorSetting(ui->fr_formatted_bg, szINI::KEY_SHP_FMT_BG);
 
-    ui->spinSymbolLimit->setValue(Settings::getValue("databrowser", "symbol_limit").toInt());
-    ui->spinCompleteThreshold->setValue(Settings::getValue("databrowser", "complete_threshold").toInt());
-    ui->checkShowImagesInline->setChecked(Settings::getValue("databrowser", "image_preview").toBool());
-    ui->txtNull->setText(Settings::getValue("databrowser", "null_text").toString());
-    ui->txtBlob->setText(Settings::getValue("databrowser", "blob_text").toString());
-    ui->editFilterEscape->setText(Settings::getValue("databrowser", "filter_escape").toString());
-    ui->spinFilterDelay->setValue(Settings::getValue("databrowser", "filter_delay").toInt());
+    ui->spinSymbolLimit->setValue(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_SYMBOL_LIMIT).toInt());
+    ui->spinCompleteThreshold->setValue(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_COMPLETE_THRESHOLD).toInt());
+    ui->checkShowImagesInline->setChecked(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_IMAGE_PREVIEW).toBool());
+    ui->txtNull->setText(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_TEXT).toString());
+    ui->txtBlob->setText(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BLOB_TEXT).toString());
+    ui->editFilterEscape->setText(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FILTER_ESCAPE).toString());
+    ui->spinFilterDelay->setValue(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FILTER_DELAY).toInt());
 
     ui->treeSyntaxHighlighting->resizeColumnToContents(1);
 
     for(int i=0; i < ui->treeSyntaxHighlighting->topLevelItemCount(); ++i)
     {
         std::string name = ui->treeSyntaxHighlighting->topLevelItem(i)->text(0).toStdString();
-        QString colorname = Settings::getValue("syntaxhighlighter", name + "_colour").toString();
+        QString colorname = Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_COLOUR).toString();
         QColor color = QColor(colorname);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setForeground(2, color);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setBackground(2, color);
@@ -139,14 +139,14 @@ void PreferencesDialog::loadSettings()
         if (name != "null" && name != "currentline" &&
             name != "background" && name != "foreground" && name != "highlight" &&
             name != "selected_fg" && name != "selected_bg") {
-            ui->treeSyntaxHighlighting->topLevelItem(i)->setCheckState(3, Settings::getValue("syntaxhighlighter", name + "_bold").toBool() ? Qt::Checked : Qt::Unchecked);
-            ui->treeSyntaxHighlighting->topLevelItem(i)->setCheckState(4, Settings::getValue("syntaxhighlighter", name + "_italic").toBool() ? Qt::Checked : Qt::Unchecked);
-            ui->treeSyntaxHighlighting->topLevelItem(i)->setCheckState(5, Settings::getValue("syntaxhighlighter", name + "_underline").toBool() ? Qt::Checked : Qt::Unchecked);
+            ui->treeSyntaxHighlighting->topLevelItem(i)->setCheckState(3, Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_BOLD).toBool() ? Qt::Checked : Qt::Unchecked);
+            ui->treeSyntaxHighlighting->topLevelItem(i)->setCheckState(4, Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_ITALIC).toBool() ? Qt::Checked : Qt::Unchecked);
+            ui->treeSyntaxHighlighting->topLevelItem(i)->setCheckState(5, Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_UNDERLINE).toBool() ? Qt::Checked : Qt::Unchecked);
         }
     }
 
     // Remote settings
-    ui->checkUseRemotes->setChecked(Settings::getValue("remote", "active").toBool());
+    ui->checkUseRemotes->setChecked(Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_ACTIVE).toBool());
     {
         auto ca_certs = RemoteNetwork::get().caCertificates();
         ui->tableCaCerts->setRowCount(ca_certs.size());
@@ -176,7 +176,7 @@ void PreferencesDialog::loadSettings()
         }
     }
     {
-        const QStringList client_certs = Settings::getValue("remote", "client_certificates").toStringList();
+        const QStringList client_certs = Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLIENT_CERT).toStringList();
         for(const QString& file : client_certs)
         {
             const auto certs = QSslCertificate::fromPath(file);
@@ -184,106 +184,106 @@ void PreferencesDialog::loadSettings()
                 addClientCertToTable(file, cert);
         }
     }
-    ui->editRemoteCloneDirectory->setText(QDir::toNativeSeparators(Settings::getValue("remote", "clonedirectory").toString()));
+    ui->editRemoteCloneDirectory->setText(QDir::toNativeSeparators(Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString()));
 
     // Gracefully handle the preferred Editor font not being available
-    matchingFont = ui->comboEditorFont->findText(Settings::getValue("editor", "font").toString(), Qt::MatchExactly);
+    matchingFont = ui->comboEditorFont->findText(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString(), Qt::MatchExactly);
     if (matchingFont == -1)
-        matchingFont = ui->comboDataBrowserFont->findText(Settings::getDefaultValue("editor", "font").toString());
+        matchingFont = ui->comboDataBrowserFont->findText(Settings::getDefaultValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString());
     ui->comboEditorFont->setCurrentIndex(matchingFont);
 
-    ui->spinEditorFontSize->setValue(Settings::getValue("editor", "fontsize").toInt());
-    ui->spinTabSize->setValue(Settings::getValue("editor", "tabsize").toInt());
-    ui->checkIndentationUseTabs->setChecked(Settings::getValue("editor", "indentation_use_tabs").toBool());
-    ui->spinLogFontSize->setValue(Settings::getValue("log", "fontsize").toInt());
-    ui->wrapComboBox->setCurrentIndex(Settings::getValue("editor", "wrap_lines").toInt());
-    ui->quoteComboBox->setCurrentIndex(Settings::getValue("editor", "identifier_quotes").toInt());
-    ui->checkAutoCompletion->setChecked(Settings::getValue("editor", "auto_completion").toBool());
-    ui->checkCompleteUpper->setEnabled(Settings::getValue("editor", "auto_completion").toBool());
-    ui->checkCompleteUpper->setChecked(Settings::getValue("editor", "upper_keywords").toBool());
-    ui->checkErrorIndicators->setChecked(Settings::getValue("editor", "error_indicators").toBool());
-    ui->checkHorizontalTiling->setChecked(Settings::getValue("editor", "horizontal_tiling").toBool());
-    ui->checkCloseButtonOnTabs->setChecked(Settings::getValue("editor", "close_button_on_tabs").toBool());
+    ui->spinEditorFontSize->setValue(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONTSIZE).toInt());
+    ui->spinTabSize->setValue(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_TABSIZE).toInt());
+    ui->checkIndentationUseTabs->setChecked(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_INDENTATION_USE_TABS).toBool());
+    ui->spinLogFontSize->setValue(Settings::getValue(szINI::SEC_LOG, szINI::KEY_FONTSIZE).toInt());
+    ui->wrapComboBox->setCurrentIndex(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_WRAP_LINES).toInt());
+    ui->quoteComboBox->setCurrentIndex(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_IDENTIFIER_QUOTES).toInt());
+    ui->checkAutoCompletion->setChecked(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_AUTO_COMPLETION).toBool());
+    ui->checkCompleteUpper->setEnabled(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_AUTO_COMPLETION).toBool());
+    ui->checkCompleteUpper->setChecked(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_UPPER_KEYWORDS).toBool());
+    ui->checkErrorIndicators->setChecked(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_ERROR_INDICATORS).toBool());
+    ui->checkHorizontalTiling->setChecked(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_HORZ_TILING).toBool());
+    ui->checkCloseButtonOnTabs->setChecked(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_CLOSE_BUTTON_ON_TABS).toBool());
 
-    ui->listExtensions->addItems(Settings::getValue("extensions", "list").toStringList());
-    ui->checkRegexDisabled->setChecked(Settings::getValue("extensions", "disableregex").toBool());
-    ui->checkAllowLoadExtension->setChecked(Settings::getValue("extensions", "enable_load_extension").toBool());
+    ui->listExtensions->addItems(Settings::getValue(szINI::SEC_EXTENSIONS, szINI::KEY_LIST).toStringList());
+    ui->checkRegexDisabled->setChecked(Settings::getValue(szINI::SEC_EXTENSIONS, szINI::KEY_DISABLE_REGEX).toBool());
+    ui->checkAllowLoadExtension->setChecked(Settings::getValue(szINI::SEC_EXTENSIONS, szINI::KEY_ENABLE_LOAD_EXTENSION).toBool());
     fillLanguageBox();
-    ui->appStyleCombo->setCurrentIndex(Settings::getValue("General", "appStyle").toInt());
-    ui->toolbarStyleComboMain->setCurrentIndex(Settings::getValue("General", "toolbarStyle").toInt());
-    ui->toolbarStyleComboStructure->setCurrentIndex(Settings::getValue("General", "toolbarStyleStructure").toInt());
-    ui->toolbarStyleComboBrowse->setCurrentIndex(Settings::getValue("General", "toolbarStyleBrowse").toInt());
-    ui->toolbarStyleComboSql->setCurrentIndex(Settings::getValue("General", "toolbarStyleSql").toInt());
-    ui->toolbarStyleComboEditCell->setCurrentIndex(Settings::getValue("General", "toolbarStyleEditCell").toInt());
-    ui->spinGeneralFontSize->setValue(Settings::getValue("General", "fontsize").toInt());
-    ui->spinMaxRecentFiles->setValue(Settings::getValue("General", "maxRecentFiles").toInt());
+    ui->appStyleCombo->setCurrentIndex(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_APPSTYLE).toInt());
+    ui->toolbarStyleComboMain->setCurrentIndex(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_APP).toInt());
+    ui->toolbarStyleComboStructure->setCurrentIndex(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_STRUCTURE).toInt());
+    ui->toolbarStyleComboBrowse->setCurrentIndex(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_BROWSE).toInt());
+    ui->toolbarStyleComboSql->setCurrentIndex(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_SQL).toInt());
+    ui->toolbarStyleComboEditCell->setCurrentIndex(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_EDIT_CELL).toInt());
+    ui->spinGeneralFontSize->setValue(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_FONTSIZE).toInt());
+    ui->spinMaxRecentFiles->setValue(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_MAX_RECENT_FILES).toInt());
 }
 
 void PreferencesDialog::saveSettings(bool accept)
 {
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
-    Settings::setValue("db", "defaultencoding", ui->encodingComboBox->currentText());
-    Settings::setValue("db", "defaultlocation", ui->locationEdit->text());
-    Settings::setValue("db", "savedefaultlocation", ui->comboDefaultLocation->currentIndex());
-    Settings::setValue("db", "hideschemalinebreaks", ui->checkHideSchemaLinebreaks->isChecked());
-    Settings::setValue("db", "foreignkeys", ui->foreignKeysCheckBox->isChecked());
-    Settings::setValue("db", "prefetchsize", ui->spinPrefetchSize->value());
-    Settings::setValue("db", "defaultsqltext", ui->editDatabaseDefaultSqlText->text());
-    Settings::setValue("db", "defaultfieldtype", ui->defaultFieldTypeComboBox->currentIndex());
-    Settings::setValue("db", "fontsize", ui->spinStructureFontSize->value());
+    Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_ENCODING, ui->encodingComboBox->currentText());
+    Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_LOCATION, ui->locationEdit->text());
+    Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_SAVE_DEFAULT_LOCATION, ui->comboDefaultLocation->currentIndex());
+    Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_HIDE_SCHEMA_LINEBREAKS, ui->checkHideSchemaLinebreaks->isChecked());
+    Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_FOREIGN_KEYS, ui->foreignKeysCheckBox->isChecked());
+    Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_PREFETCH_SIZE, ui->spinPrefetchSize->value());
+    Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_SQL_TEXT, ui->editDatabaseDefaultSqlText->text());
+    Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_FIELD_TYPE, ui->defaultFieldTypeComboBox->currentIndex());
+    Settings::setValue(szINI::SEC_DATABASE, szINI::KEY_FONTSIZE, ui->spinStructureFontSize->value());
 
-    Settings::setValue("checkversion", "enabled", ui->checkUpdates->isChecked());
+    Settings::setValue(szINI::SEC_CHCK_VERSION, szINI::KEY_ENABLED, ui->checkUpdates->isChecked());
 
-    Settings::setValue("databrowser", "font", ui->comboDataBrowserFont->currentText());
-    Settings::setValue("databrowser", "fontsize", ui->spinDataBrowserFontSize->value());
-    Settings::setValue("databrowser", "image_preview", ui->checkShowImagesInline->isChecked());
-    saveColorSetting(ui->fr_null_fg, "null_fg");
-    saveColorSetting(ui->fr_null_bg, "null_bg");
-    saveColorSetting(ui->fr_reg_fg, "reg_fg");
-    saveColorSetting(ui->fr_reg_bg, "reg_bg");
-    saveColorSetting(ui->fr_formatted_fg, "formatted_fg");
-    saveColorSetting(ui->fr_formatted_bg, "formatted_bg");
-    saveColorSetting(ui->fr_bin_fg, "bin_fg");
-    saveColorSetting(ui->fr_bin_bg, "bin_bg");
-    Settings::setValue("databrowser", "symbol_limit", ui->spinSymbolLimit->value());
-    Settings::setValue("databrowser", "complete_threshold", ui->spinCompleteThreshold->value());
-    Settings::setValue("databrowser", "null_text", ui->txtNull->text());
-    Settings::setValue("databrowser", "blob_text", ui->txtBlob->text());
-    Settings::setValue("databrowser", "filter_escape", ui->editFilterEscape->text());
-    Settings::setValue("databrowser", "filter_delay", ui->spinFilterDelay->value());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT, ui->comboDataBrowserFont->currentText());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE, ui->spinDataBrowserFontSize->value());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_IMAGE_PREVIEW, ui->checkShowImagesInline->isChecked());
+    saveColorSetting(ui->fr_null_fg, szINI::KEY_SHP_NULL_FG);
+    saveColorSetting(ui->fr_null_bg, szINI::KEY_SHP_NULL_BG);
+    saveColorSetting(ui->fr_reg_fg, szINI::KEY_SHP_REG_FG);
+    saveColorSetting(ui->fr_reg_bg, szINI::KEY_SHP_REG_BG);
+    saveColorSetting(ui->fr_formatted_fg, szINI::KEY_SHP_FMT_FG);
+    saveColorSetting(ui->fr_formatted_bg, szINI::KEY_SHP_FMT_BG);
+    saveColorSetting(ui->fr_bin_fg, szINI::KEY_SHP_BIN_FG);
+    saveColorSetting(ui->fr_bin_bg, szINI::KEY_SHP_BIN_BG);
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_SYMBOL_LIMIT, ui->spinSymbolLimit->value());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_COMPLETE_THRESHOLD, ui->spinCompleteThreshold->value());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_TEXT, ui->txtNull->text());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BLOB_TEXT, ui->txtBlob->text());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FILTER_ESCAPE, ui->editFilterEscape->text());
+    Settings::setValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FILTER_DELAY, ui->spinFilterDelay->value());
 
     for(int i=0; i < ui->treeSyntaxHighlighting->topLevelItemCount(); ++i)
     {
         std::string name = ui->treeSyntaxHighlighting->topLevelItem(i)->text(0).toStdString();
-        Settings::setValue("syntaxhighlighter", name + "_colour", ui->treeSyntaxHighlighting->topLevelItem(i)->text(2));
-        Settings::setValue("syntaxhighlighter", name + "_bold", ui->treeSyntaxHighlighting->topLevelItem(i)->checkState(3) == Qt::Checked);
-        Settings::setValue("syntaxhighlighter", name + "_italic", ui->treeSyntaxHighlighting->topLevelItem(i)->checkState(4) == Qt::Checked);
-        Settings::setValue("syntaxhighlighter", name + "_underline", ui->treeSyntaxHighlighting->topLevelItem(i)->checkState(5) == Qt::Checked);
+        Settings::setValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_COLOUR, ui->treeSyntaxHighlighting->topLevelItem(i)->text(2));
+        Settings::setValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_BOLD, ui->treeSyntaxHighlighting->topLevelItem(i)->checkState(3) == Qt::Checked);
+        Settings::setValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_ITALIC, ui->treeSyntaxHighlighting->topLevelItem(i)->checkState(4) == Qt::Checked);
+        Settings::setValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_UNDERLINE, ui->treeSyntaxHighlighting->topLevelItem(i)->checkState(5) == Qt::Checked);
     }
-    Settings::setValue("editor", "font", ui->comboEditorFont->currentText());
-    Settings::setValue("editor", "fontsize", ui->spinEditorFontSize->value());
-    Settings::setValue("editor", "tabsize", ui->spinTabSize->value());
-    Settings::setValue("editor", "indentation_use_tabs", ui->checkIndentationUseTabs->isChecked());
-    Settings::setValue("log", "fontsize", ui->spinLogFontSize->value());
-    Settings::setValue("editor", "wrap_lines", ui->wrapComboBox->currentIndex());
-    Settings::setValue("editor", "identifier_quotes", ui->quoteComboBox->currentIndex());
-    Settings::setValue("editor", "auto_completion", ui->checkAutoCompletion->isChecked());
-    Settings::setValue("editor", "upper_keywords", ui->checkCompleteUpper->isChecked());
-    Settings::setValue("editor", "error_indicators", ui->checkErrorIndicators->isChecked());
-    Settings::setValue("editor", "horizontal_tiling", ui->checkHorizontalTiling->isChecked());
-    Settings::setValue("editor", "close_button_on_tabs", ui->checkCloseButtonOnTabs->isChecked());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_FONT, ui->comboEditorFont->currentText());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_FONTSIZE, ui->spinEditorFontSize->value());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_TABSIZE, ui->spinTabSize->value());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_INDENTATION_USE_TABS, ui->checkIndentationUseTabs->isChecked());
+    Settings::setValue(szINI::SEC_LOG, szINI::KEY_FONTSIZE, ui->spinLogFontSize->value());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_WRAP_LINES, ui->wrapComboBox->currentIndex());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_IDENTIFIER_QUOTES, ui->quoteComboBox->currentIndex());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_AUTO_COMPLETION, ui->checkAutoCompletion->isChecked());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_UPPER_KEYWORDS, ui->checkCompleteUpper->isChecked());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_ERROR_INDICATORS, ui->checkErrorIndicators->isChecked());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_HORZ_TILING, ui->checkHorizontalTiling->isChecked());
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_CLOSE_BUTTON_ON_TABS, ui->checkCloseButtonOnTabs->isChecked());
 
     QStringList extList;
     for(int i=0;i<ui->listExtensions->count();++i)
         extList.append(ui->listExtensions->item(i)->text());
-    Settings::setValue("extensions", "list", extList);
-    Settings::setValue("extensions", "disableregex", ui->checkRegexDisabled->isChecked());
-    Settings::setValue("extensions", "enable_load_extension", ui->checkAllowLoadExtension->isChecked());
+    Settings::setValue(szINI::SEC_EXTENSIONS, szINI::KEY_LIST, extList);
+    Settings::setValue(szINI::SEC_EXTENSIONS, szINI::KEY_DISABLE_REGEX, ui->checkRegexDisabled->isChecked());
+    Settings::setValue(szINI::SEC_EXTENSIONS, szINI::KEY_ENABLE_LOAD_EXTENSION, ui->checkAllowLoadExtension->isChecked());
 
     // Save remote settings
-    Settings::setValue("remote", "active", ui->checkUseRemotes->isChecked());
-    QStringList old_client_certs = Settings::getValue("remote", "client_certificates").toStringList();
+    Settings::setValue(szINI::SEC_REMOTE, szINI::KEY_ACTIVE, ui->checkUseRemotes->isChecked());
+    QStringList old_client_certs = Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLIENT_CERT).toStringList();
     QStringList new_client_certs;
     for(int i=0;i<ui->tableClientCerts->rowCount();i++)
     {
@@ -333,26 +333,26 @@ void PreferencesDialog::saveSettings(bool accept)
         // Now only the deleted client certs are still in the old list. Delete the cert files associated with them.
         QFile::remove(file);
     }
-    Settings::setValue("remote", "client_certificates", new_client_certs);
-    Settings::setValue("remote", "clonedirectory", ui->editRemoteCloneDirectory->text());
+    Settings::setValue(szINI::SEC_REMOTE, szINI::KEY_CLIENT_CERT, new_client_certs);
+    Settings::setValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR, ui->editRemoteCloneDirectory->text());
 
     // Warn about restarting to change language
     QVariant newLanguage = ui->languageComboBox->itemData(ui->languageComboBox->currentIndex());
-    if (newLanguage != Settings::getValue("General", "language"))
+    if (newLanguage != Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_LANGUAGE))
         QMessageBox::information(this, QApplication::applicationName(),
                                  tr("The language will change after you restart the application."));
 
-    Settings::setValue("General", "language", newLanguage);
-    Settings::setValue("General", "appStyle", ui->appStyleCombo->currentIndex());
-    Settings::setValue("General", "toolbarStyle", ui->toolbarStyleComboMain->currentIndex());
-    Settings::setValue("General", "toolbarStyleStructure", ui->toolbarStyleComboStructure->currentIndex());
-    Settings::setValue("General", "toolbarStyleBrowse", ui->toolbarStyleComboBrowse->currentIndex());
-    Settings::setValue("General", "toolbarStyleSql", ui->toolbarStyleComboSql->currentIndex());
-    Settings::setValue("General", "toolbarStyleEditCell", ui->toolbarStyleComboEditCell->currentIndex());
-    Settings::setValue("General", "DBFileExtensions", m_dbFileExtensions.join(";;") );
-    Settings::setValue("General", "fontsize", ui->spinGeneralFontSize->value());
-    Settings::setValue("General", "maxRecentFiles", ui->spinMaxRecentFiles->value());
-    Settings::setValue("General", "promptsqltabsinnewproject", ui->checkPromptSQLTabsInNewProject->isChecked());
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_LANGUAGE, newLanguage);
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_APPSTYLE, ui->appStyleCombo->currentIndex());
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_APP, ui->toolbarStyleComboMain->currentIndex());
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_STRUCTURE, ui->toolbarStyleComboStructure->currentIndex());
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_BROWSE, ui->toolbarStyleComboBrowse->currentIndex());
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_SQL, ui->toolbarStyleComboSql->currentIndex());
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_EDIT_CELL, ui->toolbarStyleComboEditCell->currentIndex());
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_DB_FILE_EXTS, m_dbFileExtensions.join(";;") );
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_FONTSIZE, ui->spinGeneralFontSize->value());
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_MAX_RECENT_FILES, ui->spinMaxRecentFiles->value());
+    Settings::setValue(szINI::SEC_GENERAL, szINI::KEY_PROMPT_SQL_TABS_IN_NEWPRJ, ui->checkPromptSQLTabsInNewProject->isChecked());
 
     m_proxyDialog->saveSettings();
 
@@ -482,7 +482,7 @@ void PreferencesDialog::fillLanguageBox()
     ui->languageComboBox->model()->sort(0);
 
     // Try to select the language for the stored locale
-    int index = ui->languageComboBox->findData(Settings::getValue("General", "language"),
+    int index = ui->languageComboBox->findData(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_LANGUAGE),
                                                Qt::UserRole, Qt::MatchExactly);
 
     // If there's no translation for the current locale, default to English
@@ -507,7 +507,7 @@ void PreferencesDialog::fillLanguageBox()
 
 void PreferencesDialog::loadColorSetting(QFrame *frame, const std::string& settingName)
 {
-    QColor color = QColor(Settings::getValue("databrowser", settingName + "_colour").toString());
+    QColor color = QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, settingName + szINI::KEY_ANY_COLOUR).toString());
     setColorSetting(frame, color);
 }
 
@@ -559,26 +559,26 @@ void PreferencesDialog::setColorSetting(QFrame *frame, const QColor &color)
 
 void PreferencesDialog::saveColorSetting(QFrame* frame, const std::string& settingName)
 {
-    Settings::setValue("databrowser", settingName + "_colour",
+    Settings::setValue(szINI::SEC_DATA_BROWSER, settingName + szINI::KEY_ANY_COLOUR,
         frame->palette().color(frame->backgroundRole()));
 }
 
 void PreferencesDialog::adjustColorsToStyle(int style)
 {
     Settings::AppStyle appStyle = static_cast<Settings::AppStyle>(style);
-    setColorSetting(ui->fr_null_fg, Settings::getDefaultColorValue("databrowser", "null_fg_colour", appStyle));
-    setColorSetting(ui->fr_null_bg, Settings::getDefaultColorValue("databrowser", "null_bg_colour", appStyle));
-    setColorSetting(ui->fr_bin_fg, Settings::getDefaultColorValue("databrowser", "bin_fg_colour", appStyle));
-    setColorSetting(ui->fr_bin_bg, Settings::getDefaultColorValue("databrowser", "bin_bg_colour", appStyle));
-    setColorSetting(ui->fr_reg_fg, Settings::getDefaultColorValue("databrowser", "reg_fg_colour", appStyle));
-    setColorSetting(ui->fr_reg_bg, Settings::getDefaultColorValue("databrowser", "reg_bg_colour", appStyle));
-    setColorSetting(ui->fr_formatted_fg, Settings::getDefaultColorValue("databrowser", "formatted_fg_colour", appStyle));
-    setColorSetting(ui->fr_formatted_bg, Settings::getDefaultColorValue("databrowser", "formatted_bg_colour", appStyle));
+    setColorSetting(ui->fr_null_fg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_FG_COLOUR, appStyle));
+    setColorSetting(ui->fr_null_bg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_BG_COLOUR, appStyle));
+    setColorSetting(ui->fr_bin_fg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_FG_COLOUR, appStyle));
+    setColorSetting(ui->fr_bin_bg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_BG_COLOUR, appStyle));
+    setColorSetting(ui->fr_reg_fg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_FG_COLOUR, appStyle));
+    setColorSetting(ui->fr_reg_bg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_BG_COLOUR, appStyle));
+    setColorSetting(ui->fr_formatted_fg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_FG_COLOUR, appStyle));
+    setColorSetting(ui->fr_formatted_bg, Settings::getDefaultColorValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_BG_COLOUR, appStyle));
 
     for(int i=0; i < ui->treeSyntaxHighlighting->topLevelItemCount(); ++i)
     {
         std::string name = ui->treeSyntaxHighlighting->topLevelItem(i)->text(0).toStdString();
-        QColor color = Settings::getDefaultColorValue("syntaxhighlighter", name + "_colour", appStyle);
+        QColor color = Settings::getDefaultColorValue(szINI::SEC_SYNTAX_HIGHLIGHTER, name + szINI::KEY_ANY_COLOUR, appStyle);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setForeground(2, color);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setBackground(2, color);
         ui->treeSyntaxHighlighting->topLevelItem(i)->setText(2, color.name());
@@ -734,14 +734,14 @@ void PreferencesDialog::exportSettings()
 void PreferencesDialog::importSettings()
 {
     const QString fileName = FileDialog::getOpenFileName(OpenSettingsFile, this, tr("Open Settings File"), tr("Initialization File (*.ini)"));
-    const QVariant existingLanguage = Settings::getValue("General", "language");
+    const QVariant existingLanguage = Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_LANGUAGE);
 
     if(!fileName.isEmpty())
     {
         if(Settings::importSettings(fileName))
         {
             QMessageBox::information(this, QApplication::applicationName(), tr("The settings file was loaded properly."));
-            if (existingLanguage != Settings::getValue("General", "language"))
+            if (existingLanguage != Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_LANGUAGE))
                 QMessageBox::information(this, QApplication::applicationName(),
                                          tr("The language will change after you restart the application."));
 

--- a/src/ProxyDialog.cpp
+++ b/src/ProxyDialog.cpp
@@ -15,12 +15,12 @@ ProxyDialog::ProxyDialog(QWidget *parent) :
     ui->comboType->addItem(tr("Socks v5"), "socks5");
 
     // Load current settings
-    ui->comboType->setCurrentIndex(ui->comboType->findData(Settings::getValue("proxy", "type").toString()));
-    ui->editHost->setText(Settings::getValue("proxy", "host").toString());
-    ui->spinPort->setValue(Settings::getValue("proxy", "port").toInt());
-    ui->checkAuthentication->setChecked(Settings::getValue("proxy", "authentication").toBool());
-    ui->editUser->setText(Settings::getValue("proxy", "user").toString());
-    ui->editPassword->setText(Settings::getValue("proxy", "password").toString());
+    ui->comboType->setCurrentIndex(ui->comboType->findData(Settings::getValue(szINI::SEC_PROXY, szINI::KEY_TYPE).toString()));
+    ui->editHost->setText(Settings::getValue(szINI::SEC_PROXY, szINI::KEY_HOST).toString());
+    ui->spinPort->setValue(Settings::getValue(szINI::SEC_PROXY, szINI::KEY_PORT).toInt());
+    ui->checkAuthentication->setChecked(Settings::getValue(szINI::SEC_PROXY, szINI::KEY_AUTHENTICATION).toBool());
+    ui->editUser->setText(Settings::getValue(szINI::SEC_PROXY, szINI::KEY_USER).toString());
+    ui->editPassword->setText(Settings::getValue(szINI::SEC_PROXY, szINI::KEY_PASSWORD).toString());
 }
 
 ProxyDialog::~ProxyDialog()
@@ -48,10 +48,10 @@ void ProxyDialog::authenticationRequiredChanged(bool required)
 
 void ProxyDialog::saveSettings() const
 {
-    Settings::setValue("proxy", "type", ui->comboType->currentData());
-    Settings::setValue("proxy", "host", ui->editHost->text());
-    Settings::setValue("proxy", "port", ui->spinPort->value());
-    Settings::setValue("proxy", "authentication", ui->checkAuthentication->isChecked());
-    Settings::setValue("proxy", "user", ui->editUser->text());
-    Settings::setValue("proxy", "password", ui->editPassword->text());
+    Settings::setValue(szINI::SEC_PROXY, szINI::KEY_TYPE, ui->comboType->currentData());
+    Settings::setValue(szINI::SEC_PROXY, szINI::KEY_HOST, ui->editHost->text());
+    Settings::setValue(szINI::SEC_PROXY, szINI::KEY_PORT, ui->spinPort->value());
+    Settings::setValue(szINI::SEC_PROXY, szINI::KEY_AUTHENTICATION, ui->checkAuthentication->isChecked());
+    Settings::setValue(szINI::SEC_PROXY, szINI::KEY_USER, ui->editUser->text());
+    Settings::setValue(szINI::SEC_PROXY, szINI::KEY_PASSWORD, ui->editPassword->text());
 }

--- a/src/RemoteDatabase.cpp
+++ b/src/RemoteDatabase.cpp
@@ -148,7 +148,7 @@ QString RemoteDatabase::localAdd(QString filename, QString identity, const QUrl&
         sqlite3_finalize(stmt);
 
         // Return full path to the new file
-        return Settings::getValue("remote", "clonedirectory").toString() + "/" + filename;
+        return Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString() + "/" + filename;
     }
 
     // If we get here, the file has been checked in before. Check next if it has been updated in the meantime.
@@ -268,7 +268,7 @@ QString RemoteDatabase::localCheckFile(const QString& local_file)
     localAssureOpened();
 
     // Build the full path to where the file should be
-    QString full_path = Settings::getValue("remote", "clonedirectory").toString() + "/" + local_file;
+    QString full_path = Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString() + "/" + local_file;
 
     // Check if the database still exists. If so return its path, if not return an empty string to redownload it
     if(QFile::exists(full_path))
@@ -420,7 +420,7 @@ void RemoteDatabase::localDeleteFile(QString filename)
     sqlite3_finalize(stmt);
 
     // Delete the actual file on disk
-    QFile::remove(Settings::getValue("remote", "clonedirectory").toString() + "/" + filename);
+    QFile::remove(Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString() + "/" + filename);
 }
 
 QString RemoteDatabase::LocalFileInfo::user_name() const

--- a/src/RemoteDock.cpp
+++ b/src/RemoteDock.cpp
@@ -151,7 +151,7 @@ void RemoteDock::reloadSettings()
     ui->comboUser->addItem(tr("Select an identity to connect"), "dummy");
 
     // Load list of client certs
-    const QStringList client_certs = Settings::getValue("remote", "client_certificates").toStringList();
+    const QStringList client_certs = Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLIENT_CERT).toStringList();
     for(const QString& file : client_certs)
     {
         const auto certs = QSslCertificate::fromPath(file);
@@ -353,7 +353,7 @@ void RemoteDock::pushSelectedLocalDatabase()
 
     // Push selected file
     const QString branch = ui->treeLocal->currentIndex().sibling(row, RemoteLocalFilesModel::ColumnBranch).data().toString();
-    pushDatabase(Settings::getValue("remote", "clonedirectory").toString() + "/" + filename, branch);
+    pushDatabase(Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString() + "/" + filename, branch);
 }
 
 void RemoteDock::pushDatabase(const QString& path, const QString& branch)
@@ -389,7 +389,7 @@ void RemoteDock::pushDatabase(const QString& path, const QString& branch)
     // current commit id of we are currently looking at rather than some other commit id or none at all
     // when creating a new branch.
     QString commit_id;
-    if(path.startsWith(Settings::getValue("remote", "clonedirectory").toString()))
+    if(path.startsWith(Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString()))
         commit_id = QString::fromStdString(remoteDatabase.localLastCommitId(remoteModel->currentClientCertificate(), url, branch.toStdString()));
 
     // Push database
@@ -456,7 +456,7 @@ void RemoteDock::openLocalFile(const QModelIndex& idx)
 
     QString file = idx.sibling(idx.row(), RemoteLocalFilesModel::ColumnFile).data().toString();
     if(!file.isEmpty())
-        emit openFile(Settings::getValue("remote", "clonedirectory").toString() + "/" + file);
+        emit openFile(Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString() + "/" + file);
 }
 
 void RemoteDock::fileOpened(const QString& filename)
@@ -474,7 +474,7 @@ void RemoteDock::fileOpened(const QString& filename)
         return;
 
     // Check if it is a tracked remote database file and retrieve the information we have on it
-    if(filename.startsWith(Settings::getValue("remote", "clonedirectory").toString()))
+    if(filename.startsWith(Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString()))
         currently_opened_file_info = remoteDatabase.localGetLocalFileInfo(filename);
 
     // Is this actually a clone of a remote database?
@@ -535,7 +535,7 @@ void RemoteDock::deleteLocalDatabase(const QModelIndex& index)
         return;
 
     QString filename = index.sibling(index.row(), RemoteLocalFilesModel::ColumnFile).data().toString();
-    QString path = Settings::getValue("remote", "clonedirectory").toString() + "/" + filename;
+    QString path = Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString() + "/" + filename;
 
     // Warn when trying to delete a currently opened database file
     if(mainWindow->getDb().currentFile() == path)

--- a/src/RemoteLocalFilesModel.cpp
+++ b/src/RemoteLocalFilesModel.cpp
@@ -69,7 +69,7 @@ void RemoteLocalFilesModel::refresh()
         }
 
         // Get file information
-        QFile file_info(Settings::getValue("remote", "clonedirectory").toString() + "/" + QString::fromStdString(file.file));
+        QFile file_info(Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR).toString() + "/" + QString::fromStdString(file.file));
 
         // Add file to user node
         QTreeWidgetItem* file_node = new QTreeWidgetItem(user_node);

--- a/src/RemoteNetwork.cpp
+++ b/src/RemoteNetwork.cpp
@@ -58,7 +58,7 @@ void RemoteNetwork::reloadSettings()
 {
     // Load all configured client certificates
     m_clientCertFiles.clear();
-    const auto client_certs = Settings::getValue("remote", "client_certificates").toStringList();
+    const auto client_certs = Settings::getValue(szINI::SEC_REMOTE, szINI::KEY_CLIENT_CERT).toStringList();
     for(const QString& path : client_certs)
     {
         QFile file(path);
@@ -79,7 +79,7 @@ void RemoteNetwork::reloadSettings()
 
     // Configure proxy to use
     {
-        QString type = Settings::getValue("proxy", "type").toString();
+        QString type = Settings::getValue(szINI::SEC_PROXY, szINI::KEY_TYPE).toString();
 
         QNetworkProxy proxy;
         if(type == "system")
@@ -93,9 +93,9 @@ void RemoteNetwork::reloadSettings()
             // For any other type we have to set up our own proxy configuration
 
             // Retrieve the required settings
-            QString host = Settings::getValue("proxy", "host").toString();
-            unsigned short port = static_cast<unsigned short>(Settings::getValue("proxy", "port").toUInt());
-            bool authentication = Settings::getValue("proxy", "authentication").toBool();
+            QString host = Settings::getValue(szINI::SEC_PROXY, szINI::KEY_HOST).toString();
+            unsigned short port = static_cast<unsigned short>(Settings::getValue(szINI::SEC_PROXY, szINI::KEY_PORT).toUInt());
+            bool authentication = Settings::getValue(szINI::SEC_PROXY, szINI::KEY_AUTHENTICATION).toBool();
 
             if(type == "http")
                 proxy.setType(QNetworkProxy::HttpProxy);
@@ -110,8 +110,8 @@ void RemoteNetwork::reloadSettings()
             // Only set authentication details when authentication is required
             if(authentication)
             {
-                QString user = Settings::getValue("proxy", "user").toString();
-                QString password = Settings::getValue("proxy", "password").toString();
+                QString user = Settings::getValue(szINI::SEC_PROXY, szINI::KEY_USER).toString();
+                QString password = Settings::getValue(szINI::SEC_PROXY, szINI::KEY_PASSWORD).toString();
 
                 proxy.setUser(user);
                 proxy.setPassword(password);

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,59 +1,197 @@
 #include "Settings.h"
 
+#include <iostream>
+#include <iomanip>
+#include <array>
+#include <map>
+#include <sstream>
 #include <QApplication>
 #include <QDebug>
 #include <QDir>
 #include <QSettings>
 #include <QColor>
-#include <QFontInfo>
-#include <QLocale>
 #include <QStandardPaths>
 #include <QPalette>
 
+// constant font point size applicable to:
+// general , editor, and log font settings
+#ifdef Q_OS_MAC
+    int Settings::DEFAULT_FONT_SIZE{12};
+#else
+    int Settings::DEFAULT_FONT_SIZE{9};
+#endif
+// Define platform EOL
+#ifdef Q_OS_WIN
+    const QString DEFAULT_EOL{"\r\n"};
+#else
+    const QString DEFAULT_EOL{"\n"};
+#endif
+
 QString Settings::userSettingsFile;
 QSettings* Settings::settings;
-std::unordered_map<std::string, QVariant> Settings::m_hCache;
-int Settings::m_defaultFontSize;
-
-static bool ends_with(const std::string& str, const std::string& with)
+// Initialize Settings Cache
+std::unordered_map<SectionKeyPair, QVariant, pair_hash> Settings::m_hCache{};
+// Populate Default Values Storage
+// Any Appearance/Syntax formatting is defaulted to "FollowDesktopStyle" values
+// Keys referencing colour settings established in processDefaultColours function
+std::unordered_map<SectionKeyPair, QVariant, pair_hash> Settings::m_hDefault =
 {
-    return str.rfind(with) == str.size() - with.size();
-}
+    {{szINI::SEC_CHCK_VERSION, szINI::KEY_ENABLED}, QVariant(true)},
+    {{szINI::SEC_CHCK_VERSION, szINI::KEY_IGNMAJOR}, QVariant(999)},
+    {{szINI::SEC_CHCK_VERSION, szINI::KEY_IGNMINOR}, QVariant(0)},
+    {{szINI::SEC_CHCK_VERSION, szINI::KEY_IGNPATCH}, QVariant(0)},
 
-void Settings::setUserSettingsFile(const QString& settings_file_path)
-{
-    userSettingsFile = settings_file_path;
-}
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_AUTO_SWITCH_MODE}, QVariant(true)},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_BLOB_TEXT}, QVariant("BLOB")},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_COMPLETE_THRESHOLD}, QVariant(1000)},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_EDITOR_WORD_WRAP}, QVariant(true)},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_FILTER_DELAY}, QVariant(200)},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_FILTER_ESCAPE}, QVariant("\\")},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_FONT }, QVariant()},                  // see processDefaultFixedFont()
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE}, QVariant(10)},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_IMAGE_PREVIEW}, QVariant(false)},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_INDENT_COMPACT}, QVariant(false)},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_TEXT}, QVariant("NULL")},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_SYMBOL_LIMIT}, QVariant(5000)},
+    {{szINI::SEC_DATA_BROWSER, szINI::KEY_ROWS_LIMIT}, QVariant(10'000'000)},
 
-bool Settings::isValidSettingsFile(const QString& settings_file_path)
-{
-    /*
-    Variable that stores whether or not the settings file requested by the user is a normal settings file
-    If the file does not exist and is newly created, the if statement below is not executed, so the default value is set to true
-    */
+    {{szINI::SEC_DATABASE, szINI::KEY_DEFAULT_ENCODING}, QVariant("UTF-8")},
+    {{szINI::SEC_DATABASE, szINI::KEY_DEFAULT_FIELD_TYPE}, QVariant(0)},
+    {{szINI::SEC_DATABASE, szINI::KEY_DEFAULT_LOCATION}, QVariant(QDir::homePath())},
+    {{szINI::SEC_DATABASE, szINI::KEY_DEFAULT_SQL_TEXT}, QVariant(QString())},
+    {{szINI::SEC_DATABASE, szINI::KEY_DONT_ASK_COLLATION}, QVariant(false)},
+    {{szINI::SEC_DATABASE, szINI::KEY_FONT }, QVariant()},                      // see processDefaultFixedFont()
+    {{szINI::SEC_DATABASE, szINI::KEY_FONTSIZE}, QVariant(10)},
+    {{szINI::SEC_DATABASE, szINI::KEY_FOREIGN_KEYS}, QVariant(true)},
+    {{szINI::SEC_DATABASE, szINI::KEY_HIDE_SCHEMA_LINEBREAKS}, QVariant(true)},
+    {{szINI::SEC_DATABASE, szINI::KEY_LAST_LOCATION}, QVariant(QDir::homePath())},
+    {{szINI::SEC_DATABASE, szINI::KEY_PREFETCH_SIZE}, QVariant(50000U)},
+    {{szINI::SEC_DATABASE, szINI::KEY_SAVE_DEFAULT_LOCATION}, QVariant(2)},     // Remember last location for session only
 
-    bool isNormalUserSettingsFile = true;
+    {{szINI::SEC_DONT_CARE, szINI::KEY_PROJECT_BROWSE_TABLE}, QVariant(false)},
 
-    // Code that verifies that the settings file requested by the user is a normal settings file
-    if(settings_file_path != nullptr)
-    {
-        QFile *file = new QFile;
-        file->setFileName(settings_file_path);
+    {{szINI::SEC_EDITOR, szINI::KEY_AUTO_COMPLETION}, QVariant(true)},
+    {{szINI::SEC_EDITOR, szINI::KEY_CLOSE_BUTTON_ON_TABS}, QVariant(true)},
+    {{szINI::SEC_EDITOR, szINI::KEY_ERROR_INDICATORS}, QVariant(true)},
+    {{szINI::SEC_EDITOR, szINI::KEY_FONT}, QVariant()},                         // see processDefaultFixedFont()
+    {{szINI::SEC_EDITOR, szINI::KEY_FONTSIZE}, QVariant(Settings::DEFAULT_FONT_SIZE)},
+    {{szINI::SEC_EDITOR, szINI::KEY_HORZ_TILING}, QVariant(false)},
+    {{szINI::SEC_EDITOR, szINI::KEY_IDENTIFIER_QUOTES}, QVariant(0)},           // sqlb::DoubleQuotes
+    {{szINI::SEC_EDITOR, szINI::KEY_INDENTATION_USE_TABS}, QVariant(true)},
+    {{szINI::SEC_EDITOR, szINI::KEY_SPLITTER1_SIZES}, QVariant()},
+    {{szINI::SEC_EDITOR, szINI::KEY_SPLITTER2_SIZES}, QVariant()},
+    {{szINI::SEC_EDITOR, szINI::KEY_TABSIZE}, QVariant(4)},
+    {{szINI::SEC_EDITOR, szINI::KEY_UPPER_KEYWORDS}, QVariant(true)},
+    {{szINI::SEC_EDITOR, szINI::KEY_WRAP_LINES}, QVariant(0)},                  // QsciScintilla::WrapNone
 
-        if(file->open(QIODevice::ReadOnly | QIODevice::Text))
-        {
-            // define comparison string --> "[General]\n" --> first line of any DB4S settings file
-            QString header("[" + QString::fromStdString(szINI::SEC_GENERAL) + "]\n");
-            if(file->exists() &&
-              QString::compare(header, file->readLine(), Qt::CaseInsensitive) != 0)
-                isNormalUserSettingsFile = false;
-        }
+    {{szINI::SEC_EXPORT_CSV, szINI::KEY_FIRST_ROW_HEADER}, QVariant(true)},
+    {{szINI::SEC_EXPORT_CSV, szINI::KEY_NEWLINE_CHARACTERS }, QVariant(DEFAULT_EOL)},
+    {{szINI::SEC_EXPORT_CSV, szINI::KEY_QUOTE_CHARACTER}, QVariant("\"")},
+    {{szINI::SEC_EXPORT_CSV, szINI::KEY_SEPARATOR}, QVariant(",")},
 
-        file->close();
-    }
+    {{szINI::SEC_EXPORT_JSON, szINI::KEY_PRETTY_PRINT}, QVariant(true)},
 
-    return isNormalUserSettingsFile;
-}
+    {{szINI::SEC_EXPORT_SQL, szINI::KEY_INSERT_COL_NAMES}, QVariant(false)},
+    {{szINI::SEC_EXPORT_SQL, szINI::KEY_INSERT_MULTIPLE}, QVariant(false)},
+    {{szINI::SEC_EXPORT_SQL, szINI::KEY_KEEP_ORIGINAL}, QVariant(false)},
+    {{szINI::SEC_EXPORT_SQL, szINI::KEY_OLD_SCHEMA}, QVariant(0)},
+
+    {{szINI::SEC_EXTENSIONS, szINI::KEY_DISABLE_REGEX}, QVariant(false)},
+    {{szINI::SEC_EXTENSIONS, szINI::KEY_ENABLE_LOAD_EXTENSION}, QVariant(false)},
+    {{szINI::SEC_EXTENSIONS, szINI::KEY_LIST}, QVariant(QStringList())},
+
+    {{szINI::SEC_GENERAL, szINI::KEY_APPSTYLE}, QVariant(static_cast<int>(Settings::FollowDesktopStyle))},
+    {{szINI::SEC_GENERAL, szINI::KEY_DB_FILE_EXTS},
+        QVariant(QObject::tr("SQLite database files (*.db *.sqlite *.sqlite3 *.db3)"))},
+    {{szINI::SEC_GENERAL, szINI::KEY_FONTSIZE }, QVariant(Settings::DEFAULT_FONT_SIZE)},
+    {{szINI::SEC_GENERAL, szINI::KEY_LANGUAGE}, QVariant(QLocale::system().name())},
+    {{szINI::SEC_GENERAL, szINI::KEY_MAX_RECENT_FILES}, QVariant(5)},
+    {{szINI::SEC_GENERAL, szINI::KEY_PROMPT_SQL_TABS_IN_NEWPRJ}, QVariant(true)},
+    {{szINI::SEC_GENERAL, szINI::KEY_RECENT_FILE_LIST}, QVariant(QStringList())},
+    {{szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_APP}, QVariant(static_cast<int>(Qt::ToolButtonTextBesideIcon))},
+    {{szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_BROWSE}, QVariant(static_cast<int>(Qt::ToolButtonIconOnly))},
+    {{szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_EDIT_CELL}, QVariant(static_cast<int>(Qt::ToolButtonIconOnly))},
+    {{szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_SQL}, QVariant(static_cast<int>(Qt::ToolButtonIconOnly))},
+    {{szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_STRUCTURE}, QVariant(static_cast<int>(Qt::ToolButtonTextBesideIcon))},
+
+    {{szINI::SEC_IMPORT_CSV, szINI::KEY_ENCODING}, QVariant("UTF-8")},
+    {{szINI::SEC_IMPORT_CSV, szINI::KEY_FIRST_ROW_HEADER}, QVariant(false)},
+    {{szINI::SEC_IMPORT_CSV, szINI::KEY_LOCAL_CONVENTIONS}, QVariant(false)},
+    {{szINI::SEC_IMPORT_CSV, szINI::KEY_QUOTE_CHARACTER}, QVariant("\"")},
+    {{szINI::SEC_IMPORT_CSV, szINI::KEY_SEPARATE_TABLES}, QVariant(false)},
+    {{szINI::SEC_IMPORT_CSV, szINI::KEY_SEPARATOR}, QVariant(",")},
+    {{szINI::SEC_IMPORT_CSV, szINI::KEY_TRIM_FIELDS}, QVariant(true)},
+
+    {{szINI::SEC_LOG, szINI::KEY_FONT}, QVariant()},                            // see processDefaultFixedFont()
+    {{szINI::SEC_LOG, szINI::KEY_FONTSIZE}, QVariant(Settings::DEFAULT_FONT_SIZE)},
+
+    {{szINI::SEC_MAIN_WNDW, szINI::KEY_GEOMETRY}, QVariant(QString())},
+    {{szINI::SEC_MAIN_WNDW, szINI::KEY_OPEN_TABS}, QVariant(QString())},
+    {{szINI::SEC_MAIN_WNDW, szINI::KEY_WINDOW_STATE}, QVariant(QString())},
+
+    {{szINI::SEC_PLOT_DOCK, szINI::KEY_LINE_TYPE}, QVariant(1)},                // QCPGraph::lsLine
+    {{szINI::SEC_PLOT_DOCK, szINI::KEY_POINT_SHAPE}, QVariant(4)},              // QCPScatterStyle::ssDisk
+    {{szINI::SEC_PLOT_DOCK, szINI::KEY_SPLITTER_SIZE}, QVariant(QString())},
+
+    {{szINI::SEC_PROXY, szINI::KEY_AUTHENTICATION}, QVariant(false)},
+    {{szINI::SEC_PROXY, szINI::KEY_HOST}, QVariant(QString())},
+    {{szINI::SEC_PROXY, szINI::KEY_PASSWORD}, QVariant(QString())},
+    {{szINI::SEC_PROXY, szINI::KEY_PORT}, QVariant(0)},
+    {{szINI::SEC_PROXY, szINI::KEY_TYPE}, QVariant("system")},
+    {{szINI::SEC_PROXY, szINI::KEY_USER}, QVariant(QString())},
+
+    {{szINI::SEC_REMOTE, szINI::KEY_ACTIVE}, QVariant(true)},
+    {{szINI::SEC_REMOTE, szINI::KEY_CLIENT_CERT}, QVariant(QStringList())},
+#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
+    {{szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR},
+        QVariant(QStandardPaths::writableLocation(QStandardPaths::AppDataLocation))},
+#else
+    {{szINI::SEC_REMOTE, szINI::KEY_CLONE_DIR},
+        QVariant(QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation))},
+#endif
+    {{szINI::SEC_SCHEMA_DOCK, szINI::KEY_DROP_ENQUOTED_NAMES}, QVariant(true)},
+    {{szINI::SEC_SCHEMA_DOCK, szINI::KEY_DROP_QUALIFIED_NAMES}, QVariant(false)},
+    {{szINI::SEC_SCHEMA_DOCK, szINI::KEY_DROP_SELECT_QUERY}, QVariant(true)},
+
+    {{szINI::SEC_SQL_LOG_DOCK, szINI::KEY_LOG}, QVariant("Application")},
+
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_BG_BOLD}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_BG_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_BG_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_COMMENT_BOLD}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_COMMENT_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_COMMENT_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_CUR_LINE_BOLD}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_CUR_LINE_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_CUR_LINE_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FG_BOLD}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FG_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FG_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FUNC_BOLD}, QVariant(true)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FUNC_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FUNC_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_HIGHLIGHT_BOLD}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_HIGHLIGHT_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_HIGHLIGHT_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_IDENTIFIER_BOLD}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_IDENTIFIER_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_IDENTIFIER_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_KEYWORD_BOLD}, QVariant(true)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_KEYWORD_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_KEYWORD_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_BG_BOLD}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_BG_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_BG_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_FG_BOLD}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_FG_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_FG_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_STRING_BOLD}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_STRING_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_STRING_UNDERLINE}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_TABLE_BOLD}, QVariant(true)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_TABLE_ITALIC}, QVariant(false)},
+    {{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_TABLE_UNDERLINE}, QVariant(false)},
+};
 
 void Settings::setSettingsObject()
 {
@@ -72,7 +210,8 @@ void Settings::setSettingsObject()
             settings = new QSettings(userSettingsFile, QSettings::IniFormat);
 
             // Code to verify that the user does not have access to the requested settings file
-            if(settings->status() == QSettings::AccessError) {
+            if(settings->status() == QSettings::AccessError)
+            {
                 qWarning() << qPrintable("The given settings file can NOT access. Please check the permission for the file.");
                 qWarning() << qPrintable("So, the -S/--settings option is ignored.");
 
@@ -86,538 +225,84 @@ void Settings::setSettingsObject()
             settings = new QSettings(QCoreApplication::organizationName(), QCoreApplication::organizationName());
         }
     }
+    processDefaultFixedFont();
+    processDefaultColours();
+}
+
+void Settings::setUserSettingsFile(const QString& settings_file_path)
+{
+    userSettingsFile = settings_file_path;
 }
 
 QVariant Settings::getValue(const std::string& section, const std::string& key)
 {
-    // Have a look in the cache first
-    auto cacheIndex = m_hCache.find(section + key);
-    if(cacheIndex != m_hCache.end())
+    auto qValue = new QVariant();
+    if (section.empty() || key.empty())
     {
-        return cacheIndex->second;
-    } else {
-        // Nothing found in the cache, so get the value from the settings file or get the default value if there is no value set yet
-        setSettingsObject();
-        QVariant value = settings->value(QString::fromStdString(section + "/" + key), getDefaultValue(section, key));
-
-        // Store this value in the cache for further usage and return it afterwards
-        m_hCache.insert({section + key, value});
-        return value;
+        qDebug() << "Empty Arguments(getValue): "
+                 << QString::fromStdString(section)
+                 << "\t"
+                 << QString::fromStdString(key);
+        return *qValue;
     }
+    if (fetchCacheValue(section, key, qValue))
+    {
+        // return value found in Cached Settings
+        return *qValue;
+    }
+    if (fetchFileValue(section, key, qValue))
+    {
+        // Store value found in settings file in the cache and return value
+        m_hCache.insert({{section, key}, *qValue});
+        return *qValue;
+    }
+    if (fetchDefaultValue(section, key, qValue))
+    {
+        // Store value found in Default in the cache
+        m_hCache.insert({{section, key}, *qValue});
+        // return the default value
+        return *qValue;
+    }
+    // Search not in Cache, File, nor Default
+    // Log the Section/Key to the console
+    qWarning().nospace() << "=======================================================\n"
+                         << "Value for: "
+                         << QString::fromStdString(section)
+                         << " | "
+                         << QString::fromStdString(key)
+                         << " NOT Found!!\n"
+                         << "Removing section/key value from settings!!\n"
+                         << "=======================================================\n";
+    clearValue(section, key);
+    // return the empty QVariant object
+    return *qValue;
 }
 
 void Settings::setValue(const std::string& section, const std::string& key, const QVariant& value, bool save_to_disk)
 {
-    // Sometime the value has to be saved for the current session only but get discarded when the application exits.
-    // In order to achieve this this flag can be set which disables the save to disk mechanism and only leaves the save to cache part active.
+    // Sometimes the value has to be saved for the current session only and gets discarded when the application exits.
+    // The save_to_disk flag disables the writing mechanism for the supplied section/key/value arguments.
     if(save_to_disk)
     {
-        setSettingsObject();
         // Set the group and save the given value
         settings->beginGroup(QString::fromStdString(section));
         settings->setValue(QString::fromStdString(key), value);
         settings->endGroup();
     }
-
-    // Also change it in the cache
-    m_hCache[section + key] = value;
-}
-
-QVariant Settings::getDefaultValue(const std::string& section, const std::string& key)
-{
-    // db/defaultencoding?
-    if(section == szINI::SEC_DATABASE && key == szINI::KEY_DEFAULT_ENCODING)
-        return "UTF-8";
-
-    // db/savedefaultlocation?
-    if(section == szINI::SEC_DATABASE && key == szINI::KEY_SAVE_DEFAULT_LOCATION)
-        return 2;
-
-    // db/defaultlocation?
-    if(section == szINI::SEC_DATABASE && key == szINI::KEY_DEFAULT_LOCATION)
-        return QDir::homePath();
-
-    // db/lastlocation?
-    if(section == szINI::SEC_DATABASE && key == szINI::KEY_LAST_LOCATION)
-        return getValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_LOCATION);
-
-    // db/hideschemalinebreaks?
-    if(section == szINI::SEC_DATABASE && key == szINI::KEY_HIDE_SCHEMA_LINEBREAKS)
-        return true;
-
-    // db/foreignkeys?
-    if(section == szINI::SEC_DATABASE && key == szINI::KEY_FOREIGN_KEYS)
-        return true;
-
-    // db/prefetchsize?
-    if(section == szINI::SEC_DATABASE && key == szINI::KEY_PREFETCH_SIZE)
-        return 50000U;
-
-    // db/defaultsqltext?
-    if(section == szINI::SEC_DATABASE && key == szINI::KEY_DEFAULT_SQL_TEXT)
-        return QString();
-
-    // db/fontsize?
-    if(section == szINI::SEC_DATABASE && key == szINI::KEY_FONTSIZE)
-        return 10;
-
-    // exportcsv/firstrowheader?
-    if(section == szINI::SEC_EXPORT_CSV && key == szINI::KEY_FIRST_ROW_HEADER)
-        return true;
-
-    // exportcsv/separator?
-    if(section == szINI::SEC_EXPORT_CSV && key == szINI::KEY_SEPARATOR)
-        return ',';
-
-    // exportcsv/quotecharacter?
-    if(section == szINI::SEC_EXPORT_CSV && key == szINI::KEY_QUOTE_CHARACTER)
-        return '"';
-
-    // importcsv group?
-    if(section == szINI::SEC_IMPORT_CSV)
-    {
-        if(key == szINI::KEY_FIRST_ROW_HEADER)
-            return false;
-        if(key == szINI::KEY_TRIM_FIELDS)
-            return true;
-        if(key == szINI::KEY_SEPARATE_TABLES)
-            return false;
-        if(key == szINI::KEY_SEPARATOR)
-            return ',';
-        if(key == szINI::KEY_QUOTE_CHARACTER)
-            return '"';
-        if(key == szINI::KEY_ENCODING)
-            return "UTF-8";
-        if(key == szINI::KEY_LOCAL_CONVENTIONS)
-            return false;
-    }
-
-    // exportsql group?
-    if(section == szINI::SEC_EXPORT_SQL)
-    {
-        if(key == szINI::KEY_INSERT_COL_NAMES || key == szINI::KEY_INSERT_MULTIPLE || key == szINI::KEY_KEEP_ORIGINAL)
-            return false;
-        if(key == szINI::KEY_OLD_SCHEMA)
-            return 0;
-    }
-
-    // newline character
-    if (section == szINI::SEC_EXPORT_CSV && key == szINI::KEY_NEWLINE_CHARACTERS)
-#ifdef Q_OS_WIN
-        return "\r\n";
-#else
-        return "\n";
-#endif
-
-    // exportjson/prettyprint?
-    if(section == szINI::SEC_EXPORT_JSON && key == szINI::KEY_PRETTY_PRINT)
-        return true;
-
-    // MainWindow/geometry?
-    if(section == szINI::SEC_MAIN_WNDW && key == szINI::KEY_GEOMETRY)
-        return QString();
-
-    // MainWindow/windowState?
-    if(section == szINI::SEC_MAIN_WNDW && key == szINI::KEY_WINDOW_STATE)
-        return QString();
-
-    // MainWindow/openTabs?
-    if(section == szINI::SEC_MAIN_WNDW && key == szINI::KEY_OPEN_TABS)
-        return QString();
-
-    // SQLLogDock/Log?
-    if(section == szINI::SEC_SQL_LOG_DOCK && key == szINI::KEY_LOG)
-        return "Application";
-
-    // General/recentFileList?
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_RECENT_FILE_LIST)
-        return QStringList();
-
-    // General/maxRecentFiles?
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_MAX_RECENT_FILES)
-        return 5;
-
-    // General/language?
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_LANGUAGE)
-        return QLocale::system().name();
-
-    // General/appStyle
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_APPSTYLE)
-        return static_cast<int>(FollowDesktopStyle);
-
-    // General/toolbarStyle
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_TB_STYLE_APP)
-        return static_cast<int>(Qt::ToolButtonTextBesideIcon);
-
-    // General/toolbarStyleStructure
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_TB_STYLE_STRUCTURE)
-        return static_cast<int>(Qt::ToolButtonTextBesideIcon);
-
-    // General/toolbarStyleBrowse
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_TB_STYLE_BROWSE)
-        return static_cast<int>(Qt::ToolButtonIconOnly);
-
-    // General/toolbarStyleSql
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_TB_STYLE_SQL)
-        return static_cast<int>(Qt::ToolButtonIconOnly);
-
-    // General/toolbarStyleEditCell
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_TB_STYLE_EDIT_CELL)
-        return static_cast<int>(Qt::ToolButtonIconOnly);
-
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_DB_FILE_EXTS)
-        return QObject::tr("SQLite database files (*.db *.sqlite *.sqlite3 *.db3)");
-
-    // General/fontsize
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_FONTSIZE)
-        return m_defaultFontSize;
-
-    // General/promptsqltabsinnewproject
-    if(section == szINI::SEC_GENERAL && key == szINI::KEY_PROMPT_SQL_TABS_IN_NEWPRJ)
-        return true;
-
-    // checkversion group?
-    if(section == szINI::SEC_CHCK_VERSION)
-    {
-        if(key == szINI::KEY_ENABLED)
-            return true;
-        if(key == szINI::KEY_IGNMAJOR)
-            return 999;
-        if(key == szINI::KEY_IGNMINOR || key == szINI::KEY_IGNPATCH)
-            return 0;
-    }
-
-    // Data Browser/NULL Fields
-    if(section == szINI::SEC_DATA_BROWSER)
-    {
-        if(key == szINI::KEY_FONT) {
-            QFont font("Monospace");
-            font.setStyleHint(QFont::TypeWriter);
-            return QFontInfo(font).family();
-        }
-        if(key == szINI::KEY_FONTSIZE)
-            return 10;
-        if(key == szINI::KEY_SYMBOL_LIMIT)
-            return 5000;
-        if(key == szINI::KEY_ROWS_LIMIT)
-            return 10'000'000;
-        if(key == szINI::KEY_COMPLETE_THRESHOLD)
-            return 1000;
-        if(key == szINI::KEY_IMAGE_PREVIEW)
-            return false;
-        if(key == szINI::KEY_INDENT_COMPACT)
-            return false;
-        if(key == szINI::KEY_AUTO_SWITCH_MODE)
-            return true;
-        if(key == szINI::KEY_EDITOR_WORD_WRAP)
-            return true;
-        if(key == szINI::KEY_NULL_TEXT)
-            return "NULL";
-        if(key == szINI::KEY_BLOB_TEXT)
-            return "BLOB";
-        if(key == szINI::KEY_FILTER_ESCAPE)
-            return "\\";
-        if(key == szINI::KEY_FILTER_DELAY)
-            return 200;
-        if(ends_with(key, szINI::KEY_ANY_COLOUR))
-            return getDefaultColorValue(section, key, FollowDesktopStyle);
-    }
-
-    // syntaxhighlighter?
-    if(section == szINI::SEC_SYNTAX_HIGHLIGHTER)
-    {
-        // Bold? Only tables, functions and keywords are bold by default
-        if(ends_with(key, szINI::KEY_ANY_BOLD))
-            return key == szINI::KEY_KEYWORD_BOLD || key == szINI::KEY_TABLE_BOLD || key == szINI::KEY_FUNC_BOLD;
-
-        // Italic? Nothing by default
-        if(ends_with(key, szINI::KEY_ANY_ITALIC))
-            return false;
-
-        // Underline? Nothing by default
-        if(ends_with(key, szINI::KEY_ANY_UNDERLINE))
-            return false;
-
-        // Colour?
-        if(ends_with(key, szINI::KEY_ANY_COLOUR))
-            return getDefaultColorValue(section, key, FollowDesktopStyle);
-    }
-
-    // editor/font?
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_FONT)
-    {
-        QFont font("Monospace");
-        font.setStyleHint(QFont::TypeWriter);
-        return QFontInfo(font).family();
-    }
-
-    // editor/fontsize or log/fontsize?
-    if((section == szINI::SEC_EDITOR || section == szINI::SEC_LOG) && key == szINI::KEY_FONTSIZE)
-#ifdef Q_OS_MAC
-       // Use 12 pt size as the default on macOS
-        return 12;
-#else
-        return 9;
-#endif
-
-    if(section == szINI::SEC_EDITOR)
-    {
-        if(key == szINI::KEY_TABSIZE)
-            return 4;
-        if(key == szINI::KEY_INDENTATION_USE_TABS)
-            return true;
-    }
-
-    // editor/wrap_lines
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_WRAP_LINES)
-        return 0; // QsciScintilla::WrapNone
-
-    // editor/identifier_quotes
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_IDENTIFIER_QUOTES)
-        return 0; // sqlb::DoubleQuotes
-
-    // editor/auto_completion?
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_AUTO_COMPLETION)
-        return true;
-
-    // editor/upper_keywords?
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_UPPER_KEYWORDS)
-        return true;
-
-    // editor/error_indicators?
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_ERROR_INDICATORS)
-        return true;
-
-    // editor/horizontal_tiling?
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_HORZ_TILING)
-        return false;
-
-    // editor/splitter1_sizes?
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_SPLITTER1_SIZES)
-        return QVariant();
-
-    // editor/splitter2_sizes?
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_SPLITTER2_SIZES)
-        return QVariant();
-
-    // editor/close_button_on_tabs?
-    if(section == szINI::SEC_EDITOR && key == szINI::KEY_CLOSE_BUTTON_ON_TABS)
-        return true;
-
-    // extensions/list?
-    if(section == szINI::SEC_EXTENSIONS && key == szINI::KEY_LIST)
-        return QStringList();
-
-    // extensions/disableregex?
-    if(section == szINI::SEC_EXTENSIONS && key == szINI::KEY_DISABLE_REGEX)
-        return false;
-
-    // extensions/enable_load_extension?
-    if(section == szINI::SEC_EXTENSIONS && key == szINI::KEY_ENABLE_LOAD_EXTENSION)
-        return false;
-
-    // PlotDock/lineType or pointShape?
-    if(section == szINI::SEC_PLOT_DOCK)
-    {
-        // QCPGraph::lsLine
-        if(key == szINI::KEY_LINE_TYPE)
-            return 1;
-
-        // QCPScatterStyle::ssDisk
-        if(key == szINI::KEY_POINT_SHAPE)
-            return 4;
-    }
-
-
-    // SchemaDock Drag & drop settings
-    if(section == szINI::SEC_SCHEMA_DOCK)
-    {
-        if(key == szINI::KEY_DROP_SELECT_QUERY)
-            return true;
-
-        if(key == szINI::KEY_DROP_QUALIFIED_NAMES)
-            return false;
-
-        if(key == szINI::KEY_DROP_ENQUOTED_NAMES)
-            return true;
-    }
-
-    // Remote settings?
-    if(section == szINI::SEC_REMOTE)
-    {
-        // Enable the File → Remote menu by default
-        if(key == szINI::KEY_ACTIVE)
-            return true;
-
-        // Clone directory
-        if(key == szINI::KEY_CLONE_DIR)
-#if QT_VERSION >= QT_VERSION_CHECK(5, 4, 0)
-            return QStandardPaths::writableLocation(QStandardPaths::AppDataLocation);
-#else
-            return QStandardPaths::writableLocation(QStandardPaths::GenericDataLocation);
-#endif
-    }
-
-    // Proxy settings
-    if(section == szINI::SEC_PROXY)
-    {
-        // Use system settings by default
-        if(key == szINI::KEY_TYPE)
-            return "system";
-    }
-
-    // Unknown combination of group and name? Return an invalid QVariant!
-    return QVariant();
-}
-
-QColor Settings::getDefaultColorValue(const std::string& section, const std::string& key, AppStyle style)
-{
-    // Data Browser/NULL & Binary Fields
-    if(section == szINI::SEC_DATA_BROWSER)
-    {
-        // The switch on style can be removed if the following issue is fixed:
-        // https://github.com/ColinDuquesnoy/QDarkStyleSheet/issues/171
-        switch (style) {
-        case FollowDesktopStyle :
-            if(key == szINI::KEY_NULL_FG_COLOUR)
-                return QColor(Qt::lightGray).name();
-            if(key == szINI::KEY_NULL_BG_COLOUR)
-                return QPalette().color(QPalette::Active, QPalette::Base).name();
-            if(key == szINI::KEY_REG_FG_COLOUR)
-                return QPalette().color(QPalette::Active, QPalette::Text).name();
-            if(key == szINI::KEY_REG_BG_COLOUR)
-                return QPalette().color(QPalette::Active, QPalette::Base).name();
-            if(key == szINI::KEY_FMT_FG_COLOUR)
-                return QPalette().color(QPalette::Active, QPalette::Text).name();
-            if(key == szINI::KEY_FMT_BG_COLOUR)
-                return QPalette().color(QPalette::Active, QPalette::AlternateBase).name();
-            if(key == szINI::KEY_BIN_FG_COLOUR)
-                return QColor(Qt::lightGray).name();
-            if(key == szINI::KEY_BIN_BG_COLOUR)
-                return QPalette().color(QPalette::Active, QPalette::Base).name();
-            break;
-        case DarkStyle :
-            if(key == szINI::KEY_NULL_FG_COLOUR)
-                return QColor(0x78, 0x78, 0x78);
-            if(key == szINI::KEY_NULL_BG_COLOUR)
-                return QColor(0x19, 0x23, 0x2D);
-            if(key == szINI::KEY_REG_FG_COLOUR)
-                return QColor(0xF0, 0xF0, 0xF0);
-            if(key == szINI::KEY_REG_BG_COLOUR)
-                return QColor(0x19, 0x23, 0x2D);
-            if(key == szINI::KEY_FMT_FG_COLOUR)
-                return QColor(0xF0, 0xF0, 0xF0);
-            if(key == szINI::KEY_FMT_BG_COLOUR)
-                return QColor(0x19, 0x23, 0x2D);
-            if(key == szINI::KEY_BIN_FG_COLOUR)
-                return QColor(0x78, 0x78, 0x78);
-            if(key == szINI::KEY_BIN_BG_COLOUR)
-                return QColor(0x19, 0x23, 0x2D);
-            break;
-        case LightStyle :
-            if(key == szINI::KEY_NULL_FG_COLOUR || key == szINI::KEY_BIN_FG_COLOUR)
-                return QColor(0xA5, 0xA9, 0xAC);
-            if(key == szINI::KEY_NULL_BG_COLOUR || key == szINI::KEY_BIN_BG_COLOUR)
-                return QColor(0xFA, 0xFA, 0xFA);
-            if(key == szINI::KEY_REG_FG_COLOUR)
-                return QColor(0x00, 0x00, 0x00);
-            if(key == szINI::KEY_REG_BG_COLOUR)
-                return QColor(0xFA, 0xFA, 0xFA);
-            if(key == szINI::KEY_FMT_FG_COLOUR)
-                return QColor(0x00, 0x00, 0x00);
-            if(key == szINI::KEY_FMT_BG_COLOUR)
-                return QColor(0xFA, 0xFA, 0xFA);
-            break;
-        }
-    }
-
-    // syntaxhighlighter?
-    if(section == szINI::SEC_SYNTAX_HIGHLIGHTER)
-    {
-        // Colour?
-        if(ends_with(key, szINI::KEY_ANY_COLOUR))
-        {
-            QColor backgroundColour;
-            QColor foregroundColour;
-
-            switch (style) {
-            case FollowDesktopStyle :
-                backgroundColour = QPalette().color(QPalette::Active, QPalette::Base);
-                foregroundColour = QPalette().color(QPalette::Active, QPalette::Text);
-                break;
-            case DarkStyle :
-                foregroundColour = QColor(0xF0, 0xF0, 0xF0);
-                backgroundColour = QColor(0x19, 0x23, 0x2D);
-                break;
-            case LightStyle :
-                foregroundColour = QColor(0x00, 0x00, 0x00);
-                backgroundColour = QColor(0xFA, 0xFA, 0xFA);
-                break;
-            }
-            if(key == szINI::KEY_FG_COLOUR)
-                return foregroundColour;
-            else if(key == szINI::KEY_BG_COLOUR)
-                return backgroundColour;
-            else if(key == szINI::KEY_SELECTED_FG_COLOUR)
-                return QPalette().color(QPalette::Active, QPalette::HighlightedText);
-            else if(key == szINI::KEY_SELECTED_BG_COLOUR)
-                return QPalette().color(QPalette::Active, QPalette::Highlight);
-
-            // Detect and provide sensible defaults for dark themes
-            if (backgroundColour.value() < foregroundColour.value()) {
-                if(key == szINI::KEY_KEYWORD_COLOUR)
-                    return QColor(82, 148, 226);
-                else if(key == szINI::KEY_FUNC_COLOUR)
-                    return QColor(Qt::yellow);
-                else if(key == szINI::KEY_TABLE_COLOUR)
-                    return QColor(Qt::cyan);
-                else if(key == szINI::KEY_COMMENT_COLOUR)
-                    return QColor(Qt::green);
-                else if(key == szINI::KEY_IDENTIFIER_COLOUR)
-                    return QColor(221, 160, 221);
-                else if(key == szINI::KEY_STRING_COLOUR)
-                    return QColor(Qt::lightGray);
-                else if(key == szINI::KEY_CUR_LINE_COLOUR)
-                    return backgroundColour.lighter(150);
-                else if(key == szINI::KEY_HIGHLIGHT_COLOUR)
-                    return QColor(79, 148, 205);
-            } else {
-                if(key == szINI::KEY_KEYWORD_COLOUR)
-                    return QColor(Qt::darkBlue);
-                else if(key == szINI::KEY_FUNC_COLOUR)
-                    return QColor(Qt::blue);
-                else if(key == szINI::KEY_TABLE_COLOUR)
-                    return QColor(Qt::darkCyan);
-                else if(key == szINI::KEY_COMMENT_COLOUR)
-                    return QColor(Qt::darkGreen);
-                else if(key == szINI::KEY_IDENTIFIER_COLOUR)
-                    return QColor(Qt::darkMagenta);
-                else if(key == szINI::KEY_STRING_COLOUR)
-                    return QColor(Qt::red);
-                else if(key == szINI::KEY_CUR_LINE_COLOUR)
-                    return QColor(236, 236, 245);
-                else if(key == szINI::KEY_HIGHLIGHT_COLOUR)
-                    return QColor(Qt::cyan);
-            }
-        }
-    }
-
-    // Unknown combination of group and name? Return an invalid QColor!
-    return QColor();
+    // Also push value into cache
+    m_hCache[{section, key}] = value;
 }
 
 void Settings::clearValue(const std::string& section, const std::string& key)
 {
-    setSettingsObject();
     settings->beginGroup(QString::fromStdString(section));
     settings->remove(QString::fromStdString(key));
     settings->endGroup();
-    m_hCache.clear();
+    m_hCache.erase({section, key});
 }
 
 void Settings::restoreDefaults ()
 {
-    setSettingsObject();
     settings->clear();
     m_hCache.clear();
 }
@@ -626,15 +311,15 @@ void Settings::exportSettings(const QString& fileName)
 {
     QSettings exportSettings(fileName, QSettings::IniFormat);
 
-    const QStringList groups = settings->childGroups();
-    for(const QString& currentGroup : groups)
+    const QStringList sections = settings->childGroups();
+    for(const QString& currentSection : sections)
     {
-        settings->beginGroup(currentGroup);
+        settings->beginGroup(currentSection);
         const QStringList keys = settings->childKeys();
         for(const QString& currentKey : keys)
         {
-            exportSettings.beginGroup(currentGroup);
-            exportSettings.setValue(currentKey, getValue((currentGroup.toStdString()), (currentKey.toStdString())));
+            exportSettings.beginGroup(currentSection);
+            exportSettings.setValue(currentKey, getValue((currentSection.toStdString()), (currentKey.toStdString())));
             exportSettings.endGroup();
         }
         settings->endGroup();
@@ -648,20 +333,19 @@ bool Settings::importSettings(const QString& fileName)
 
     QSettings importSettings(fileName, QSettings::IniFormat);
 
-    const QStringList groups = importSettings.childGroups();
-    for(const QString& currentGroup : groups)
+    const QStringList sections = importSettings.childGroups();
+    for(const QString& currentSection : sections)
     {
-        importSettings.beginGroup(currentGroup);
+        importSettings.beginGroup(currentSection);
         const QStringList keys = importSettings.childKeys();
         for(const QString& currentKey : keys)
         {
-            settings->beginGroup(currentGroup);
+            settings->beginGroup(currentSection);
             settings->setValue(currentKey, importSettings.value(currentKey));
             settings->endGroup();
         }
         importSettings.endGroup();
     }
-
     m_hCache.clear();
     return true;
 }
@@ -669,4 +353,477 @@ bool Settings::importSettings(const QString& fileName)
 void Settings::sync()
 {
     settings->sync();
+}
+
+void Settings::debug_cache()
+{
+    std::cout << "Cache Values" << std::endl
+              << "---------------" << std::endl
+              << "File: " << userSettingsFile.toStdString() << std::endl
+              << "---------------" << std::endl;
+    std::stringstream buffer;
+    // unordered map sorted when items added into map container
+    std::map<SectionKeyPair, QVariant, pair_compare> temp_debug;
+    for (const auto& item : m_hCache)
+    {
+        temp_debug[{item.first.first, item.first.second}] = item.second;
+    }
+    for (const auto& item : temp_debug)
+    {
+        buffer << "Section:"
+               << std::setw(18) << item.first.first     // SectionKeyPair.section
+               << "\tKey:"
+               << std::setw(28) << item.first.second    // SectionKeyPair.key
+               << "\tValue:["
+               << item.second.toString().toStdString()
+               << "]"
+               << std::endl;
+    }
+    std::cout << buffer.str() << std::endl;
+}
+
+void Settings::debug_default()
+{
+    std::cout << "Default Values" << std::endl
+              << "---------------" << std::endl;
+    std::stringstream buffer;
+    // unordered map sorted when items added into map container
+    std::map<SectionKeyPair, QVariant, pair_compare> temp_debug;
+    for (const auto& item : m_hDefault)
+    {
+        temp_debug[{item.first.first, item.first.second}] = item.second;
+    }
+    for (const auto& item : temp_debug)
+    {
+        buffer << "Section:"
+               << std::setw(18) << item.first.first     // SectionKeyPair.section
+               << "\tKey:"
+               << std::setw(28) << item.first.second    // SectionKeyPair.key
+               << "\tValue:["
+               << item.second.toString().toStdString()
+               << "]"
+               << std::endl;
+    }
+    std::cout << buffer.str() << std::endl;
+}
+
+bool Settings::isValidSettingsFile(const QString& settings_file_path)
+{
+    /*
+    Variable storing settings file path requested by the user is a normal settings file if
+    the file does not exist and is newly created. In this instance, the if statement below
+    is not executed. Therefore, the default value is set to true.
+    */
+    bool isNormalUserSettingsFile = true;
+
+    // Code that verifies that the settings file requested by the user is a normal settings file
+    if(settings_file_path != nullptr)
+    {
+        auto *file = new QFile;
+        file->setFileName(settings_file_path);
+
+        if(file->open(QIODevice::ReadOnly | QIODevice::Text))
+        {
+            // define comparison string
+            // "[General]\n" --> first line of any DB4S settings file
+            QString header("[" + QString::fromStdString(szINI::SEC_GENERAL) + "]\n");
+            if(file->exists() &&
+               QString::compare(header, file->readLine(), Qt::CaseInsensitive) != 0)
+                isNormalUserSettingsFile = false;
+        }
+
+        file->close();
+    }
+    qDebug() << "Settings File: "
+             << settings_file_path
+             << "\nReturn: "
+             << QString(isNormalUserSettingsFile ? "True" : "False");
+    return isNormalUserSettingsFile;
+}
+
+QVariant Settings::getDefaultValue(const std::string& section, const std::string& key)
+{
+    auto qValue = new QVariant();
+    if (section.empty() || key.empty())
+    {
+        qDebug() << "Empty Arguments(getDefaultValue): "
+                 << QString::fromStdString(section)
+                 << "\t"
+                 << QString::fromStdString(key);
+        return *qValue;
+    }
+    if (!fetchDefaultValue(section, key, qValue))
+    {
+        // Log the Section/Key to the console
+        qWarning() << "Value for"
+                   << QString::fromStdString(section)
+                   << "|"
+                   << QString::fromStdString(key)
+                   << " NOT Found!!";
+        // return the empty QVariant object
+    }
+    return *qValue;
+}
+
+QColor Settings::getDefaultColourValue(const std::string& section, const std::string& key, AppStyle style)
+{
+    // Data Browser/NULL & Binary Fields
+    if(section == szINI::SEC_DATA_BROWSER)
+    {
+        // The switch on style can be removed if the following issue is fixed:
+        // https://github.com/ColinDuquesnoy/QDarkStyleSheet/issues/171
+        switch (style)
+        {
+        case FollowDesktopStyle :
+            if(key == szINI::KEY_NULL_FG_COLOUR)
+                return QColor{Qt::lightGray};
+            if(key == szINI::KEY_NULL_BG_COLOUR)
+                return QPalette().color(QPalette::Active, QPalette::Base);
+            if(key == szINI::KEY_REG_FG_COLOUR)
+                return QPalette().color(QPalette::Active, QPalette::Text);
+            if(key == szINI::KEY_REG_BG_COLOUR)
+                return QPalette().color(QPalette::Active, QPalette::Base);
+            if(key == szINI::KEY_FMT_FG_COLOUR)
+                return QPalette().color(QPalette::Active, QPalette::Text);
+            if(key == szINI::KEY_FMT_BG_COLOUR)
+                return QPalette().color(QPalette::Active, QPalette::AlternateBase);
+            if(key == szINI::KEY_BIN_FG_COLOUR)
+                return QColor{Qt::lightGray};
+            if(key == szINI::KEY_BIN_BG_COLOUR)
+                return QPalette().color(QPalette::Active, QPalette::Base);
+            break;
+        case DarkStyle :
+            if(key == szINI::KEY_NULL_FG_COLOUR)
+                return QColor{0x78, 0x78, 0x78};
+            if(key == szINI::KEY_NULL_BG_COLOUR)
+                return QColor{0x19, 0x23, 0x2D};
+            if(key == szINI::KEY_REG_FG_COLOUR)
+                return QColor{0xF0, 0xF0, 0xF0};
+            if(key == szINI::KEY_REG_BG_COLOUR)
+                return QColor{0x19, 0x23, 0x2D};
+            if(key == szINI::KEY_FMT_FG_COLOUR)
+                return QColor{0xF0, 0xF0, 0xF0};
+            if(key == szINI::KEY_FMT_BG_COLOUR)
+                return QColor{0x19, 0x23, 0x2D};
+            if(key == szINI::KEY_BIN_FG_COLOUR)
+                return QColor{0x78, 0x78, 0x78};
+            if(key == szINI::KEY_BIN_BG_COLOUR)
+                return QColor{0x19, 0x23, 0x2D};
+            break;
+        case LightStyle :
+            if(key == szINI::KEY_NULL_FG_COLOUR || key == szINI::KEY_BIN_FG_COLOUR)
+                return QColor{0xA5, 0xA9, 0xAC};
+            if(key == szINI::KEY_NULL_BG_COLOUR || key == szINI::KEY_BIN_BG_COLOUR)
+                return QColor{0xFA, 0xFA, 0xFA};
+            if(key == szINI::KEY_REG_FG_COLOUR)
+                return QColor{0x00, 0x00, 0x00};
+            if(key == szINI::KEY_REG_BG_COLOUR)
+                return QColor{0xFA, 0xFA, 0xFA};
+            if(key == szINI::KEY_FMT_FG_COLOUR)
+                return QColor{0x00, 0x00, 0x00};
+            if(key == szINI::KEY_FMT_BG_COLOUR)
+                return QColor{0xFA, 0xFA, 0xFA};
+            break;
+        }
+    }
+
+    if (section == szINI::SEC_SYNTAX_HIGHLIGHTER)
+    {
+        if (ends_with(key, szINI::KEY_ANY_COLOUR))
+        {
+            QColor backgroundColour;
+            QColor foregroundColour;
+
+            switch (style)
+            {
+            case FollowDesktopStyle :
+                backgroundColour = QPalette().color(QPalette::Active, QPalette::Base);
+                foregroundColour = QPalette().color(QPalette::Active, QPalette::Text);
+                break;
+            case DarkStyle :
+                foregroundColour = QColor{0xF0, 0xF0, 0xF0};
+                backgroundColour = QColor{0x19, 0x23, 0x2D};
+                break;
+            case LightStyle :
+                foregroundColour = QColor{0x00, 0x00, 0x00};
+                backgroundColour = QColor{0xFA, 0xFA, 0xFA};
+                break;
+            }
+            if(key == szINI::KEY_FG_COLOUR)
+                return foregroundColour;
+            if(key == szINI::KEY_BG_COLOUR)
+                return backgroundColour;
+            if(key == szINI::KEY_SELECTED_FG_COLOUR)
+                return QPalette().color(QPalette::Active, QPalette::HighlightedText);
+            if(key == szINI::KEY_SELECTED_BG_COLOUR)
+                return QPalette().color(QPalette::Active, QPalette::Highlight);
+
+            // Detect and provide sensible defaults for dark themes
+            if (backgroundColour.value() < foregroundColour.value())
+            {
+                if(key == szINI::KEY_KEYWORD_COLOUR)
+                    return QColor{82, 148, 226};
+                if(key == szINI::KEY_FUNC_COLOUR)
+                    return QColor{Qt::yellow};
+                if(key == szINI::KEY_TABLE_COLOUR)
+                    return QColor{Qt::cyan};
+                if(key == szINI::KEY_COMMENT_COLOUR)
+                    return QColor{Qt::green};
+                if(key == szINI::KEY_IDENTIFIER_COLOUR)
+                    return QColor{221, 160, 221};
+                if(key == szINI::KEY_STRING_COLOUR)
+                    return QColor{Qt::lightGray};
+                if(key == szINI::KEY_CUR_LINE_COLOUR)
+                    return backgroundColour.lighter(150);
+                if(key == szINI::KEY_HIGHLIGHT_COLOUR)
+                    return QColor{79, 148, 205};
+            } else {
+                if(key == szINI::KEY_KEYWORD_COLOUR)
+                    return QColor{Qt::darkBlue};
+                if(key == szINI::KEY_FUNC_COLOUR)
+                    return QColor{Qt::blue};
+                if(key == szINI::KEY_TABLE_COLOUR)
+                    return QColor{Qt::darkCyan};
+                if(key == szINI::KEY_COMMENT_COLOUR)
+                    return QColor{Qt::darkGreen};
+                if(key == szINI::KEY_IDENTIFIER_COLOUR)
+                    return QColor{Qt::darkMagenta};
+                if(key == szINI::KEY_STRING_COLOUR)
+                    return QColor{Qt::red};
+                if(key == szINI::KEY_CUR_LINE_COLOUR)
+                    return QColor{236, 236, 245};
+                if(key == szINI::KEY_HIGHLIGHT_COLOUR)
+                    return QColor{Qt::cyan};
+            }
+        }
+    }
+    // Unknown combination of section and key!
+    // Log the missed colour search and return an invalid QColor.
+    qWarning() << "No value for GetDefaultColour "
+               << QString::fromStdString(section)
+               << "|"
+               << QString::fromStdString(key);
+    return QColor{};
+}
+
+bool Settings::fetchCacheValue(const std::string& section, const std::string& key, QVariant* foundData)
+{
+    // Search settings cache for section/key.
+    // IF FOUND, return true and set pointer variable contents to found value
+    // ELSE return false - Pointer variable contents are indeterminate.
+    // Assumption: section/key assumed to be non-empty, valid strings.
+    bool bReturn{false};
+    auto cacheIndex = m_hCache.find({section, key});
+    if (cacheIndex != m_hCache.end())
+    {
+        bReturn = true;
+        foundData->setValue(cacheIndex->second);
+    }
+    return bReturn;
+}
+
+bool Settings::fetchFileValue(const std::string& section, const std::string& key, QVariant* foundData)
+{
+    // Search settings file for section/key.
+    // IF FOUND, return true and set pointer variable contents to found value
+    // ELSE return false - Pointer variable contents are indeterminate.
+    // Assumption: section/key assumed to be non-empty, valid strings.
+    bool bReturn{false};
+    auto str_sect_key = QString::fromStdString(section + "/" + key);
+    if (settings->contains(str_sect_key))
+    {
+        bReturn = true;
+        foundData->setValue(settings->value(str_sect_key));
+    }
+    return bReturn;
+}
+
+bool Settings::fetchDefaultValue(const std::string& section, const std::string& key, QVariant* foundData)
+{
+    // Search settings default for section/key.
+    // IF FOUND, return true and set pointer variable contents to found value
+    // ELSE return false - Pointer variable contents are indeterminate.
+    // Assumption: section/key assumed to be non-empty, valid strings.
+    bool bReturn{false};
+    auto defaultIndex = m_hDefault.find({section, key});
+    if (defaultIndex != m_hDefault.end())
+    {
+        bReturn = true;
+        foundData->setValue(defaultIndex->second);
+    }
+    return bReturn;
+}
+
+// Taken from Qt/QtBase/QFontComboBox source file
+// ref: https://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/widgets/qfontcombobox.cpp
+// Utilized as part of determination of suitable fixed width font
+// Remove after QTBUG-116223 (https://bugreports.qt.io/browse/QTBUG-116223) is resolved.
+QFontDatabase::WritingSystem Settings::writingSystemFromScript(QLocale::Script script)
+{
+    switch (script) {
+        case QLocale::ArabicScript:
+            return QFontDatabase::Arabic;
+        case QLocale::CyrillicScript:
+            return QFontDatabase::Cyrillic;
+        case QLocale::GurmukhiScript:
+            return QFontDatabase::Gurmukhi;
+        case QLocale::SimplifiedHanScript:
+            return QFontDatabase::SimplifiedChinese;
+        case QLocale::TraditionalHanScript:
+            return QFontDatabase::TraditionalChinese;
+        case QLocale::LatinScript:
+            return QFontDatabase::Latin;
+        case QLocale::ArmenianScript:
+            return QFontDatabase::Armenian;
+        case QLocale::BengaliScript:
+            return QFontDatabase::Bengali;
+        case QLocale::DevanagariScript:
+            return QFontDatabase::Devanagari;
+        case QLocale::GeorgianScript:
+            return QFontDatabase::Georgian;
+        case QLocale::GreekScript:
+            return QFontDatabase::Greek;
+        case QLocale::GujaratiScript:
+            return QFontDatabase::Gujarati;
+        case QLocale::HebrewScript:
+            return QFontDatabase::Hebrew;
+        case QLocale::JapaneseScript:
+            return QFontDatabase::Japanese;
+        case QLocale::KhmerScript:
+            return QFontDatabase::Khmer;
+        case QLocale::KannadaScript:
+            return QFontDatabase::Kannada;
+        case QLocale::KoreanScript:
+            return QFontDatabase::Korean;
+        case QLocale::LaoScript:
+            return QFontDatabase::Lao;
+        case QLocale::MalayalamScript:
+            return QFontDatabase::Malayalam;
+        case QLocale::MyanmarScript:
+            return QFontDatabase::Myanmar;
+        case QLocale::TamilScript:
+            return QFontDatabase::Tamil;
+        case QLocale::TeluguScript:
+            return QFontDatabase::Telugu;
+        case QLocale::ThaanaScript:
+            return QFontDatabase::Thaana;
+        case QLocale::ThaiScript:
+            return QFontDatabase::Thai;
+        case QLocale::TibetanScript:
+            return QFontDatabase::Tibetan;
+        case QLocale::SinhalaScript:
+            return QFontDatabase::Sinhala;
+        case QLocale::SyriacScript:
+            return QFontDatabase::Syriac;
+        case QLocale::OriyaScript:
+            return QFontDatabase::Oriya;
+        case QLocale::OghamScript:
+            return QFontDatabase::Ogham;
+        case QLocale::RunicScript:
+            return QFontDatabase::Runic;
+        case QLocale::NkoScript:
+            return QFontDatabase::Nko;
+        default:
+            return QFontDatabase::Any;
+    }
+}
+
+// Taken from Qt/QtBase/QFontComboBox source file
+// ref: https://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/widgets/qfontcombobox.cpp
+// Utilized as part of determination of suitable fixed width font
+// Remove after QTBUG-116223 (https://bugreports.qt.io/browse/QTBUG-116223) is resolved.
+QFontDatabase::WritingSystem Settings::writingSystemFromLocale()
+{
+    QStringList uiLanguages = QLocale::system().uiLanguages();
+    QLocale::Script script;
+    if (!uiLanguages.isEmpty())
+        script = QLocale(uiLanguages.at(0)).script();
+    else
+        script = QLocale::system().script();
+
+    return writingSystemFromScript(script);
+}
+
+void Settings::processDefaultFixedFont()
+{
+    QFontDatabase fontDB;
+    QString fixed_family(QFontDatabase::systemFont(QFontDatabase::FixedFont).family());
+    // Font "SANITY" Check
+    // Selected fixed font must be listed in font database
+    // AND be a FixedPitch (i.e. fixed width) font.
+    // NOTE ASSUMPTION: a fixed pitch font will be found on the system
+    QFontDatabase::WritingSystem fontWriteSys = writingSystemFromLocale();
+    QStringList check_families(fontDB.families(fontWriteSys));
+    bool bCheck_Found = check_families.contains(fixed_family);
+    bool bCheck_IsFixed = fontDB.isFixedPitch(fixed_family);
+    if (!bCheck_Found || !bCheck_IsFixed)
+    {
+        // sanity check failed
+        // find first available fixed pitched font
+        QStringList font_families(fontDB.families(fontWriteSys));
+        for (const auto& each_font_name : font_families)
+        {
+            bool isFixed = fontDB.isFixedPitch(each_font_name);
+            qDebug() << "Testing font: "
+                     << each_font_name
+                     << " fixed?: "
+                     << (isFixed ? "True" : "False");
+            if (!isFixed)
+                continue;
+            fixed_family = each_font_name;
+            break;
+        }
+        qWarning().nospace() << "=======================================================\n"
+                             << "Unable to obtain default fixed font. Qt Environment\n"
+                             << "may be misconfigured. Using first fixed font available\n"
+                             << "from system: " << fixed_family << "\n"
+                             << "=======================================================\n";
+    } else {
+        qDebug() << "System Fixed Font: " << fixed_family;
+    }
+    m_hDefault[{szINI::SEC_DATA_BROWSER, szINI::KEY_FONT }] = QVariant(fixed_family);
+    m_hDefault[{szINI::SEC_DATABASE, szINI::KEY_FONT }] = QVariant(fixed_family);
+    m_hDefault[{szINI::SEC_EDITOR, szINI::KEY_FONT }] = QVariant(fixed_family);
+    m_hDefault[{szINI::SEC_LOG, szINI::KEY_FONT }] = QVariant(fixed_family);
+}
+
+void Settings::processDefaultColours()
+{
+    // using the current application style, establish colour values in default settings storage.
+    std::array<SectionKeyPair, 20> colourPairs
+    {
+        SectionKeyPair{szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_BG_COLOUR},
+        SectionKeyPair{szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_FG_COLOUR},
+        SectionKeyPair{szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_BG_COLOUR},
+        SectionKeyPair{szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_FG_COLOUR},
+        SectionKeyPair{szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_BG_COLOUR},
+        SectionKeyPair{szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_FG_COLOUR},
+        SectionKeyPair{szINI::SEC_DATA_BROWSER, szINI::KEY_REG_BG_COLOUR},
+        SectionKeyPair{szINI::SEC_DATA_BROWSER, szINI::KEY_REG_FG_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_BG_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_COMMENT_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_CUR_LINE_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FG_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FUNC_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_HIGHLIGHT_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_IDENTIFIER_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_KEYWORD_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_BG_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_SELECTED_FG_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_STRING_COLOUR},
+        SectionKeyPair{szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_TABLE_COLOUR}
+    };
+
+    AppStyle style = static_cast<Settings::AppStyle>(getValue(szINI::SEC_GENERAL, szINI::KEY_APPSTYLE).toInt());
+    for (const auto& sec_key : colourPairs)
+    {
+        const auto& section = sec_key.first;
+        const auto& key = sec_key.second;
+        m_hDefault[{section, key}] = QVariant(getDefaultColourValue(section, key, style));
+    }
+}
+
+bool Settings::ends_with(const std::string& str, const std::string& with)
+{
+    return str.rfind(with) == str.size() - with.size();
 }

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -5,6 +5,7 @@
 #include <string>
 #include <unordered_map>
 #include <utility>
+#include <vector>
 #include <QFontDatabase>
 #include <QLocale>
 #include <QSettings>
@@ -315,6 +316,13 @@ private:
     // Search settings defaults for section/key. Return true if found and set by-reference variable to found value
     static bool fetchDefaultValue(const std::string& section, const std::string& key, QVariant* foundData);
 
+    // Search current settings file and correct/replace any deprecated
+    // settings found to preserve and persist user's intent
+    static void processDeprecatedSettings();
+
+    // Search current settings file and remove any settings found that DO NOT HAVE a replacement
+    static void processDeletedSettings();
+
     // Utility functions to obtain QFont writing system from user's locale
     static QFontDatabase::WritingSystem writingSystemFromScript(QLocale::Script script);
     static QFontDatabase::WritingSystem writingSystemFromLocale();
@@ -342,6 +350,12 @@ private:
 
     // Default Values storage
     static std::unordered_map<SectionKeyPair, QVariant, pair_hash> m_hDefault;
+
+    // Deprecated Settings Storage
+    static std::map<SectionKeyPair, SectionKeyPair, pair_compare> m_hDeprecated;
+
+    // Deleted Settings Storage
+    static std::vector<SectionKeyPair> m_hDeleted;
 };
 
 #endif

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -1,9 +1,239 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
+#include <iostream>
+#include <string>
 #include <unordered_map>
 #include <QSettings>
 #include <QVariant>
+
+namespace szINI
+{
+    // Settings identification strings constants
+    // SEC_ -> INI Section
+    // KEY_ -> INI Key name in Section
+    // strings used in multiple places
+    const std::string KEY_FONT = "font";
+    const std::string KEY_FONTSIZE = "fontsize";
+    const std::string KEY_FIRST_ROW_HEADER = "firstrowheader";
+    const std::string KEY_SEPARATOR = "separator";
+    const std::string KEY_QUOTE_CHARACTER = "quotecharacter";
+
+    // Group - checkversion
+    const std::string SEC_CHCK_VERSION = "checkversion";
+    const std::string KEY_ENABLED = "enabled";
+    const std::string KEY_IGNMAJOR = "ignmajor";
+    const std::string KEY_IGNMINOR = "ignminor";
+    const std::string KEY_IGNPATCH = "ignpatch";
+
+    // Group - databrowser
+    // includes KEY_FONT
+    const std::string SEC_DATA_BROWSER = "databrowser";
+    const std::string KEY_AUTO_SWITCH_MODE = "auto_switch_mode";
+    const std::string KEY_BIN_BG_COLOUR = "bin_bg_colour";
+    const std::string KEY_BIN_FG_COLOUR = "bin_fg_colour";
+    const std::string KEY_BLOB_TEXT = "blob_text";
+    const std::string KEY_COMPLETE_THRESHOLD = "complete_threshold";
+    const std::string KEY_EDITOR_WORD_WRAP = "editor_word_wrap";
+    const std::string KEY_FILTER_DELAY = "filter_delay";
+    const std::string KEY_FILTER_ESCAPE = "filter_escape";
+    const std::string KEY_FMT_BG_COLOUR = "formatted_bg_colour";
+    const std::string KEY_FMT_FG_COLOUR = "formatted_fg_colour";
+    const std::string KEY_IMAGE_PREVIEW = "image_preview";
+    const std::string KEY_INDENT_COMPACT = "indent_compact";
+    const std::string KEY_NULL_BG_COLOUR = "null_bg_colour";
+    const std::string KEY_NULL_FG_COLOUR = "null_fg_colour";
+    const std::string KEY_NULL_TEXT = "null_text";
+    const std::string KEY_REG_BG_COLOUR = "reg_bg_colour";
+    const std::string KEY_REG_FG_COLOUR = "reg_fg_colour";
+    const std::string KEY_ROWS_LIMIT = "rows_limit";
+    const std::string KEY_SYMBOL_LIMIT = "symbol_limit";
+
+    // Group - db
+    // includes KEY_FONT, KEY_FONTSIZE
+    const std::string SEC_DATABASE = "db";
+    const std::string KEY_DEFAULT_ENCODING = "defaultencoding";
+    const std::string KEY_DEFAULT_FIELD_TYPE = "defaultfieldtype";
+    const std::string KEY_DEFAULT_LOCATION = "defaultlocation";
+    const std::string KEY_DEFAULT_SQL_TEXT = "defaultsqltext";
+    const std::string KEY_DONT_ASK_COLLATION = "dont_ask_collation";
+    const std::string KEY_FOREIGN_KEYS = "foreignkeys";
+    const std::string KEY_HIDE_SCHEMA_LINEBREAKS = "hideschemalinebreaks";
+    const std::string KEY_LAST_LOCATION = "lastlocation";
+    const std::string KEY_PREFETCH_SIZE = "prefetchsize";
+    const std::string KEY_SAVE_DEFAULT_LOCATION = "savedefaultlocation";
+
+    // Group - idontcare (pre v3.12 project setting preference)
+    const std::string SEC_DONT_CARE = "idontcare";
+    const std::string KEY_PROJECT_BROWSE_TABLE = "projectBrowseTable";
+
+    // Group - editor
+    // includes KEY_FONT, KEY_FONTSIZE
+    const std::string SEC_EDITOR = "editor";
+    const std::string KEY_AUTO_COMPLETION = "auto_completion";
+    const std::string KEY_CLOSE_BUTTON_ON_TABS = "close_button_on_tabs";
+    const std::string KEY_ERROR_INDICATORS = "error_indicators";
+    const std::string KEY_HORZ_TILING = "horizontal_tiling";
+    const std::string KEY_IDENTIFIER_QUOTES = "identifier_quotes";
+    const std::string KEY_INDENTATION_USE_TABS = "indentation_use_tabs";
+    const std::string KEY_SPLITTER1_SIZES = "splitter1_sizes";
+    const std::string KEY_SPLITTER2_SIZES = "splitter2_sizes";
+    const std::string KEY_TABSIZE = "tabsize";
+    const std::string KEY_UPPER_KEYWORDS = "upper_keywords";
+    const std::string KEY_WRAP_LINES = "wrap_lines";
+
+    // Group - exportcsv
+    // includes KEY_FIRST_ROW_HEADER, KEY_QUOTE_CHARACTER, KEY_SEPARATOR
+    const std::string SEC_EXPORT_CSV = "exportcsv";
+    const std::string KEY_NEWLINE_CHARACTERS = "newlinecharacters";
+
+    // Group - exportjson
+    const std::string SEC_EXPORT_JSON = "exportjson";
+    const std::string KEY_PRETTY_PRINT = "prettyprint";
+
+    // Group - exportsql
+    const std::string SEC_EXPORT_SQL = "exportsql";
+    const std::string KEY_INSERT_COL_NAMES = "insertcolnames";
+    const std::string KEY_INSERT_MULTIPLE = "insertmultiple";
+    const std::string KEY_KEEP_ORIGINAL = "keeporiginal";
+    const std::string KEY_OLD_SCHEMA = "oldschema";
+
+    // Group - Extensions
+    const std::string SEC_EXTENSIONS = "extensions";
+    const std::string KEY_DISABLE_REGEX = "disableregex";
+    const std::string KEY_ENABLE_LOAD_EXTENSION = "enable_load_extension";
+    const std::string KEY_LIST = "list";
+
+    // Group - General
+    // includes KEY_FONTSIZE
+    const std::string SEC_GENERAL = "General";
+    const std::string KEY_APPSTYLE = "appStyle";
+    const std::string KEY_DB_FILE_EXTS = "DBFileExtensions";
+    const std::string KEY_LANGUAGE = "language";
+    const std::string KEY_MAX_RECENT_FILES = "maxRecentFiles";
+    const std::string KEY_PROMPT_SQL_TABS_IN_NEWPRJ = "promptsqltabsinnewproject";
+    const std::string KEY_RECENT_FILE_LIST = "recentFileList";
+    const std::string KEY_TB_STYLE_APP = "toolbarStyle";
+    const std::string KEY_TB_STYLE_BROWSE = "toolbarStyleBrowse";
+    const std::string KEY_TB_STYLE_EDIT_CELL = "toolbarStyleEditCell";
+    const std::string KEY_TB_STYLE_SQL = "toolbarStyleSql";
+    const std::string KEY_TB_STYLE_STRUCTURE = "toolbarStyleStructure";
+
+    // Group - importcsv
+    // includes KEY_FIRST_ROW_HEADER, KEY_QUOTE_CHARACTER, KEY_SEPARATOR
+    const std::string SEC_IMPORT_CSV = "importcsv";
+    const std::string KEY_ENCODING = "encoding";
+    const std::string KEY_LOCAL_CONVENTIONS = "localconventions";
+    const std::string KEY_SEPARATE_TABLES = "separatetables";
+    const std::string KEY_TRIM_FIELDS = "trimfields";
+
+    // Group - log
+    // includes KEY_FONT, KEY_FONT_SIZE
+    const std::string SEC_LOG = "log";
+
+    // Group - MainWindow
+    const std::string SEC_MAIN_WNDW = "MainWindow";
+    const std::string KEY_GEOMETRY = "geometry";
+    const std::string KEY_OPEN_TABS = "openTabs";
+    const std::string KEY_WINDOW_STATE = "windowState";
+
+    // Group - PlotDock
+    const std::string SEC_PLOT_DOCK = "PlotDock";
+    const std::string KEY_LINE_TYPE = "lineType";
+    const std::string KEY_POINT_SHAPE = "pointShape";
+    const std::string KEY_SPLITTER_SIZE = "splitterSize";
+
+    // Group - proxy
+    const std::string SEC_PROXY = "proxy";
+    const std::string KEY_AUTHENTICATION = "authentication";
+    const std::string KEY_HOST = "host";
+    const std::string KEY_PASSWORD = "password";
+    const std::string KEY_PORT = "port";
+    const std::string KEY_TYPE = "type";
+    const std::string KEY_USER = "user";
+
+    // Group - remote
+    const std::string SEC_REMOTE = "remote";
+    const std::string KEY_ACTIVE = "active";
+    const std::string KEY_CLIENT_CERT = "client_certificates";
+    const std::string KEY_CLONE_DIR = "clonedirectory";
+
+    // Group - SchemaDock
+    const std::string SEC_SCHEMA_DOCK = "SchemaDock";
+    const std::string KEY_DROP_ENQUOTED_NAMES = "dropEnquotedNames";
+    const std::string KEY_DROP_QUALIFIED_NAMES = "dropQualifiedNames";
+    const std::string KEY_DROP_SELECT_QUERY = "dropSelectQuery";
+
+    // Group - SQLLogDock
+    const std::string SEC_SQL_LOG_DOCK = "SQLLogDock";
+    const std::string KEY_LOG = "Log";
+
+    // Group - syntaxhighlighter
+    const std::string SEC_SYNTAX_HIGHLIGHTER = "syntaxhighlighter";
+    // postfixes for bulk setting of attributes
+    const std::string KEY_ANY_BOLD = "_bold";
+    const std::string KEY_ANY_COLOUR = "_colour";
+    const std::string KEY_ANY_ITALIC = "_italic";
+    const std::string KEY_ANY_UNDERLINE = "_underline";
+    // prefixes for bulk setting of attributes
+    const std::string KEY_SHP_NULL_BG = "null_bg";
+    const std::string KEY_SHP_NULL_FG = "null_fg";
+    const std::string KEY_SHP_REG_BG = "reg_bg";
+    const std::string KEY_SHP_REG_FG = "reg_fg";
+    const std::string KEY_SHP_FMT_BG = "formatted_bg";
+    const std::string KEY_SHP_FMT_FG = "formatted_fg";
+    const std::string KEY_SHP_BIN_BG = "bin_bg";
+    const std::string KEY_SHP_BIN_FG = "bin_fg";
+    // specific syntax highlighter attributes
+    const std::string KEY_BG_BOLD = "background_bold";
+    const std::string KEY_BG_COLOUR = "background_colour";
+    const std::string KEY_BG_ITALIC = "background_italic";
+    const std::string KEY_BG_UNDERLINE = "background_underline";
+    const std::string KEY_COMMENT_BOLD = "comment_bold";
+    const std::string KEY_COMMENT_COLOUR = "comment_colour";
+    const std::string KEY_COMMENT_ITALIC = "comment_italic";
+    const std::string KEY_COMMENT_UNDERLINE = "comment_underline";
+    const std::string KEY_CUR_LINE_BOLD = "currentline_bold";
+    const std::string KEY_CUR_LINE_COLOUR = "currentline_colour";
+    const std::string KEY_CUR_LINE_ITALIC = "currentline_italic";
+    const std::string KEY_CUR_LINE_UNDERLINE = "currentline_underline";
+    const std::string KEY_FG_BOLD = "foreground_bold";
+    const std::string KEY_FG_COLOUR = "foreground_colour";
+    const std::string KEY_FG_ITALIC = "foreground_italic";
+    const std::string KEY_FG_UNDERLINE = "foreground_underline";
+    const std::string KEY_FUNC_BOLD = "function_bold";
+    const std::string KEY_FUNC_COLOUR = "function_colour";
+    const std::string KEY_FUNC_ITALIC = "function_italic";
+    const std::string KEY_FUNC_UNDERLINE = "function_underline";
+    const std::string KEY_HIGHLIGHT_BOLD = "highlight_bold";
+    const std::string KEY_HIGHLIGHT_COLOUR = "highlight_colour";
+    const std::string KEY_HIGHLIGHT_ITALIC = "highlight_italic";
+    const std::string KEY_HIGHLIGHT_UNDERLINE = "highlight_underline";
+    const std::string KEY_IDENTIFIER_BOLD = "identifier_bold";
+    const std::string KEY_IDENTIFIER_COLOUR = "identifier_colour";
+    const std::string KEY_IDENTIFIER_ITALIC = "identifier_italic";
+    const std::string KEY_IDENTIFIER_UNDERLINE = "identifier_underline";
+    const std::string KEY_KEYWORD_BOLD = "keyword_bold";
+    const std::string KEY_KEYWORD_COLOUR = "keyword_colour";
+    const std::string KEY_KEYWORD_ITALIC = "keyword_italic";
+    const std::string KEY_KEYWORD_UNDERLINE = "keyword_underline";
+    const std::string KEY_SELECTED_BG_BOLD = "selected_bg_bold";
+    const std::string KEY_SELECTED_BG_COLOUR = "selected_bg_colour";
+    const std::string KEY_SELECTED_BG_ITALIC = "selected_bg_italic";
+    const std::string KEY_SELECTED_BG_UNDERLINE = "selected_bg_underline";
+    const std::string KEY_SELECTED_FG_BOLD = "selected_fg_bold";
+    const std::string KEY_SELECTED_FG_COLOUR = "selected_fg_colour";
+    const std::string KEY_SELECTED_FG_ITALIC = "selected_fg_italic";
+    const std::string KEY_SELECTED_FG_UNDERLINE = "selected_fg_underline";
+    const std::string KEY_STRING_BOLD = "string_bold";
+    const std::string KEY_STRING_COLOUR = "string_colour";
+    const std::string KEY_STRING_ITALIC = "string_italic";
+    const std::string KEY_STRING_UNDERLINE = "string_underline";
+    const std::string KEY_TABLE_BOLD = "table_bold";
+    const std::string KEY_TABLE_COLOUR = "table_colour";
+    const std::string KEY_TABLE_ITALIC = "table_italic";
+    const std::string KEY_TABLE_UNDERLINE = "table_underline";
+}
 
 class Settings
 {
@@ -16,10 +246,10 @@ public:
         LightStyle
     };
 
-    static void setUserSettingsFile(const QString& userSettingsFileArg);
-    static QVariant getValue(const std::string& group, const std::string& name);
-    static void setValue(const std::string& group, const std::string& name, const QVariant& value, bool save_to_disk = true);
-    static void clearValue(const std::string& group, const std::string& name);
+    static void setUserSettingsFile(const QString& settings_file_path);
+    static QVariant getValue(const std::string& section, const std::string& key);
+    static void setValue(const std::string& section, const std::string& key, const QVariant& value, bool save_to_disk = true);
+    static void clearValue(const std::string& section, const std::string& key);
     static void restoreDefaults();
 
     static void rememberDefaultFontSize(int size) { m_defaultFontSize = size; }
@@ -31,11 +261,11 @@ private:
     Settings() = delete;    // class is fully static
 
     // This works similar to getValue but returns the default value instead of the value set by the user
-    static QVariant getDefaultValue(const std::string& group, const std::string& name);
+    static QVariant getDefaultValue(const std::string& section, const std::string& key);
 
     // This works similar to getDefaultValue but returns the default color value based on the passed application style
     // instead of the current palette.
-    static QColor getDefaultColorValue(const std::string& group, const std::string& name, AppStyle style);
+    static QColor getDefaultColorValue(const std::string& section, const std::string& key, AppStyle style);
 
     // User settings file path
     static QString userSettingsFile;
@@ -44,7 +274,7 @@ private:
     static QSettings* settings;
 
     // This works verify that the settings file provided by the user is a normal settings file
-    static bool isVaildSettingsFile(const QString& userSettingsFile);
+    static bool isValidSettingsFile(const QString& settings_file_path);
 
     // This works initialize QSettings object
     static void setSettingsObject();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -38,6 +38,9 @@ struct pair_compare
 namespace szINI
 {
     // Settings identification strings constants
+
+    // Environment Variable Name
+    const std::string ENV_SET_FILE = "DB4S_SETTINGS_FILE";
     // SEC_ -> INI Section
     // KEY_ -> INI Key name in Section
     // strings used in multiple places
@@ -275,9 +278,7 @@ public:
     };
 
     // Initialize QSettings object
-    static void setSettingsObject();
-
-    static void setUserSettingsFile(const QString& settings_file_path);
+    static void Initialize(const QString& settings_file_path = QString());
     static QVariant getValue(const std::string& section, const std::string& key);
     static void setValue(
             const std::string& section,

--- a/src/SqlExecutionArea.cpp
+++ b/src/SqlExecutionArea.cpp
@@ -145,7 +145,6 @@ void SqlExecutionArea::reloadSettings()
 
     // Set font
     QFont logfont(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString());
-    logfont.setStyleHint(QFont::TypeWriter);
     logfont.setPointSize(Settings::getValue(szINI::SEC_LOG, szINI::KEY_FONTSIZE).toInt());
     ui->editErrors->setFont(logfont);
 

--- a/src/SqlExecutionArea.cpp
+++ b/src/SqlExecutionArea.cpp
@@ -44,10 +44,10 @@ SqlExecutionArea::SqlExecutionArea(DBBrowserDB& _db, QWidget* parent) :
 
     // Save to settings when sppliter is moved, but only to memory.
     connect(ui->splitter, &QSplitter::splitterMoved, this,  [this]() {
-            Settings::setValue("editor", "splitter1_sizes", ui->splitter->saveState(), /* save_to_disk */ false);
+            Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_SPLITTER1_SIZES, ui->splitter->saveState(), /* save_to_disk */ false);
         });
     connect(ui->splitter_2, &QSplitter::splitterMoved, this, [this]() {
-            Settings::setValue("editor", "splitter2_sizes", ui->splitter_2->saveState(), /* save_to_disk */ false);
+            Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_SPLITTER2_SIZES, ui->splitter_2->saveState(), /* save_to_disk */ false);
         });
 
     // Set collapsible the editErrors panel
@@ -144,25 +144,25 @@ void SqlExecutionArea::reloadSettings()
     ui->tableResult->reloadSettings();
 
     // Set font
-    QFont logfont(Settings::getValue("editor", "font").toString());
+    QFont logfont(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString());
     logfont.setStyleHint(QFont::TypeWriter);
-    logfont.setPointSize(Settings::getValue("log", "fontsize").toInt());
+    logfont.setPointSize(Settings::getValue(szINI::SEC_LOG, szINI::KEY_FONTSIZE).toInt());
     ui->editErrors->setFont(logfont);
 
     // Apply horizontal/vertical tiling option
-    if(Settings::getValue("editor", "horizontal_tiling").toBool())
+    if(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_HORZ_TILING).toBool())
         ui->splitter->setOrientation(Qt::Horizontal);
     else
         ui->splitter->setOrientation(Qt::Vertical);
 
-    ui->splitter->restoreState(Settings::getValue("editor", "splitter1_sizes").toByteArray());
-    ui->splitter_2->restoreState(Settings::getValue("editor", "splitter2_sizes").toByteArray());
+    ui->splitter->restoreState(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_SPLITTER1_SIZES).toByteArray());
+    ui->splitter_2->restoreState(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_SPLITTER2_SIZES).toByteArray());
 
     // Reload model settings
     model->reloadSettings();
 
     // Check if error indicators are enabled for the not-ok background clue
-    showErrorIndicators = Settings::getValue("editor", "error_indicators").toBool();
+    showErrorIndicators = Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_ERROR_INDICATORS).toBool();
     if (!showErrorIndicators)
         ui->editErrors->setStyleSheet("");
 
@@ -354,6 +354,6 @@ void SqlExecutionArea::fileChanged(const QString& filename)
 void SqlExecutionArea::saveState() {
 
     // Save to disk last stored splitter sizes
-    Settings::setValue("editor", "splitter1_sizes", Settings::getValue("editor", "splitter1_sizes"));
-    Settings::setValue("editor", "splitter2_sizes", Settings::getValue("editor", "splitter2_sizes"));
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_SPLITTER1_SIZES, Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_SPLITTER1_SIZES));
+    Settings::setValue(szINI::SEC_EDITOR, szINI::KEY_SPLITTER2_SIZES, Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_SPLITTER2_SIZES));
 }

--- a/src/SqlExecutionArea.ui
+++ b/src/SqlExecutionArea.ui
@@ -219,12 +219,6 @@
          <verstretch>120</verstretch>
         </sizepolicy>
        </property>
-       <property name="font">
-        <font>
-         <family>Monospace</family>
-         <pointsize>8</pointsize>
-        </font>
-       </property>
        <property name="acceptDrops">
         <bool>false</bool>
        </property>

--- a/src/SqlUiLexer.cpp
+++ b/src/SqlUiLexer.cpp
@@ -64,7 +64,7 @@ SqlUiLexer::SqlUiLexer(QObject* parent) :
 
 void SqlUiLexer::setupAutoCompletion()
 {
-    bool upperKeywords = Settings::getValue("editor", "upper_keywords").toBool();
+    bool upperKeywords = Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_UPPER_KEYWORDS).toBool();
     for(const QString& keyword : qAsConst(keywordPatterns))
     {
         if (upperKeywords)

--- a/src/TableBrowser.cpp
+++ b/src/TableBrowser.cpp
@@ -518,7 +518,7 @@ void TableBrowser::refresh()
                 int columns = static_cast<int>(ui->dataTable->colsInSelection().size());
                 statusMessage += tr(", %n column(s)", "", columns);
 
-                if (sel.count() < Settings::getValue("databrowser", "complete_threshold").toInt()) {
+                if (sel.count() < Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_COMPLETE_THRESHOLD).toInt()) {
                     double sum = 0;
                     double first = m_model->data(sel.first(), Qt::EditRole).toDouble();
                     double min = first;
@@ -566,7 +566,7 @@ void TableBrowser::reloadSettings()
 {
     ui->dataTable->reloadSettings();
 
-    ui->browseToolbar->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue("General", "toolbarStyleBrowse").toInt()));
+    ui->browseToolbar->setToolButtonStyle(static_cast<Qt::ToolButtonStyle>(Settings::getValue(szINI::SEC_GENERAL, szINI::KEY_TB_STYLE_BROWSE).toInt()));
     m_model->reloadSettings();
 }
 
@@ -621,12 +621,12 @@ void TableBrowser::updateFilter(size_t column, const QString& value)
 
 void TableBrowser::addCondFormatFromFilter(size_t column, const QString& value)
 {
-    QFont font = QFont(Settings::getValue("databrowser", "font").toString());
-    font.setPointSize(Settings::getValue("databrowser", "fontsize").toInt());
+    QFont font = QFont(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT).toString());
+    font.setPointSize(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE).toInt());
 
     // Create automatically a new conditional format with the next serial background color according to the theme and the regular foreground
     // color and font in the settings.
-    CondFormat newCondFormat(value, QColor(Settings::getValue("databrowser", "reg_fg_colour").toString()),
+    CondFormat newCondFormat(value, QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_FG_COLOUR).toString()),
                              m_condFormatPalette.nextSerialColor(Palette::appHasDarkTheme()),
                              font,
                              CondFormat::AlignLeft,

--- a/src/docktextedit.cpp
+++ b/src/docktextedit.cpp
@@ -36,8 +36,8 @@ void DockTextEdit::reloadSettings()
     reloadLexerSettings(xmlLexer);
 
     // Set the databrowser font for the plain text editor.
-    plainTextFont = QFont(Settings::getValue("databrowser", "font").toString());
-    plainTextFont.setPointSize(Settings::getValue("databrowser", "fontsize").toInt());
+    plainTextFont = QFont(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT).toString());
+    plainTextFont.setPointSize(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE).toInt());
     setFont(plainTextFont);
 
     setupSyntaxHighlightingFormat(jsonLexer, "comment", QsciLexerJSON::CommentLine);
@@ -54,18 +54,18 @@ void DockTextEdit::reloadSettings()
     // precedence, so it is by default white over gray. We change the
     // default to something more readable for the current line at
     // invalid JSON.
-    QColor stringColor = QColor(Settings::getValue("syntaxhighlighter", "string_colour").toString());
+    QColor stringColor = QColor(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_STRING_COLOUR).toString());
     jsonLexer->setColor(stringColor, QsciLexerJSON::Error);
     jsonLexer->setColor(stringColor, QsciLexerJSON::UnclosedString);
-    QFont errorFont(Settings::getValue("editor", "font").toString());
-    errorFont.setPointSize(Settings::getValue("editor", "fontsize").toInt());
+    QFont errorFont(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONT).toString());
+    errorFont.setPointSize(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_FONTSIZE).toInt());
     errorFont.setItalic(true);
     jsonLexer->setFont(errorFont, QsciLexerJSON::Error);
     jsonLexer->setFont(errorFont, QsciLexerJSON::UnclosedString);
     jsonLexer->setPaper(jsonLexer->defaultPaper(QsciLexerJSON::String), QsciLexerJSON::Error);
     jsonLexer->setPaper(jsonLexer->defaultPaper(QsciLexerJSON::String), QsciLexerJSON::UnclosedString);
 
-    xmlLexer->setColor(QColor(Settings::getValue("syntaxhighlighter", "foreground_colour").toString()));
+    xmlLexer->setColor(QColor(Settings::getValue(szINI::SEC_SYNTAX_HIGHLIGHTER, szINI::KEY_FG_COLOUR).toString()));
     setupSyntaxHighlightingFormat(xmlLexer, "comment", QsciLexerHTML::HTMLComment);
     setupSyntaxHighlightingFormat(xmlLexer, "keyword", QsciLexerHTML::Tag);
     setupSyntaxHighlightingFormat(xmlLexer, "keyword", QsciLexerHTML::XMLTagEnd);

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -227,11 +227,11 @@ bool DBBrowserDB::open(const QString& db, bool readOnly)
         sqlite3_collation_needed(_db, nullptr, c_callback);
 
         // Set foreign key settings as requested in the preferences
-        bool foreignkeys = Settings::getValue("db", "foreignkeys").toBool();
+        bool foreignkeys = Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_FOREIGN_KEYS).toBool();
         setPragma("foreign_keys", foreignkeys ? "1" : "0");
 
         // Register REGEXP function
-        if(Settings::getValue("extensions", "disableregex").toBool() == false)
+        if(Settings::getValue(szINI::SEC_EXTENSIONS, szINI::KEY_DISABLE_REGEX).toBool() == false)
             sqlite3_create_function(_db, "REGEXP", 2, SQLITE_UTF8, nullptr, regexp, nullptr, nullptr);
 
         // Register our internal helper function for putting multiple values into a single column
@@ -263,7 +263,7 @@ bool DBBrowserDB::open(const QString& db, bool readOnly)
         // Execute default SQL
         if(!isReadOnly)
         {
-            QByteArray default_sql = Settings::getValue("db", "defaultsqltext").toByteArray();
+            QByteArray default_sql = Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_SQL_TEXT).toByteArray();
             if(!default_sql.isEmpty())
                 executeMultiSQL(default_sql, false, true);
         }
@@ -657,7 +657,7 @@ bool DBBrowserDB::create ( const QString & db)
         close();
 
     // read encoding from settings and open with sqlite3_open for utf8 and sqlite3_open16 for utf16
-    QString sEncoding = Settings::getValue("db", "defaultencoding").toString();
+    QString sEncoding = Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_DEFAULT_ENCODING).toString();
 
     int openresult = SQLITE_OK;
 
@@ -2143,7 +2143,7 @@ bool DBBrowserDB::loadExtension(const QString& filePath)
 
     // Disable extension loading if so configured
     // (we don't want to leave the possibility of calling load_extension() from SQL without user informed permission)
-    if (!Settings::getValue("extensions", "enable_load_extension").toBool())
+    if (!Settings::getValue(szINI::SEC_EXTENSIONS, szINI::KEY_ENABLE_LOAD_EXTENSION).toBool())
         sqlite3_enable_load_extension(_db, 0);
 
     if (result == SQLITE_OK)
@@ -2162,9 +2162,9 @@ void DBBrowserDB::loadExtensionsFromSettings()
     if(!_db)
         return;
 
-    sqlite3_enable_load_extension(_db, Settings::getValue("extensions", "enable_load_extension").toBool());
+    sqlite3_enable_load_extension(_db, Settings::getValue(szINI::SEC_EXTENSIONS, szINI::KEY_ENABLE_LOAD_EXTENSION).toBool());
 
-    const QStringList list = Settings::getValue("extensions", "list").toStringList();
+    const QStringList list = Settings::getValue(szINI::SEC_EXTENSIONS, szINI::KEY_LIST).toStringList();
     for(const QString& ext : list)
     {
         if(loadExtension(ext) == false)

--- a/src/sqlitetablemodel.cpp
+++ b/src/sqlitetablemodel.cpp
@@ -1140,20 +1140,20 @@ QModelIndex SqliteTableModel::nextMatch(const QModelIndex& start, const std::vec
 
 void SqliteTableModel::reloadSettings()
 {
-    m_nullText = Settings::getValue("databrowser", "null_text").toString();
-    m_blobText = Settings::getValue("databrowser", "blob_text").toString();
-    m_regFgColour = QColor(Settings::getValue("databrowser", "reg_fg_colour").toString());
-    m_regBgColour = QColor(Settings::getValue("databrowser", "reg_bg_colour").toString());
-    m_formattedFgColour = QColor(Settings::getValue("databrowser", "formatted_fg_colour").toString());
-    m_formattedBgColour = QColor(Settings::getValue("databrowser", "formatted_bg_colour").toString());
-    m_nullFgColour = QColor(Settings::getValue("databrowser", "null_fg_colour").toString());
-    m_nullBgColour = QColor(Settings::getValue("databrowser", "null_bg_colour").toString());
-    m_binFgColour = QColor(Settings::getValue("databrowser", "bin_fg_colour").toString());
-    m_binBgColour = QColor(Settings::getValue("databrowser", "bin_bg_colour").toString());
-    m_font = QFont(Settings::getValue("databrowser", "font").toString());
-    m_font.setPointSize(Settings::getValue("databrowser", "fontsize").toInt());
-    m_symbolLimit = Settings::getValue("databrowser", "symbol_limit").toInt();
-    m_rowsLimit = Settings::getValue("databrowser", "rows_limit").toInt();
-    m_imagePreviewEnabled = Settings::getValue("databrowser", "image_preview").toBool();
-    m_chunkSize = static_cast<std::size_t>(Settings::getValue("db", "prefetchsize").toUInt());
+    m_nullText = Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_TEXT).toString();
+    m_blobText = Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BLOB_TEXT).toString();
+    m_regFgColour = QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_FG_COLOUR).toString());
+    m_regBgColour = QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_REG_BG_COLOUR).toString());
+    m_formattedFgColour = QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_FG_COLOUR).toString());
+    m_formattedBgColour = QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FMT_BG_COLOUR).toString());
+    m_nullFgColour = QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_FG_COLOUR).toString());
+    m_nullBgColour = QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_NULL_BG_COLOUR).toString());
+    m_binFgColour = QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_FG_COLOUR).toString());
+    m_binBgColour = QColor(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_BIN_BG_COLOUR).toString());
+    m_font = QFont(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONT).toString());
+    m_font.setPointSize(Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_FONTSIZE).toInt());
+    m_symbolLimit = Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_SYMBOL_LIMIT).toInt();
+    m_rowsLimit = Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_ROWS_LIMIT).toInt();
+    m_imagePreviewEnabled = Settings::getValue(szINI::SEC_DATA_BROWSER, szINI::KEY_IMAGE_PREVIEW).toBool();
+    m_chunkSize = static_cast<std::size_t>(Settings::getValue(szINI::SEC_DATABASE, szINI::KEY_PREFETCH_SIZE).toUInt());
 }

--- a/src/sqltextedit.cpp
+++ b/src/sqltextedit.cpp
@@ -55,7 +55,7 @@ SqlTextEdit::SqlTextEdit(QWidget* parent) :
 void SqlTextEdit::reloadSettings()
 {
     // Enable auto completion if it hasn't been disabled
-    if(Settings::getValue("editor", "auto_completion").toBool())
+    if(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_AUTO_COMPLETION).toBool())
     {
         setAutoCompletionThreshold(3);
         setAutoCompletionCaseSensitivity(true);
@@ -65,7 +65,7 @@ void SqlTextEdit::reloadSettings()
         setAutoCompletionThreshold(0);
     }
     // Set wrap lines
-    setWrapMode(static_cast<QsciScintilla::WrapMode>(Settings::getValue("editor", "wrap_lines").toInt()));
+    setWrapMode(static_cast<QsciScintilla::WrapMode>(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_WRAP_LINES).toInt()));
 
     ExtendedScintilla::reloadSettings();
 
@@ -78,7 +78,7 @@ void SqlTextEdit::reloadSettings()
     setupSyntaxHighlightingFormat(sqlLexer, "string", QsciLexerSQL::SingleQuotedString);
 
     // Highlight double quote strings as identifier or as literal string depending on user preference
-    switch(static_cast<sqlb::escapeQuoting>(Settings::getValue("editor", "identifier_quotes").toInt())) {
+    switch(static_cast<sqlb::escapeQuoting>(Settings::getValue(szINI::SEC_EDITOR, szINI::KEY_IDENTIFIER_QUOTES).toInt())) {
     case sqlb::DoubleQuotes:
         setupSyntaxHighlightingFormat(sqlLexer, "identifier", QsciLexerSQL::DoubleQuotedString);
         sqlLexer->setQuotedIdentifiers(false);


### PR DESCRIPTION
Effort managed under discussion #3317.

Changes effect a mechanism for fallback values for application settings. 
Code implemented to correct bug #3312. Also corrected is bug #3348 with mechanism to identify available fixed width fonts.

Note: warning still issued for "Monospace" on MacOS due to QHexEdit code explicitly using "Monospace" font on non-Windows platforms.