### PR TITLE
Disable the fileio extension in our Windows nightly builds

### DIFF
--- a/installer/windows/product.wxs
+++ b/installer/windows/product.wxs
@@ -63,7 +63,6 @@
                     <Directory Id="extensions" Name="extensions">
                         <Component><File Source="$(var.SQLitePath)\math.dll" /></Component>
                         <Component><File Source="$(var.SQLitePath)\formats.dll" /></Component>
-                        <Component><File Source="$(var.SQLitePath)\fileio.dll" /></Component>
                     </Directory>
                     <Directory Id="imageformats" Name="imageformats">
                         <Component><File Source="$(var.QtPath)\plugins\imageformats\qgif.dll" /></Component>
@@ -148,9 +147,6 @@
                 </Feature>
                 <Feature Id="FormatsExtension" Title="Formats" Description="Provide additional field display formats." AllowAdvertise="no">
                     <ComponentRef Id="formats.dll" />
-                </Feature>
-                <Feature Id="FileioExtension" Title="Fileio" Description="Implements SQL functions readfile(), writefile(), and eponymous virtual type 'fsdir'." AllowAdvertise="no">
-                    <ComponentRef Id="fileio.dll" />
                 </Feature>
             </Feature>
 


### PR DESCRIPTION
We download the very latest (development) source code for extensions every time they're built.

Occasionally, this causes things to things break when the extension source code is incompatible with the release build of SQLite that we're using.

That's what's currently happening with the fileio extension, so for now lets disable it.