### PR TITLE
German translation by stheel83

### DIFF
--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2892,7 +2892,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
         <location filename="../MainWindow.ui" line="1232"/>
         <location filename="../MainWindow.cpp" line="476"/>
         <source>Ctrl+F4</source>
-        <translation>Strg+F4</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1271"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3907,7 +3907,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1569"/>
         <source>Ctrl+Return</source>
-        <translation>Strg+Enter</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3703,7 +3703,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1536"/>
         <source>&amp;Recently opened</source>
-        <translation>&amp;Zuletzt geöffnet</translation>
+        <translation>&amp;Kürzlich geöffnet</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1551"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3613,7 +3613,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1338"/>
         <source>Ctrl+Q</source>
-        <translation>Strg+Q</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1349"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2933,7 +2933,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1584"/>
         <source>Ctrl+Shift+T</source>
-        <translation>Strg+Umschalt+T</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1605"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3885,7 +3885,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.cpp" line="276"/>
         <source>Ctrl+L</source>
-        <translation>Strg+L</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2132"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -1694,7 +1694,7 @@ Sollen die bearbeiteten Daten auf Zeile=%1, Spalte=%2 angewendet werden?</transl
     <message>
         <location filename="../EditTableDialog.ui" line="595"/>
         <source>Check Constraints</source>
-        <translation>Check-Beschränkungen</translation>
+        <translation>CHECK-Beschränkungen</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="685"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3592,7 +3592,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1307"/>
         <source>Ctrl+S</source>
-        <translation>Strg+S</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1321"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2160,7 +2160,7 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="327"/>
         <source>Ctrl+Shift+C</source>
-        <translation>Strg+Umschalt+C</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="328"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3044,7 +3044,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1897"/>
         <source>This button lets you save the results of the last executed query</source>
-        <translation>Dieser Button erlaubt Ihnen das Speichern der Ergebnisse der zuletzt ausgeführten Abfragen</translation>
+        <translation>Dieser Button erlaubt Ihnen das Speichern der Ergebnisse der zuletzt ausgeführten Abfrage</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1909"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3065,7 +3065,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1921"/>
         <source>Ctrl+F</source>
-        <translation>Strg+F</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1936"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -6731,7 +6731,7 @@ Die Verwendung dieser Funktion muss in den Einstellungen authorisiert werden.</t
     <message>
         <location filename="../SqlUiLexer.cpp" line="112"/>
         <source>() The total_changes() function returns the number of row changes caused by INSERT, UPDATE or DELETE statements since the current database connection was opened.</source>
-        <translation>() Die changes()-Funktion gibt die Anzahl der geänderten Datenbankzeilen zurück, die seit dem Öffnen der aktuellen Datenbankverbindung mit INSERT-, DELETE- oder UPDATE-Anweisung geändert, einfügt oder gelöscht worden sind.</translation>
+        <translation>() Die changes()-Funktion gibt die Anzahl der geänderten Datenbankzeilen zurück, die seit dem Öffnen der aktuellen Datenbankverbindung mit INSERT-, DELETE- oder UPDATE-Anweisung geändert, eingefügt oder gelöscht worden sind.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="113"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -6554,7 +6554,7 @@ Soll wirklich fortgefahren werden?</translation>
     <message>
         <location filename="../sqltextedit.cpp" line="48"/>
         <source>Ctrl+PgDown</source>
-        <translation>Strg+BildAb</translation>
+        <translation></translation>
     </message>
 </context>
 <context>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2165,7 +2165,7 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="328"/>
         <source>Ctrl+Alt+C</source>
-        <translation>Strg+Alt+C</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="799"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3133,7 +3133,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
         <location filename="../MainWindow.ui" line="2263"/>
         <location filename="../MainWindow.cpp" line="477"/>
         <source>Ctrl+Shift+W</source>
-        <translation>Strg+Umschalt+W</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2292"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2026,7 +2026,7 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
         <location filename="../ExtendedScintilla.cpp" line="63"/>
         <location filename="../ExtendedScintilla.cpp" line="295"/>
         <source>Ctrl+H</source>
-        <translation>Strg+H</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../ExtendedScintilla.cpp" line="65"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3029,7 +3029,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1879"/>
         <source>Ctrl+Shift+O</source>
-        <translation>Strg+Umschalt+0</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1891"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -4066,7 +4066,7 @@ Bei der Antwort NEIN werden die Daten in die SQL-Datei der aktuellen Datenbank i
     <message>
         <location filename="../MainWindow.cpp" line="341"/>
         <source>Shift+Alt+0</source>
-        <translation>Umschalt+Alt+0</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="350"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -4046,7 +4046,7 @@ Bei der Antwort NEIN werden die Daten in die SQL-Datei der aktuellen Datenbank i
     <message>
         <location filename="../MainWindow.cpp" line="218"/>
         <source>Ctrl+PgUp</source>
-        <translation>Strg+BildAuf</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="235"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -6549,7 +6549,7 @@ Soll wirklich fortgefahren werden?</translation>
     <message>
         <location filename="../sqltextedit.cpp" line="45"/>
         <source>Ctrl+/</source>
-        <translation>Strg+/</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../sqltextedit.cpp" line="48"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -6607,7 +6607,7 @@ Soll wirklich fortgefahren werden?</translation>
     <message>
         <location filename="../SqlUiLexer.cpp" line="88"/>
         <source>() The last_insert_rowid() function returns the ROWID of the last row insert from the database connection which invoked the function.</source>
-        <translation>() Die last_insert_rowid()-Funktion gibt die ROWID der letzte Zeile zurück, die von der diese Funktion aufrufenden Datenbankverbindung eingefügt wurde.</translation>
+        <translation>() Die last_insert_rowid()-Funktion gibt die ROWID der letzte Zeile zurück, die von der Datenbankverbindung eingefügt wurde und die dann die Funktion aufrief.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="89"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -6420,7 +6420,7 @@ Soll wirklich fortgefahren werden?</translation>
     <message>
         <location filename="../SqlExecutionArea.ui" line="91"/>
         <source>Shift+F3</source>
-        <translation>Umschalt+F3</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.ui" line="105"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -1987,7 +1987,7 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
     <message>
         <location filename="../ExportSqlDialog.ui" line="148"/>
         <source>Keep original CREATE statements</source>
-        <translation>Originale CREATE-Statements behalten</translation>
+        <translation>Originale CREATE-Anweisungen behalten</translation>
     </message>
     <message>
         <location filename="../ExportSqlDialog.ui" line="109"/>
@@ -3481,12 +3481,12 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1832"/>
         <source>Copy Create statement</source>
-        <translation>Create-Statement kopieren</translation>
+        <translation>Create-Anweisung kopieren</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1835"/>
         <source>Copy the CREATE statement of the item to the clipboard</source>
-        <translation>CREATE-Statement des Elements in die Zwischenablage kopieren</translation>
+        <translation>CREATE-Anweisung des Elements in die Zwischenablage kopieren</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="946"/>
@@ -4086,7 +4086,7 @@ Bei der Antwort NEIN werden die Daten in die SQL-Datei der aktuellen Datenbank i
     <message>
         <location filename="../MainWindow.cpp" line="718"/>
         <source>You are still executing SQL statements. Closing the database now will stop their execution, possibly leaving the database in an inconsistent state. Are you sure you want to close the database?</source>
-        <translation>Es werden aktuell SQL-Statements ausgeführt. Das Schließen der Datenbank wird deren Ausführung stoppen, was die Datenbank möglicherweise in einem inkonsistenten Zustand belässt. Soll die Datenbank wirklich geschlossen werden?</translation>
+        <translation>Es werden aktuell SQL-Anweisungen ausgeführt. Das Schließen der Datenbank wird deren Ausführung stoppen, was die Datenbank möglicherweise in einem inkonsistenten Zustand belässt. Soll die Datenbank wirklich geschlossen werden?</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="813"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3549,7 +3549,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1205"/>
         <source>Ctrl+O</source>
-        <translation>Strg+0</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1220"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3891,7 +3891,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
         <location filename="../MainWindow.ui" line="2132"/>
         <location filename="../MainWindow.ui" line="2159"/>
         <source>Ctrl+P</source>
-        <translation>Strg+P</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="400"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -7577,7 +7577,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="814"/>
         <source>Ctrl+P</source>
-        <translation>Strg+P</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="844"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3522,7 +3522,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1181"/>
         <source>Ctrl+N</source>
-        <translation>Strg+N</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1193"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3698,7 +3698,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1520"/>
         <source>Shift+F1</source>
-        <translation>Umschalt+F1</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1536"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -7622,7 +7622,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="889"/>
         <source>Ctrl+B</source>
-        <translation>Strg+B</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="901"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -4041,7 +4041,7 @@ Bei der Antwort NEIN werden die Daten in die SQL-Datei der aktuellen Datenbank i
     <message>
         <location filename="../MainWindow.cpp" line="207"/>
         <source>Ctrl+Shift+Tab</source>
-        <translation>Strg+Umschalt+Tab</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="218"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2828,7 +2828,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="2183"/>
         <source>Ctrl+/</source>
-        <translation>Strg+/</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2195"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -7127,7 +7127,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="277"/>
         <source>Shift+F3</source>
-        <translation>Umschalt+F3</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="284"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2881,7 +2881,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="781"/>
         <source>&amp;Recent Files</source>
-        <translation>&amp;Zuletzt geöffnete Dateien</translation>
+        <translation>&amp;Kürzliche Dateien</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1169"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -1165,7 +1165,7 @@ Fehler werden mittels eine roten Wellenlinie angezeigt.</translation>
     <message>
         <location filename="../EditDialog.ui" line="295"/>
         <source>Ctrl+Shift+C</source>
-        <translation>Strg+Umschalt+C</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="352"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -6676,7 +6676,7 @@ Die Verwendung dieser Funktion muss in den Einstellungen authorisiert werden.</t
     <message>
         <location filename="../SqlUiLexer.cpp" line="101"/>
         <source>(X) The quote(X) function returns the text of an SQL literal which is the value of its argument suitable for inclusion into an SQL statement.</source>
-        <translation>(X) Die quote(X)-Funktion gibt den Text eines SQL-Literals zurück, wobei der Wert des Arguments zum Einfügen in eine SQL-Anweisungen geeignet ist.</translation>
+        <translation>(X) Die quote(X)-Funktion gibt den Text eines SQL-Literals zurück, wobei der Wert des Arguments zum Einfügen in eine SQL-Anweisung geeignet ist.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="102"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -1656,7 +1656,7 @@ Sollen die bearbeiteten Daten auf Zeile=%1, Spalte=%2 angewendet werden?</transl
     </message>
     <message>
         <source>Constraints</source>
-        <translation type="vanished">Beschränkungen</translation>
+        <translation type="vanished">Constraints</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="415"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3455,7 +3455,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1629"/>
         <source>Shift+F5</source>
-        <translation>Umschalt+F5</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1712"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -1714,7 +1714,7 @@ Sollen die bearbeiteten Daten auf Zeile=%1, Spalte=%2 angewendet werden?</transl
     </message>
     <message>
         <source>Add a foreign key constraint</source>
-        <translation type="vanished">Eine Beschränkung für den Fremdschlüssel hinzufügen</translation>
+        <translation type="vanished">Ein Constraint für den Fremdschlüssel hinzufügen</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="720"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3565,7 +3565,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
         <location filename="../MainWindow.cpp" line="190"/>
         <location filename="../MainWindow.cpp" line="3774"/>
         <source>Ctrl+W</source>
-        <translation>Strg+W</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1250"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -1145,7 +1145,7 @@ Fehler werden mittels eine roten Wellenlinie angezeigt.</translation>
     <message>
         <location filename="../EditDialog.ui" line="277"/>
         <source>Ctrl+P</source>
-        <translation>Strg+P</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="271"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -69,7 +69,7 @@ Attribution Share Alike 4.0 license.&lt;br/&gt;See &lt;/span&gt;&lt;a href=&quot
     <message>
         <location filename="../AddRecordDialog.ui" line="110"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Save&lt;/span&gt; will submit the shown SQL statement to the database for inserting the new record.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Restore Defaults&lt;/span&gt; will restore the initial values in the &lt;span style=&quot; font-weight:600;&quot;&gt;Value&lt;/span&gt; column.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Cancel&lt;/span&gt; will close this dialog without executing the query.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Speichern&lt;/span&gt; wird das dargestellte SQL-Statement zum Einfügen des neuen Eintrags an die Datenbank übermitteln.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Voreinstellungen&lt;/span&gt; wird die ursprünglichen Werte der &lt;span style=&quot; font-weight:600;&quot;&gt;Wert&lt;/span&gt;-Spalte wiederherstellen.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Abbrechen&lt;/span&gt; schließt diesen Dialog, ohne die Abfrage auszuführen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Speichern&lt;/span&gt; wird die dargestellte SQL-Anweisung zum Einfügen des neuen Eintrags an die Datenbank übermitteln.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Voreinstellungen&lt;/span&gt; wird die ursprünglichen Werte der &lt;span style=&quot; font-weight:600;&quot;&gt;Wert&lt;/span&gt;-Spalte wiederherstellen.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Abbrechen&lt;/span&gt; schließt diesen Dialog, ohne die Abfrage auszuführen.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../AddRecordDialog.cpp" line="239"/>
@@ -767,7 +767,7 @@ Falls weitere Einstellungen für diese Datenbank-Datei vorgenommen worden sind, 
         <location filename="../sqlitedb.cpp" line="1225"/>
         <source>Error in statement #%1: %2.
 Aborting execution%3.</source>
-        <translation>Fehler im Statement #%1: %2.
+        <translation>Fehler in der Anweisung #%1: %2.
 Ausführung wird abgebrochen %3.</translation>
     </message>
     <message>
@@ -867,7 +867,7 @@ Meldung von Datenbank:
         <source>Restoring some of the objects associated with this table failed. This is most likely because some column names changed. Here&apos;s the SQL statement which you might want to fix and execute manually:
 
 </source>
-        <translation>Wiederherstellung einiger mit dieser Tabelle verbundener Objekte fehlgeschagen. Dies passiert häufig durch geänderte Spaltennamen. SQL-Statement zum manuellen Reparieren und Ausführen:
+        <translation>Wiederherstellung einiger mit dieser Tabelle verbundener Objekte fehlgeschagen. Dies passiert häufig durch geänderte Spaltennamen. SQL-Anweisung zum manuellen Reparieren und Ausführen:
 
 </translation>
     </message>
@@ -1967,7 +1967,7 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
     <message>
         <location filename="../ExportSqlDialog.ui" line="122"/>
         <source>Multiple rows (VALUES) per INSERT statement</source>
-        <translation>Mehrere Reihen (VALUES) je INSERT-Statement</translation>
+        <translation>Mehrere Reihen (VALUES) je INSERT-Anweisung</translation>
     </message>
     <message>
         <location filename="../ExportSqlDialog.ui" line="130"/>
@@ -2756,7 +2756,7 @@ x~y	Bereich: Werte zwischen x und y
     <message>
         <location filename="../ImportCsvDialog.cpp" line="636"/>
         <source>Could not prepare INSERT statement: %1</source>
-        <translation>INSERT-Statement konnte nicht vorbereitet werden: %1</translation>
+        <translation>INSERT-Anweisung konnte nicht vorbereitet werden: %1</translation>
     </message>
     <message>
         <location filename="../ImportCsvDialog.cpp" line="726"/>
@@ -2802,7 +2802,7 @@ x~y	Bereich: Werte zwischen x und y
 You can drag SQL statements from an object row and drop them into other applications or into another instance of &apos;DB Browser for SQLite&apos;.
 </source>
         <translation>Dies ist die Struktur der geöffneten Datenbank.
-Sie können SQL-Statements aus einer Objektzeile fassen und in anderen Anwendungen oder einer anderen &apos;DB-Browser für SQLite&apos;-Instanz ablegen.
+Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendungen oder einer anderen &apos;DB-Browser für SQLite&apos;-Instanz ablegen.
 </translation>
     </message>
     <message>
@@ -2928,7 +2928,7 @@ Sie können SQL-Statements aus einer Objektzeile fassen und in anderen Anwendung
     <message>
         <location filename="../MainWindow.ui" line="1566"/>
         <source>This button executes the currently selected SQL statements. If no text is selected, all SQL statements are executed.</source>
-        <translation>Dieser Button führt das aktuell ausgewählte SQL-Statement aus. Falls kein Text ausgewählt ist, werden alle SQL-Statements ausgeführt.</translation>
+        <translation>Dieser Button führt die aktuell ausgewählte SQL-Anweisung aus. Falls kein Text ausgewählt ist, werden alle SQL-Anweisungen ausgeführt.</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1584"/>
@@ -3450,7 +3450,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1626"/>
         <source>This button executes the SQL statement present in the current editor line</source>
-        <translation>Dieser Button führt das SQL-Statement in der aktuellen Editorzeile aus</translation>
+        <translation>Dieser Button führt die SQL-Anweisung in der aktuellen Editorzeile aus</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1629"/>
@@ -4210,7 +4210,7 @@ Möchten Sie die Datenbank wirklich speichern?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="1107"/>
         <source>You are already executing SQL statements. Do you want to stop them in order to execute the current statements instead? Note that this might leave the database in an inconsistent state.</source>
-        <translation>Es werden bereits SQL-Statements ausgeführt. Sollen diese gestoppt werden, um stattdessen die aktuellen Statements auszuführen? Dies führt möglicherweise zu einem inkonsistenten Zustand der Datenbank.</translation>
+        <translation>Es werden bereits SQL-Anweisungen ausgeführt. Sollen diese gestoppt werden, um stattdessen die aktuellen Anweisungen auszuführen? Dies führt möglicherweise zu einem inkonsistenten Zustand der Datenbank.</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="1156"/>
@@ -4278,7 +4278,7 @@ Sind Sie sich sicher?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="2084"/>
         <source>The statements in the tab &apos;%1&apos; are still executing. Closing the tab will stop the execution. This might leave the database in an inconsistent state. Are you sure you want to close the tab?</source>
-        <translation>Die Statements im Tab &apos;%1&apos; werden noch ausgeführt. Das Schließen des Tabs stoppt die Ausführung. Dies hinterlässt die Datenbank möglicherweise in einem inkonsistenten Zustand. Soll der Tab wirklich geschlossen werden?</translation>
+        <translation>Die Anweisungen im Tab &apos;%1&apos; werden noch ausgeführt. Das Schließen des Tabs stoppt die Ausführung. Dies hinterlässt die Datenbank möglicherweise in einem inkonsistenten Zustand. Soll der Tab wirklich geschlossen werden?</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="2867"/>
@@ -6491,17 +6491,17 @@ Soll wirklich fortgefahren werden?</translation>
     <message>
         <location filename="../SqlExecutionArea.ui" line="232"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Results of the last executed statements.&lt;/p&gt;&lt;p&gt;You may want to collapse this panel and use the &lt;span style=&quot; font-style:italic;&quot;&gt;SQL Log&lt;/span&gt; dock with &lt;span style=&quot; font-style:italic;&quot;&gt;User&lt;/span&gt; selection instead.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ergebnisse der zuletzt ausgeführten Statements.&lt;/p&gt;&lt;p&gt;Dieses Panel kann zusammengeklappt und stattdessen der &lt;span style=&quot; font-style:italic;&quot;&gt;SQL-Log&lt;/span&gt;-Dock mit der Auswahl &lt;span style=&quot; font-style:italic;&quot;&gt;Benutzer&lt;/span&gt; verwendet werden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ergebnisse der zuletzt ausgeführten Anweisungen.&lt;/p&gt;&lt;p&gt;Dieses Panel kann zusammengeklappt und stattdessen der &lt;span style=&quot; font-style:italic;&quot;&gt;SQL-Log&lt;/span&gt;-Dock mit der Auswahl &lt;span style=&quot; font-style:italic;&quot;&gt;Benutzer&lt;/span&gt; verwendet werden.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.ui" line="253"/>
         <source>Results of the last executed statements</source>
-        <translation>Ergebnisse des zuletzt ausgeführten Statements</translation>
+        <translation>Ergebnisse der zuletzt ausgeführten Anweisungen</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.ui" line="235"/>
         <source>This field shows the results and status codes of the last executed statements.</source>
-        <translation>Dieses Feld zeigt die Ergebnisse und Statuscodes der zuletzt ausgeführten Statements.</translation>
+        <translation>Dieses Feld zeigt die Ergebnisse und Statuscodes der zuletzt ausgeführten Anweisungen.</translation>
     </message>
     <message>
         <source>Couldn&apos;t read file: %1.</source>
@@ -6567,7 +6567,7 @@ Soll wirklich fortgefahren werden?</translation>
     <message>
         <location filename="../SqlUiLexer.cpp" line="80"/>
         <source>() The changes() function returns the number of database rows that were changed or inserted or deleted by the most recently completed INSERT, DELETE, or UPDATE statement.</source>
-        <translation>() Die changes()-Funktion gibt die Anzahl der Datenbankzeilen zurück, die mit dem zuletzt abgeschlossenen INSERT-, DELETE- oder UPDATE-Statement geändert, einfügt oder gelöscht worden sind.</translation>
+        <translation>() Die changes()-Funktion gibt die Anzahl der Datenbankzeilen zurück, die mit der zuletzt abgeschlossenen INSERT-, DELETE- oder UPDATE-Anweisung geändert, einfügt oder gelöscht worden sind.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="81"/>
@@ -6676,7 +6676,7 @@ Die Verwendung dieser Funktion muss in den Einstellungen authorisiert werden.</t
     <message>
         <location filename="../SqlUiLexer.cpp" line="101"/>
         <source>(X) The quote(X) function returns the text of an SQL literal which is the value of its argument suitable for inclusion into an SQL statement.</source>
-        <translation>(X) Die quote(X)-Funktion gibt den Text eines SQL-Literals zurück, wobei der Wert des Arguments zum Einfügen in ein SQL-Statement geeignet ist.</translation>
+        <translation>(X) Die quote(X)-Funktion gibt den Text eines SQL-Literals zurück, wobei der Wert des Arguments zum Einfügen in eine SQL-Anweisungen geeignet ist.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="102"/>
@@ -6731,7 +6731,7 @@ Die Verwendung dieser Funktion muss in den Einstellungen authorisiert werden.</t
     <message>
         <location filename="../SqlUiLexer.cpp" line="112"/>
         <source>() The total_changes() function returns the number of row changes caused by INSERT, UPDATE or DELETE statements since the current database connection was opened.</source>
-        <translation>() Die changes()-Funktion gibt die Anzahl dergeänderten Datenbankzeilen zurück, die seit dem Öffnen der aktuellen Datenbankverbindung mit INSERT-, DELETE- oder UPDATE-Statement geändert, einfügt oder gelöscht worden sind.</translation>
+        <translation>() Die changes()-Funktion gibt die Anzahl der geänderten Datenbankzeilen zurück, die seit dem Öffnen der aktuellen Datenbankverbindung mit INSERT-, DELETE- oder UPDATE-Anweisung geändert, einfügt oder gelöscht worden sind.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="113"/>
@@ -7468,7 +7468,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="699"/>
         <source>This button saves the current setting of the browsed table (filters, display formats and order column) as an SQL view that you can later browse or use in SQL statements.</source>
-        <translation>Dieser Button speichert die aktuellen Einstellungen der ausgewählten Tabelle (Filter, Anzeigeformate und Spaltenreihenfolge) als SQL-Ansicht, welche Sie später durchsuchen oder in SQL-Statements verwenden können.</translation>
+        <translation>Dieser Button speichert die aktuellen Einstellungen der ausgewählten Tabelle (Filter, Anzeigeformate und Spaltenreihenfolge) als SQL-Ansicht, welche Sie später durchsuchen oder in SQL-Anweisungen verwenden können.</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="708"/>
@@ -7484,7 +7484,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="717"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This popup menu provides the following options applying to the currently browsed and filtered table:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Export to CSV: this option exports the data of the browsed table as currently displayed (after filters, display formats and order column) to a CSV file.&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Save as view: this option saves the current setting of the browsed table (filters, display formats and order column) as an SQL view that you can later browse or use in SQL statements.&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dieses Popup-Menü bietet die folgenden Optionen zur Anwendung auf die aktuell ausgewählte und gefilterte Tabelle:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;CSV exportieren: diese Option exportiert die Daten der ausgewählten Tabelle wie aktuell angezeigt (gefiltert, Anzeigeformat und Spaltenreihenfolge) in eine CSV-Datei.&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Als Ansicht speichern: diese Option speichert die aktuelle Einstellung der ausgewählten Tabelle (Filter, Anzeigeformat und Spaltenreihenfolge) als eine SQL-Ansicht, die Sie später durchsuchen oder in SQL-Statements verwenden können.&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Dieses Popup-Menü bietet die folgenden Optionen zur Anwendung auf die aktuell ausgewählte und gefilterte Tabelle:&lt;/p&gt;&lt;ul style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;CSV exportieren: diese Option exportiert die Daten der ausgewählten Tabelle wie aktuell angezeigt (gefiltert, Anzeigeformat und Spaltenreihenfolge) in eine CSV-Datei.&lt;/li&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Als Ansicht speichern: diese Option speichert die aktuelle Einstellung der ausgewählten Tabelle (Filter, Anzeigeformat und Spaltenreihenfolge) als eine SQL-Ansicht, die Sie später durchsuchen oder in SQL-Anweisungen verwenden können.&lt;/li&gt;&lt;/ul&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="722"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3870,7 +3870,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
         <source>Ctrl+E</source>
-        <translation>Strg+E</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1637"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -1145,7 +1145,7 @@ Fehler werden mittels eine roten Wellenlinie angezeigt.</translation>
     <message>
         <location filename="../EditDialog.ui" line="277"/>
         <source>Ctrl+P</source>
-        <translation></translation>
+        <translation>Strg+P</translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="271"/>
@@ -1165,7 +1165,7 @@ Fehler werden mittels eine roten Wellenlinie angezeigt.</translation>
     <message>
         <location filename="../EditDialog.ui" line="295"/>
         <source>Ctrl+Shift+C</source>
-        <translation></translation>
+        <translation>Strg+Umschalt+C</translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="352"/>
@@ -2026,18 +2026,18 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
         <location filename="../ExtendedScintilla.cpp" line="63"/>
         <location filename="../ExtendedScintilla.cpp" line="295"/>
         <source>Ctrl+H</source>
-        <translation></translation>
+        <translation>Strg+H</translation>
     </message>
     <message>
         <location filename="../ExtendedScintilla.cpp" line="65"/>
         <source>Ctrl+F</source>
-        <translation></translation>
+        <translation>Strg+F</translation>
     </message>
     <message>
         <location filename="../ExtendedScintilla.cpp" line="78"/>
         <location filename="../ExtendedScintilla.cpp" line="299"/>
         <source>Ctrl+P</source>
-        <translation></translation>
+        <translation>Strg+P</translation>
     </message>
     <message>
         <location filename="../ExtendedScintilla.cpp" line="289"/>
@@ -2155,17 +2155,17 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="324"/>
         <source>Alt+Del</source>
-        <translation></translation>
+        <translation>Alt+Entf</translation>
     </message>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="327"/>
         <source>Ctrl+Shift+C</source>
-        <translation></translation>
+        <translation>Strg+Umschalt+C</translation>
     </message>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="328"/>
         <source>Ctrl+Alt+C</source>
-        <translation></translation>
+        <translation>Strg+Alt+C</translation>
     </message>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="799"/>
@@ -2534,7 +2534,7 @@ x~y	Bereich: Werte zwischen x und y
     <message>
         <location filename="../ImageViewer.ui" line="132"/>
         <source>Ctrl+P</source>
-        <translation></translation>
+        <translation>Strg+P</translation>
     </message>
 </context>
 <context>
@@ -2828,7 +2828,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="2183"/>
         <source>Ctrl+/</source>
-        <translation></translation>
+        <translation>Strg+/</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2195"/>
@@ -2892,7 +2892,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
         <location filename="../MainWindow.ui" line="1232"/>
         <location filename="../MainWindow.cpp" line="476"/>
         <source>Ctrl+F4</source>
-        <translation></translation>
+        <translation>Strg+F4</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1271"/>
@@ -2933,7 +2933,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1584"/>
         <source>Ctrl+Shift+T</source>
-        <translation>Ctrl+Shift+T</translation>
+        <translation>Strg+Umschalt+T</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1605"/>
@@ -3029,7 +3029,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1879"/>
         <source>Ctrl+Shift+O</source>
-        <translation></translation>
+        <translation>Strg+Umschalt+0</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1891"/>
@@ -3065,7 +3065,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1921"/>
         <source>Ctrl+F</source>
-        <translation></translation>
+        <translation>Strg+F</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1936"/>
@@ -3086,7 +3086,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1948"/>
         <source>Ctrl+H</source>
-        <translation></translation>
+        <translation>Strg+H</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1956"/>
@@ -3133,7 +3133,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
         <location filename="../MainWindow.ui" line="2263"/>
         <location filename="../MainWindow.cpp" line="477"/>
         <source>Ctrl+Shift+W</source>
-        <translation></translation>
+        <translation>Strg+Umschalt+W</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2292"/>
@@ -3325,7 +3325,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="2240"/>
         <source>Ctrl+Shift+S</source>
-        <translation></translation>
+        <translation>Strg+Umschalt+S</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2254"/>
@@ -3341,7 +3341,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.cpp" line="477"/>
         <source>Ctrl+Shift+F4</source>
-        <translation></translation>
+        <translation>Strg+Umschalt+F4</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2272"/>
@@ -3455,7 +3455,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1629"/>
         <source>Shift+F5</source>
-        <translation></translation>
+        <translation>Umschalt+F5</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1712"/>
@@ -3522,7 +3522,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1181"/>
         <source>Ctrl+N</source>
-        <translation></translation>
+        <translation>Strg+N</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1193"/>
@@ -3549,7 +3549,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1205"/>
         <source>Ctrl+O</source>
-        <translation></translation>
+        <translation>Strg+0</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1220"/>
@@ -3565,7 +3565,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
         <location filename="../MainWindow.cpp" line="190"/>
         <location filename="../MainWindow.cpp" line="3774"/>
         <source>Ctrl+W</source>
-        <translation></translation>
+        <translation>Strg+W</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1250"/>
@@ -3592,7 +3592,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1307"/>
         <source>Ctrl+S</source>
-        <translation></translation>
+        <translation>Strg+S</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1321"/>
@@ -3613,7 +3613,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1338"/>
         <source>Ctrl+Q</source>
-        <translation></translation>
+        <translation>Strg+Q</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1349"/>
@@ -3698,7 +3698,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1520"/>
         <source>Shift+F1</source>
-        <translation></translation>
+        <translation>Umschalt+F1</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1536"/>
@@ -3708,7 +3708,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1551"/>
         <source>Ctrl+T</source>
-        <translation></translation>
+        <translation>Strg+T</translation>
     </message>
     <message>
         <source>Database Structure</source>
@@ -3870,7 +3870,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
         <source>Ctrl+E</source>
-        <translation></translation>
+        <translation>Strg+E</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1637"/>
@@ -3885,13 +3885,13 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.cpp" line="276"/>
         <source>Ctrl+L</source>
-        <translation></translation>
+        <translation>Strg+L</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2132"/>
         <location filename="../MainWindow.ui" line="2159"/>
         <source>Ctrl+P</source>
-        <translation></translation>
+        <translation>Strg+P</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="400"/>
@@ -3907,7 +3907,7 @@ Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor ode
     <message>
         <location filename="../MainWindow.ui" line="1569"/>
         <source>Ctrl+Return</source>
-        <translation>Strg+Return</translation>
+        <translation>Strg+Enter</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
@@ -4036,17 +4036,17 @@ Bei der Antwort NEIN werden die Daten in die SQL-Datei der aktuellen Datenbank i
     <message>
         <location filename="../MainWindow.cpp" line="198"/>
         <source>Ctrl+Tab</source>
-        <translation></translation>
+        <translation>Strg+Tab</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="207"/>
         <source>Ctrl+Shift+Tab</source>
-        <translation></translation>
+        <translation>Strg+Umschalt+Tab</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="218"/>
         <source>Ctrl+PgUp</source>
-        <translation></translation>
+        <translation>Strg+BildAuf</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="235"/>
@@ -4066,7 +4066,7 @@ Bei der Antwort NEIN werden die Daten in die SQL-Datei der aktuellen Datenbank i
     <message>
         <location filename="../MainWindow.cpp" line="341"/>
         <source>Shift+Alt+0</source>
-        <translation></translation>
+        <translation>Umschalt+Alt+0</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="350"/>
@@ -4338,12 +4338,12 @@ Sind Sie sich sicher?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="332"/>
         <source>Ctrl+Alt+0</source>
-        <translation></translation>
+        <translation>Strg+Alt+0</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="476"/>
         <source>Ctrl+Alt+W</source>
-        <translation></translation>
+        <translation>Strg+Alt+W</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="693"/>
@@ -4565,7 +4565,7 @@ Erstellen Sie ein Backup!</translation>
     <message>
         <location filename="../AddRecordDialog.cpp" line="46"/>
         <source>Alt+Del</source>
-        <translation></translation>
+        <translation>Alt+Entf</translation>
     </message>
 </context>
 <context>
@@ -6420,7 +6420,7 @@ Soll wirklich fortgefahren werden?</translation>
     <message>
         <location filename="../SqlExecutionArea.ui" line="91"/>
         <source>Shift+F3</source>
-        <translation></translation>
+        <translation>Umschalt+F3</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.ui" line="105"/>
@@ -6549,12 +6549,12 @@ Soll wirklich fortgefahren werden?</translation>
     <message>
         <location filename="../sqltextedit.cpp" line="45"/>
         <source>Ctrl+/</source>
-        <translation></translation>
+        <translation>Strg+/</translation>
     </message>
     <message>
         <location filename="../sqltextedit.cpp" line="48"/>
         <source>Ctrl+PgDown</source>
-        <translation></translation>
+        <translation>Strg+BildAb</translation>
     </message>
 </context>
 <context>
@@ -7127,7 +7127,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="277"/>
         <source>Shift+F3</source>
-        <translation></translation>
+        <translation>Umschalt+F3</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="284"/>
@@ -7577,7 +7577,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="814"/>
         <source>Ctrl+P</source>
-        <translation></translation>
+        <translation>Strg+P</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="844"/>
@@ -7622,7 +7622,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="889"/>
         <source>Ctrl+B</source>
-        <translation></translation>
+        <translation>Strg+B</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="901"/>
@@ -7639,7 +7639,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="922"/>
         <source>Ctrl+U</source>
-        <translation></translation>
+        <translation>Strg+U</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="934"/>
@@ -7728,7 +7728,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="1068"/>
         <source>Ctrl+Space</source>
-        <translation></translation>
+        <translation>Strg+Leertaste</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="1083"/>
@@ -7753,7 +7753,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.cpp" line="113"/>
         <source>Ctrl+R</source>
-        <translation></translation>
+        <translation>Strg+R</translation>
     </message>
     <message numerus="yes">
         <location filename="../TableBrowser.cpp" line="517"/>
@@ -7832,7 +7832,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.cpp" line="1284"/>
         <source>Ctrl+&quot;</source>
-        <translation></translation>
+        <translation>Strg+&quot;</translation>
     </message>
     <message>
         <location filename="../TableBrowser.cpp" line="1303"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -7639,7 +7639,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="922"/>
         <source>Ctrl+U</source>
-        <translation>Strg+U</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="934"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -7832,7 +7832,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.cpp" line="1284"/>
         <source>Ctrl+&quot;</source>
-        <translation>Strg+&quot;</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../TableBrowser.cpp" line="1303"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -6567,7 +6567,7 @@ Soll wirklich fortgefahren werden?</translation>
     <message>
         <location filename="../SqlUiLexer.cpp" line="80"/>
         <source>() The changes() function returns the number of database rows that were changed or inserted or deleted by the most recently completed INSERT, DELETE, or UPDATE statement.</source>
-        <translation>() Die changes()-Funktion gibt die Anzahl der Datenbankzeilen zurück, die mit der zuletzt abgeschlossenen INSERT-, DELETE- oder UPDATE-Anweisung geändert, einfügt oder gelöscht worden sind.</translation>
+        <translation>() Die changes()-Funktion gibt die Anzahl der Datenbankzeilen zurück, die mit der zuletzt abgeschlossenen INSERT-, DELETE- oder UPDATE-Anweisung geändert, eingefügt oder gelöscht worden sind.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="81"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3481,7 +3481,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1832"/>
         <source>Copy Create statement</source>
-        <translation>Create-Anweisung kopieren</translation>
+        <translation>CREATE-Anweisung kopieren</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1835"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3325,7 +3325,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="2240"/>
         <source>Ctrl+Shift+S</source>
-        <translation>Strg+Umschalt+S</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2254"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2031,7 +2031,7 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
     <message>
         <location filename="../ExtendedScintilla.cpp" line="65"/>
         <source>Ctrl+F</source>
-        <translation>Strg+F</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../ExtendedScintilla.cpp" line="78"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3417,8 +3417,8 @@ You can drag multiple object names from the Name column and drop them into the S
 You can drag SQL statements from the Schema column and drop them into the SQL editor or into other applications.
 </source>
         <translation>Dies ist die Struktur der geöffneten Datenbank.
-Sie können mehrere Objektnamen aus der Namensspalte nehmen und in den SQL-Editor ziehen und Sie können die Eigenschaften der abgelegten Namen über das Kontextmenü anpassen. Dies kann Sie bei der Erstellung von SQL-Statements unterstützen.
-Sie können SQL-Statements aus der Schemaspalte nehmen und in den SQL-Editor oder in anderen Anwendungen ablegen.
+Sie können mehrere Objektnamen aus der Namensspalte nehmen und in den SQL-Editor ziehen und Sie können die Eigenschaften der abgelegten Namen über das Kontextmenü anpassen. Dies kann Sie bei der Erstellung von SQL-Anweisungen unterstützen.
+Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor oder in anderen Anwendungen ablegen.
 </translation>
     </message>
     <message>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2155,7 +2155,7 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="324"/>
         <source>Alt+Del</source>
-        <translation>Alt+Entf</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="327"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -4565,7 +4565,7 @@ Erstellen Sie ein Backup!</translation>
     <message>
         <location filename="../AddRecordDialog.cpp" line="46"/>
         <source>Alt+Del</source>
-        <translation>Alt+Entf</translation>
+        <translation></translation>
     </message>
 </context>
 <context>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -7753,7 +7753,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.cpp" line="113"/>
         <source>Ctrl+R</source>
-        <translation>Strg+R</translation>
+        <translation></translation>
     </message>
     <message numerus="yes">
         <location filename="../TableBrowser.cpp" line="517"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3708,7 +3708,7 @@ Sie können SQL-Anweisungen aus der Schemaspalte nehmen und in den SQL-Editor od
     <message>
         <location filename="../MainWindow.ui" line="1551"/>
         <source>Ctrl+T</source>
-        <translation>Strg+T</translation>
+        <translation></translation>
     </message>
     <message>
         <source>Database Structure</source>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -4338,7 +4338,7 @@ Sind Sie sich sicher?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="332"/>
         <source>Ctrl+Alt+0</source>
-        <translation>Strg+Alt+0</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="476"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -4036,7 +4036,7 @@ Bei der Antwort NEIN werden die Daten in die SQL-Datei der aktuellen Datenbank i
     <message>
         <location filename="../MainWindow.cpp" line="198"/>
         <source>Ctrl+Tab</source>
-        <translation>Strg+Tab</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="207"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3101,7 +3101,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1966"/>
         <source>Save as &amp;view</source>
-        <translation>Als &amp;Ansicht speichern</translation>
+        <translation>Als &amp;View speichern</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1969"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -4343,7 +4343,7 @@ Sind Sie sich sicher?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="476"/>
         <source>Ctrl+Alt+W</source>
-        <translation>Strg+Alt+W</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="693"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3341,7 +3341,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.cpp" line="477"/>
         <source>Ctrl+Shift+F4</source>
-        <translation>Strg+Umschalt+F4</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2272"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -3086,7 +3086,7 @@ Sie können SQL-Anweisungen aus einer Objektzeile fassen und in anderen Anwendun
     <message>
         <location filename="../MainWindow.ui" line="1948"/>
         <source>Ctrl+H</source>
-        <translation>Strg+H</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1956"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -7728,7 +7728,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="1068"/>
         <source>Ctrl+Space</source>
-        <translation>Strg+Leertaste</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="1083"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2534,7 +2534,7 @@ x~y	Bereich: Werte zwischen x und y
     <message>
         <location filename="../ImageViewer.ui" line="132"/>
         <source>Ctrl+P</source>
-        <translation>Strg+P</translation>
+        <translation></translation>
     </message>
 </context>
 <context>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -4363,7 +4363,7 @@ Sind Sie sich sicher?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="1576"/>
         <source>Import completed. Some foreign key constraints are violated. Please fix them before saving.</source>
-        <translation>Import vollständig. Ein paar Fremdschlüssel Beschränkungen wurden verletzt. Bitten beheben Sie diese vor dem Speichern.</translation>
+        <translation>Import vollständig. Ein paar Fremdschlüssel-Beschränkungen wurden verletzt. Bitten beheben Sie diese vor dem Speichern.</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="1661"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -7457,7 +7457,7 @@ Halten Sie %3Umschalt und klicken Sie, um hierher zu springen</translation>
     <message>
         <location filename="../TableBrowser.ui" line="690"/>
         <source>Save as &amp;view</source>
-        <translation>Als &amp;Ansicht speichern</translation>
+        <translation>Als &amp;View speichern</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="693"/>

--- a/src/translations/sqlb_de.ts
+++ b/src/translations/sqlb_de.ts
@@ -2037,7 +2037,7 @@ Alle aktuell in diesem Feld gespeicherten Daten gehen verloren.</translation>
         <location filename="../ExtendedScintilla.cpp" line="78"/>
         <location filename="../ExtendedScintilla.cpp" line="299"/>
         <source>Ctrl+P</source>
-        <translation>Strg+P</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../ExtendedScintilla.cpp" line="289"/>


### PR DESCRIPTION
Hi,
i did the following changes to the german translation.
I hope i did it right so please have a look.

not or inconsistent translated:
change row(s) to Zeile and Zeilen 
    row(s) = Zeile / Zeilen (1x)
change Constrain to Beschränkung
    Constrain = Beschränkung (10x)
change View to Ansicht(en)
    View = Ansichten (8x)
change Toolbar to Werkzeugleiste
    Toobar = Werkzeugleiste (8x)
change Recent to Zuletzt
    Recently opened = zuletzt geöffnet (1x)
    Recent Files = zuletzt geöffnete Dateien (1x)
    Max Recent Files = Maximale Anzahl zuletzt geöffneter Dateien (1x)
change Query to Abfrage
    Query = Abfrage (10x)
    
change Statement to Anweisung
    Create-Statement = (SQL-)Anweisung (3x)
    SQL-Statement = SQL-Anweisung (1x)
found more "Statements" which i changed to Anweisung(en), with additional minor changes like an added Space or the change from "dem Statement" to "die Anweisungen" or "der Anweisung"
    Statement = Anweisung (21x)
---------------------------------

changed some and added missing german short cuts:
    Ctrl = Strg (39x)
    Shift = Umschalt (13x)
    PgUp = BildAuf (1x)
    PgDown = BildAb (1x)
    Space = Leertaste (1x)
    Del = Entf (2x)
----------------------------------

suggestion to change a sentence from
() Die last_insert_rowid()-Funktion gibt die ROWID der letzte Zeile zurück, die von der diese Funktion aufrufenden Datenbankverbindung eingefügt wurde.
to
() Die last_insert_rowid()-Funktion gibt die ZeilenID der letzten Zeile zurück, die von der Datenbankverbindung eingefügt wurde und die dann die Funktion aufrief.
----------------------------------