### PR TITLE
Add Webkit / Chromium epoch format function

### DIFF
--- a/src/ColumnDisplayFormatDialog.cpp
+++ b/src/ColumnDisplayFormatDialog.cpp
@@ -29,6 +29,8 @@ ColumnDisplayFormatDialog::ColumnDisplayFormatDialog(DBBrowserDB& db, const sqlb
     ui->comboDisplayFormat->addItem(tr("Julian day to date"), "julian");
     ui->comboDisplayFormat->addItem(tr("Unix epoch to date"), "epoch");
     ui->comboDisplayFormat->addItem(tr("Unix epoch to local time"), "epochLocalTime");
+    ui->comboDisplayFormat->addItem(tr("WebKit / Chromium epoch to date"), "webkitEpoch");
+    ui->comboDisplayFormat->addItem(tr("WebKit / Chromium epoch to local time"), "webkitEpochLocalTime");
     ui->comboDisplayFormat->addItem(tr("Windows DATE to date"), "winDate");
     ui->comboDisplayFormat->addItem(tr("Date as dd/mm/yyyy"), "ddmmyyyyDate");
     ui->comboDisplayFormat->insertSeparator(ui->comboDisplayFormat->count());
@@ -57,6 +59,8 @@ ColumnDisplayFormatDialog::ColumnDisplayFormatDialog(DBBrowserDB& db, const sqlb
     formatFunctions["julian"] = "datetime(" + e_column_name + ")";
     formatFunctions["epoch"] = "datetime(" + e_column_name + ", 'unixepoch')";
     formatFunctions["epochLocalTime"] = "datetime(" + e_column_name + ", 'unixepoch', 'localtime')";
+    formatFunctions["webkitEpoch"] = "datetime(" + e_column_name + " / 1e6 - 11644473600, 'unixepoch')";
+    formatFunctions["webkitEpochLocalTime"] = "datetime(" + e_column_name + " / 1e6 - 11644473600, 'unixepoch', 'localtime')";
     formatFunctions["winDate"] = "datetime('1899-12-30', " + e_column_name + " || ' days')";
     formatFunctions["ddmmyyyyDate"] = "strftime('%d/%m/%Y', " + e_column_name + ")";
     formatFunctions["lower"] = "lower(" + e_column_name + ")";


### PR DESCRIPTION
This adds formatting options for WebKit time (also used by Chrome / Chromium-based browsers).
For me, this was useful while I was doing some forensic works having to look at Chrome's SQLite3 history file, so I thought maybe I can just contribute it here and get it upstreamed.

Some information about WebKit time:
WebKit epoch are microseconds from 1601-01-01 00:00 UTC to now.
This can map to UNIX time by converting them to seconds (`/ 1e6`)  and then subtracting the offset between the two start dates (`11644473600`).

Hence, we just convert the time to an UNIX epoch and let `datetime` handle the rest of the conversion.


![Formatting Option](https://github.com/sqlitebrowser/sqlitebrowser/assets/26608194/8cfca2b3-c005-4876-8e10-a8513cf984dc)
![Example with formatting applied](https://github.com/sqlitebrowser/sqlitebrowser/assets/26608194/35bc9115-b603-441b-b00f-c2ed20f4f2fa)

