### PR TITLE
Improve tooltip for the "WITHOUT ROWID" checkbox

### DIFF
--- a/src/EditTableDialog.ui
+++ b/src/EditTableDialog.ui
@@ -82,7 +82,7 @@
          <item row="1" column="1">
           <widget class="QCheckBox" name="checkWithoutRowid">
            <property name="toolTip">
-            <string>Make this a 'WITHOUT rowid' table. Setting this flag requires a field of type INTEGER with the primary key flag set and the auto increment flag unset.</string>
+            <string>Make this a 'WITHOUT ROWID' table. Setting this flag requires specifying a PRIMARY KEY (which can be of any type, and can be composite), and forbids the AUTOINCREMENT flag.</string>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
Notably, the required PRIMARY KEY can be of any type, and can be composite.

Refs:

- [Clustered Indexes and the WITHOUT ROWID Optimization](https://www.sqlite.org/withoutrowid.html) - in particular in [section 4](https://www.sqlite.org/withoutrowid.html#when_to_use_without_rowid):
  > The WITHOUT ROWID optimization is likely to be helpful for tables that have non-integer or composite (multi-column) PRIMARY KEYs and that do not store large strings or BLOBs.
- [SQLite Autoincrement](https://www.sqlite.org/autoinc.html) - in particular [at the end](https://www.sqlite.org/autoinc.html#the_autoincrement_keyword) of the page:
  > Because AUTOINCREMENT keyword changes the behavior of the ROWID selection algorithm, AUTOINCREMENT is not allowed on [WITHOUT ROWID](https://www.sqlite.org/withoutrowid.html) tables or on any table column other than INTEGER PRIMARY KEY. Any attempt to use AUTOINCREMENT on a [WITHOUT ROWID](https://www.sqlite.org/withoutrowid.html) table or on a column other than the INTEGER PRIMARY KEY column results in an error.

Not sure how the translations should be handled. Does "lupdate" handle everything? (updating the `<source>` tags, and marking the `<translations>` tags as needing update)