### PR TITLE
Fix AppStream valdidator errors and warnings

### DIFF
--- a/distri/sqlitebrowser.desktop.appdata.xml
+++ b/distri/sqlitebrowser.desktop.appdata.xml
@@ -49,4 +49,5 @@
     <release version="3.12.2" date="2021-05-17" />
     <release version="3.12.1" date="2020-11-09" />
   </releases>
+  <launchable type="desktop-id">sqlitebrowser.desktop</launchable>
 </component>

--- a/distri/sqlitebrowser.desktop.appdata.xml
+++ b/distri/sqlitebrowser.desktop.appdata.xml
@@ -5,7 +5,7 @@
   <project_license>MPL-2.0 and GPL-3.0+</project_license>
   <developer_name>DB Browser for SQLite developers</developer_name>
   <name>DB Browser for SQLite</name>
-  <summary>DB Browser for SQLite is a light GUI editor for SQLite databases</summary>
+  <summary>light GUI editor for SQLite databases</summary>
   <description>
     <p>DB Browser for SQLite is a high quality, visual, open source tool to create, design, and edit database files compatible with SQLite.</p>
     <p>It is for users and developers wanting to create databases, search, and edit data. It uses a familiar spreadsheet-like interface, and you don't need to learn complicated SQL commands.</p>

--- a/distri/sqlitebrowser.desktop.appdata.xml
+++ b/distri/sqlitebrowser.desktop.appdata.xml
@@ -3,6 +3,7 @@
   <id>sqlitebrowser.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0 and GPL-3.0+</project_license>
+  <developer_name>DB Browser for SQLite developers</developer_name>
   <name>DB Browser for SQLite</name>
   <summary>DB Browser for SQLite is a light GUI editor for SQLite databases</summary>
   <description>


### PR DESCRIPTION
Fixes

```json
{
    "errors": [
        "appstream-failed-validation",
        "appstream-missing-developer-name"
    ],
    "warnings": [
        "appstream-summary-too-long",
        "appstream-name-too-long"
    ],
    "appstream": [
        "E: org.sqlitebrowser.sqlitebrowser:~: desktop-app-launchable-missing"
    ],
    "message": "Please consult the documentation at https://docs.flathub.org/docs/for-app-authors/linter"
}
```

Required for https://github.com/flathub/org.sqlitebrowser.sqlitebrowser/pull/18