### PR TITLE
Marked QLabel and ComboBox texts as translatable in 'Edit Pragma' QTabWidget

### DIFF
--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -211,17 +211,17 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaAutoVacuum">
               <item>
                <property name="text">
-                <string>None</string>
+                <string notr="true">None</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Full</string>
+                <string notr="true">Full</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Incremental</string>
+                <string notr="true">Incremental</string>
                </property>
               </item>
              </widget>
@@ -366,32 +366,32 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaJournalMode">
               <item>
                <property name="text">
-                <string>Delete</string>
+                <string notr="true">Delete</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Truncate</string>
+                <string notr="true">Truncate</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Persist</string>
+                <string notr="true">Persist</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Memory</string>
+                <string notr="true">Memory</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>WAL</string>
+                <string notr="true">WAL</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Off</string>
+                <string notr="true">Off</string>
                </property>
               </item>
              </widget>
@@ -436,12 +436,12 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaLockingMode">
               <item>
                <property name="text">
-                <string>Normal</string>
+                <string notr="true">Normal</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Exclusive</string>
+                <string notr="true">Exclusive</string>
                </property>
               </item>
              </widget>
@@ -580,17 +580,17 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaSynchronous">
               <item>
                <property name="text">
-                <string>Off</string>
+                <string notr="true">Off</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Normal</string>
+                <string notr="true">Normal</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Full</string>
+                <string notr="true">Full</string>
                </property>
               </item>
              </widget>
@@ -612,17 +612,17 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaTempStore">
               <item>
                <property name="text">
-                <string>Default</string>
+                <string notr="true">Default</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>File</string>
+                <string notr="true">File</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string>Memory</string>
+                <string notr="true">Memory</string>
                </property>
               </item>
              </widget>

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -194,7 +194,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="0" column="0">
              <widget class="QLabel" name="labelPragmaAutoVacuum">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Auto Vacuum &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_auto_vacuum&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Auto Vacuum &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_auto_vacuum&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -211,17 +211,17 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaAutoVacuum">
               <item>
                <property name="text">
-                <string notr="true">None</string>
+                <string>None</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Full</string>
+                <string>Full</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Incremental</string>
+                <string>Incremental</string>
                </property>
               </item>
              </widget>
@@ -229,7 +229,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="1" column="0">
              <widget class="QLabel" name="labelPragmaAutomaticIndex">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatic Index &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_automatic_index&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatic Index &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_automatic_index&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -249,7 +249,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="2" column="0">
              <widget class="QLabel" name="labelPragmaCaseSensitiveLike">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Case Sensitive Like &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_case_sensitive_like&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Case Sensitive Like &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_case_sensitive_like&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -272,7 +272,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="3" column="0">
              <widget class="QLabel" name="labelPragmaCheckpointFullFsync">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Checkpoint Full FSYNC &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_checkpoint_fullfsync&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Checkpoint Full FSYNC &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_checkpoint_fullfsync&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -292,7 +292,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="4" column="0">
              <widget class="QLabel" name="labelPragmaForeignKeys">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Foreign Keys &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_foreign_keys&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Foreign Keys &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_foreign_keys&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -312,7 +312,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="5" column="0">
              <widget class="QLabel" name="labelPragmaFullFsync">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Full FSYNC &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_fullfsync&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Full FSYNC &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_fullfsync&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -332,7 +332,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="6" column="0">
              <widget class="QLabel" name="labelPragmaIgnoreCheckConstraints">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ignore Check Constraints &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_ignore_check_constraints&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Ignore Check Constraints &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_ignore_check_constraints&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -352,7 +352,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="7" column="0">
              <widget class="QLabel" name="labelPragmaJournalMode">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Journal Mode &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_journal_mode&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Journal Mode &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_journal_mode&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -366,32 +366,32 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaJournalMode">
               <item>
                <property name="text">
-                <string notr="true">Delete</string>
+                <string>Delete</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Truncate</string>
+                <string>Truncate</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Persist</string>
+                <string>Persist</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Memory</string>
+                <string>Memory</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">WAL</string>
+                <string>WAL</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Off</string>
+                <string>Off</string>
                </property>
               </item>
              </widget>
@@ -399,7 +399,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="8" column="0">
              <widget class="QLabel" name="labelJournalSizeLimit">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Journal Size Limit &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_journal_size_limit&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Journal Size Limit &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_journal_size_limit&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -422,7 +422,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="9" column="0">
              <widget class="QLabel" name="labelPragmaLockingMode">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Locking Mode &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_locking_mode&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Locking Mode &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_locking_mode&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -436,12 +436,12 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaLockingMode">
               <item>
                <property name="text">
-                <string notr="true">Normal</string>
+                <string>Normal</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Exclusive</string>
+                <string>Exclusive</string>
                </property>
               </item>
              </widget>
@@ -449,7 +449,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="10" column="0">
              <widget class="QLabel" name="labelPragmaMaxPageCount">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Max Page Count &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_max_page_count&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Max Page Count &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_max_page_count&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -469,7 +469,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="11" column="0">
              <widget class="QLabel" name="labelPragmaPageSize">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Page Size &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_page_size&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Page Size &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_page_size&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -526,7 +526,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="12" column="0">
              <widget class="QLabel" name="labelPragmaRecursiveTriggers">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recursive Triggers &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_recursive_triggers&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Recursive Triggers &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_recursive_triggers&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -546,7 +546,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="13" column="0">
              <widget class="QLabel" name="labelPragmaSecureDelete">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Secure Delete &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_secure_delete&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Secure Delete &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_secure_delete&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -566,7 +566,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="14" column="0">
              <widget class="QLabel" name="labelPragmaSynchronous">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Synchronous &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_synchronous&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Synchronous &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_synchronous&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -580,17 +580,17 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaSynchronous">
               <item>
                <property name="text">
-                <string notr="true">Off</string>
+                <string>Off</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Normal</string>
+                <string>Normal</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Full</string>
+                <string>Full</string>
                </property>
               </item>
              </widget>
@@ -598,7 +598,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="15" column="0">
              <widget class="QLabel" name="labelPragmaTempStore">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Temp Store &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_temp_store&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Temp Store &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_temp_store&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -612,17 +612,17 @@ You can drag SQL statements from an object row and drop them into other applicat
              <widget class="QComboBox" name="comboboxPragmaTempStore">
               <item>
                <property name="text">
-                <string notr="true">Default</string>
+                <string>Default</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">File</string>
+                <string>File</string>
                </property>
               </item>
               <item>
                <property name="text">
-                <string notr="true">Memory</string>
+                <string>Memory</string>
                </property>
               </item>
              </widget>
@@ -630,7 +630,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="16" column="0">
              <widget class="QLabel" name="labelPragmaUserVersion">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;User Version &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_user_version&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;User Version &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_user_version&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>
@@ -650,7 +650,7 @@ You can drag SQL statements from an object row and drop them into other applicat
             <item row="17" column="0">
              <widget class="QLabel" name="labelPragmaWalAutoCheckpoint">
               <property name="text">
-               <string notr="true">&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WAL Auto Checkpoint &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_wal_autocheckpoint&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;WAL Auto Checkpoint &lt;a href=&quot;https://www.sqlite.org/pragma.html#pragma_wal_autocheckpoint&quot;&gt;&lt;img src=&quot;:/icons/whatis&quot;/&gt;&lt;/a&gt;&lt;/a&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
               <property name="openExternalLinks">
                <bool>true</bool>


### PR DESCRIPTION
Currently, these strings cannot be translated and are always in English, regardless of the user's language.