### PR TITLE
Fix freeze/deadlock after aborted pragma

### DIFF
--- a/src/RunSql.cpp
+++ b/src/RunSql.cpp
@@ -137,6 +137,7 @@ bool RunSql::executeNextStatement()
                 } else {
                     // Abort
                     emit statementErrored(tr("Execution aborted by user"), execute_current_position, execute_current_position + (query_type == PragmaStatement ? 5 : 6));
+                    releaseDbAccess();
                     return false;
                 }
             }


### PR DESCRIPTION
This is a proposed fix for [#3741](https://github.com/sqlitebrowser/sqlitebrowser/issues/3741).
(I stumbled upon this when using `pragma legacy_alter_table=1` as a workaround for [#1686](https://github.com/sqlitebrowser/sqlitebrowser/issues/1686), *after* I had added a few rows to a table.)

When saving, the GUI thread blocks on `DBBrowserDB::waitForDbRelease` line 847, where it waits for `db_used` to become `false`. This must be done by `~db_pointer_type` (`DatabaseReleaser`).

In `RunSql::executeNextStatement` this deleter is normally invoked by `RunSql::releaseDbAccess`, but in the case of a pragma statement on a dirty DB, the function exits early (line 140) without calling `releaseDbAccess`. This creates a deadlock, as `db_used` is never set to `false` - thus hindering the GUI thread from accepting any user input.

Calling the aforementioned method before returning resolved the issue for me. I'm neither familiar with the `sqlitebrowser` codebase nor with C++ in general, so this probably isn't the best solution.