### PR TITLE
Reduce foreign key layout margins

### DIFF
--- a/src/ForeignKeyEditorDelegate.cpp
+++ b/src/ForeignKeyEditorDelegate.cpp
@@ -29,6 +29,7 @@ public:
         layout->addWidget(clauseEdit);
         layout->addWidget(m_btnReset);
         layout->setSpacing(0);
+        layout->setContentsMargins(0, 0, 0, 0);
         setLayout(layout);
 
         connect(m_btnReset, &QPushButton::clicked, this, [&]


### PR DESCRIPTION
Hello. Currently, the child widgets of the `ForeignKeyEditor` are displayed in a shrunk form:

![screenshot](https://github.com/user-attachments/assets/c9d54eb9-bad9-4a2e-bd8a-f0e7db1a4c2e)

This PR sets layout margins to 0 to avoid shrinking the `ForeignKeyEditor`'s child widgets.
Something similar was previously implemented using `setMargin` and was disabled in #3711 because `setMargin` was deprecated.