### PR TITLE
Add 'Check for Updates' menu

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -213,7 +213,7 @@ private slots:
     void saveSqlResultsAsJson();
     void saveSqlResultsAsView();
     void loadExtension();
-    void checkNewVersion(const QString& versionstring, const QString& url);
+    void checkNewVersion(const bool silent);
     void openLinkWiki() const;
     void openLinkBugReport() const;
     void openLinkFeatureRequest() const;

--- a/src/MainWindow.ui
+++ b/src/MainWindow.ui
@@ -1211,6 +1211,7 @@ You can drag SQL statements from an object row and drop them into other applicat
     <addaction name="actionDonatePatreon"/>
     <addaction name="separator"/>
     <addaction name="helpAboutAction"/>
+    <addaction name="actionCheck_for_Updates"/>
    </widget>
    <widget class="QMenu" name="menuTools">
     <property name="title">
@@ -2697,6 +2698,11 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
    </property>
    <property name="toolTip">
     <string>Reload the database structure</string>
+   </property>
+  </action>
+  <action name="actionCheck_for_Updates">
+   <property name="text">
+    <string>Check for Updates...</string>
    </property>
   </action>
  </widget>
@@ -4302,6 +4308,22 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
     </hint>
    </hints>
   </connection>
+  <connection>
+   <sender>actionCheck_for_Updates</sender>
+   <signal>triggered(bool)</signal>
+   <receiver>MainWindow</receiver>
+   <slot>checkNewVersion(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>518</x>
+     <y>314</y>
+    </hint>
+   </hints>
+  </connection>
  </connections>
  <slots>
   <slot>fileOpen()</slot>
@@ -4371,5 +4393,6 @@ You can drag SQL statements from the Schema column and drop them into the SQL ed
   <slot>openLinkSqlCipherFaq()</slot>
   <slot>openLinkWebsite()</slot>
   <slot>openLinkDonatePatreon()</slot>
+  <slot>checkNewVersion(bool)</slot>
  </slots>
 </ui>


### PR DESCRIPTION
This PR adds a menu for users to manually check for the latest updates. While there was already an automatic check for updates, there was previously no way for users to check again if they decided to ignore an update. Related: #3788

It may come off as a bit rude or presumptuous,
but this PR simply relocates existing code and adds a few lines, so I won’t be detailing the changes extensively. If there are any parts that need clarification, please let me know in the comments, and I’ll be happy to provide a detailed response.

However, the reason I'm requesting a review for this change as a PR is that I have the following two questions for myself.
https://github.com/sqlitebrowser/sqlitebrowser/blob/5ff87937c16b82e02c2ba774e9df7373b996ad82/src/MainWindow.cpp#L116-L125
1. Why didn’t we define the code I relocated right within the checkNewVersion function from the start? Of course, it can be defined separately, and **I fully respect that choice**. However, what I'm really wondering is whether there might be something related to network communication that I’m not aware of.

https://github.com/sqlitebrowser/sqlitebrowser/blob/c6ce01b3c5702db28f79ea95a506b8eb2f5edd95/src/MainWindow.h#L216
2. Would it be a good idea to change the name of the "silent" variable to "manual"?

Any comments and review are welcome. Thanks :)

> Confirmed to work in the Ubuntu 24.04 environment.