### PR TITLE
Correct snap nightlies's channel name to 'edge'

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ or this command:
 
 #### Snap Nightlies
 
-     snap install sqlitebrowser --devmode
+     snap install sqlitebrowser --edge
 
 #### Snap Stable
 


### PR DESCRIPTION
There is a mistake in the description of snap nightlies.

**--devmode** refers to the parameter that should be used when testing locally built snaps. 

And the ngihtly build version I think should refer to the edge channel.

See: https://snapcraft.io/docs/install-modes#developer-mode