### PR TITLE
change duplicateRecord sortcut Ctrl+Shift+D

### DIFF
--- a/src/TableBrowser.cpp
+++ b/src/TableBrowser.cpp
@@ -82,7 +82,7 @@ TableBrowser::TableBrowser(DBBrowserDB* _db, QWidget* parent) :
     });
 
     // Set up shortcuts
-    QShortcut* dittoRecordShortcut = new QShortcut(QKeySequence("Ctrl+\""), this);
+    QShortcut* dittoRecordShortcut = new QShortcut(QKeySequence("Ctrl+Shift+D"), this);
     connect(dittoRecordShortcut, &QShortcut::activated, this, [this]() {
         int currentRow = ui->dataTable->currentIndex().row();
         duplicateRecord(currentRow);


### PR DESCRIPTION
Changed shortcut for duplicate record, from " Ctrl + " " to "Ctrl + Shift + D". Tested OK.