### PR TITLE
add ; to CREATE TABLE statement for Copy Create statement

### DIFF
--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -2013,6 +2013,7 @@ void DBBrowserDB::updateSchema()
             if(!val_sql.empty())
             {
                 val_sql.erase(std::remove(val_sql.begin(), val_sql.end(), '\r'), val_sql.end());
+                val_sql += ";";
 
                 if(val_type == "table" || val_type == "view")
                 {


### PR DESCRIPTION
Before this, if you copied and pasted the Database Structure - Table items multiple times and tried to execute SQL statements, you would get syntax errors due to missing ;.