### PR TITLE
fix building tests for Windows

### DIFF
--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -1,5 +1,9 @@
 include_directories("${CMAKE_CURRENT_BINARY_DIR}" ..)
 
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
 find_package(${QT_MAJOR} REQUIRED COMPONENTS Test Widgets)
 if(QT_MAJOR STREQUAL "Qt6")
     find_package(Qt6 REQUIRED COMPONENTS Core5Compat)


### PR DESCRIPTION
This will avoid Linker Tools Error LNK2019 in VS 2022.
Perhaps we should have an updated documentation for building & testing in Windows, it's still a pain to do.