### PR TITLE
CorrectToNearestValue for spinPrefetchSize

### DIFF
--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -684,6 +684,9 @@ in new project file</string>
          </item>
          <item row="3" column="1">
           <widget class="QSpinBox" name="spinPrefetchSize">
+           <property name="correctionMode">
+            <enum>QAbstractSpinBox::CorrectionMode::CorrectToNearestValue</enum>
+           </property>
            <property name="minimum">
             <number>255</number>
            </property>


### PR DESCRIPTION
I want it to take the minimum allowed value (255) instead of reverting to its original state, as though modification is not allowed, when I input like 100.