### PR TITLE
Avoid touching the Modified asterisk marker on Execute SQL tabs

### DIFF
--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -244,6 +244,7 @@ private slots:
     void openUrlOrFile(const QString& urlString);
     void newRowCountsTab();
 
+    void markTabsModified();
     int openSqlTab(bool resetCounter = false);
     void closeSqlTab(int index, bool force = false, bool askSaving = true);
     void changeSqlTab(int index);


### PR DESCRIPTION
Prevent the marker from being presented and used by tabs renaming, cloning and project file saving.