### PR TITLE
Turkish language support

### DIFF
--- a/src/translations/sqlb_tr.ts
+++ b/src/translations/sqlb_tr.ts
@@ -11,12 +11,12 @@
     <message>
         <location filename="../AboutDialog.ui" line="29"/>
         <source>Version</source>
-        <translation>Versiyon</translation>
+        <translation>Sürüm</translation>
     </message>
     <message>
         <location filename="../AboutDialog.ui" line="90"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DB Browser for SQLite is an open source, freeware visual tool used to create, design and edit SQLite database files.&lt;/p&gt;&lt;p&gt;It is bi-licensed under the Mozilla Public License Version 2, as well as the GNU General Public License Version 3 or later. You can modify or redistribute it under the conditions of these licenses.&lt;/p&gt;&lt;p&gt;See &lt;a href=&quot;https://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://www.gnu.org/licenses/gpl.html&lt;/span&gt;&lt;/a&gt; and &lt;a href=&quot;https://www.mozilla.org/MPL/2.0/index.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://www.mozilla.org/MPL/2.0/index.txt&lt;/span&gt;&lt;/a&gt; for details.&lt;/p&gt;&lt;p&gt;For more information on this program please visit our website at: &lt;a href=&quot;https://sqlitebrowser.org&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://sqlitebrowser.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:small;&quot;&gt;This software uses the GPL/LGPL Qt Toolkit from &lt;/span&gt;&lt;a href=&quot;https://qt-project.org/&quot;&gt;&lt;span style=&quot; font-size:small; text-decoration: underline; color:#0000ff;&quot;&gt;https://qt-project.org/&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:small;&quot;&gt;&lt;br/&gt;See &lt;/span&gt;&lt;a href=&quot;https://doc.qt.io/qt-5/licensing.html&quot;&gt;&lt;span style=&quot; font-size:small; text-decoration: underline; color:#0000ff;&quot;&gt;https://doc.qt.io/qt-5/licensing.html&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:small;&quot;&gt; for licensing terms and information.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;We use the nalgeon/sqlean library for SQLite extensions support.&lt;br/&gt;This library is licensed under the MIT license, see the following for more information:&lt;br/&gt;&lt;/span&gt;&lt;a href=&quot;https://github.com/nalgeon/sqlean&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/nalgeon/sqlean&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:small;&quot;&gt;It also uses the Pastel SVG icon set by Michael Buckley under a Creative Commons Attribution Share Alike 4.0 license.&lt;br/&gt;See &lt;/span&gt;&lt;a href=&quot;https://codefisher.org/pastel-svg/&quot;&gt;&lt;span style=&quot; font-size:small; text-decoration: underline; color:#0000ff;&quot;&gt;https://codefisher.org/pastel-svg/&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:small;&quot;&gt; for details.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;DB Browser for SQLite, SQLite veritabanı dosyaları oluşturmak, tasarlamak ve düzenlemek için kullanılan açık kaynaklı, ücretsiz bir görsel araçtır.&lt;/p&gt;&lt;p&gt;Mozilla Public License Version 2 ve GNU General Public License Version 3 veya sonraki sürümleri altında çift lisanslıdır. Bu lisansların koşulları altında bunu değiştirebilir veya yeniden dağıtabilirsiniz.&lt;/p&gt;&lt;p&gt;Ayrıntılar için &lt;a href=&quot;https://www.gnu.org/licenses/gpl.html&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://www.gnu.org/licenses/gpl.html&lt;/span&gt;&lt;/a&gt; ve &lt;a href=&quot;https://www.mozilla.org/MPL/2.0/index.txt&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://www.mozilla.org/MPL/2.0/index.txt&lt;/span&gt;&lt;/a&gt; adreslerine bakın.&lt;/p&gt;&lt;p&gt;Bu program hakkında daha fazla bilgi için lütfen web sitemizi ziyaret edin: &lt;a href=&quot;https://sqlitebrowser.org&quot;&gt;&lt;span style=&quot; text-decoration: underline; color:#0000ff;&quot;&gt;https://sqlitebrowser.org&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:small;&quot;&gt;Bu yazılım, lisanslama koşulları ve diğer bilgiler için &lt;/span&gt;&lt;a href=&quot;https://qt-project.org/&quot;&gt;&lt;span style=&quot; font-size:small; text-decoration: underline; color:#0000ff;&quot;&gt;https://qt-project.org/&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:small;&quot;&gt;&lt;br/&gt;https://doc.qt.io/qt-5/licensing.html&quot;&gt;&lt;span style=&quot; font-size:small; text-decoration: underline; color:#0000ff;&quot;&gt;https://doc.qt.io/qt-5/licensing.html&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:small;&quot;&gt; adresine bakın&lt;/span&gt;&lt;a href=&quot;https://doc.qt.io/qt-5/licensing.html&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:small;&quot;&gt; bilgi.&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;SQLite uzantılarını desteklemek için nalgeon/sqlean kütüphanesini kullanıyoruz.&lt;br/&gt;Bu kütüphane MIT lisansı altında lisanslanmıştır, daha fazla bilgi için aşağıdakilere bakın:&lt;br/&gt;&lt;/span&gt;&lt;a href=&quot;https://github.com/nalgeon/sqlean&quot;&gt;&lt;span style=&quot; font-size:8pt; text-decoration: underline; color:#0000ff;&quot;&gt;https://github.com/nalgeon/sqlean&lt;/span&gt;&lt;/a&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-size:small;&quot;&gt;Ayrıca, Creative Commons Atıf-Benzer Paylaşım 4.0 lisansı altında Michael Buckley tarafından oluşturulan Pastel SVG simge setini kullanır.&lt;br/&gt;Bkz.&lt;/span&gt;&lt;a href=&quot;https://codefisher.org/pastel-svg/&quot;&gt;&lt;span style=&quot; font-size:small; text-decoration: underline; color:#0000ff;&quot;&gt;https://codefisher.org/pastel-svg/&lt;/span&gt;&lt;/a&gt;&lt;span style=&quot; font-size:small;&quot;&gt; ayrıntılar için.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
 </context>
 <context>
@@ -91,7 +91,7 @@
         <location filename="../AddRecordDialog.cpp" line="249"/>
         <source>Foreign key:	 %1
 </source>
-        <translation>Yabancı anahatar:	 %1
+        <translation>Yabancı anahtar:	 %1
 </translation>
     </message>
     <message>
@@ -126,12 +126,12 @@
     <message>
         <location filename="../Application.cpp" line="98"/>
         <source>The user settings file location is replaced with the argument value instead of the environment variable value.</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı ayarları dosyasının konumu, ortam değişkeni değeri yerine argüman değeriyle değiştirilir.</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="99"/>
         <source>Ignored environment variable (DB4S_SETTINGS_FILE) value: </source>
-        <translation type="unfinished"></translation>
+        <translation>Yoksayılan ortam değişkeni (DB4S_SETTINGS_FILE) değeri: </translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="220"/>
@@ -142,141 +142,141 @@
     <message>
         <location filename="../Application.cpp" line="180"/>
         <source>Usage</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanım</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="181"/>
         <source>options</source>
-        <translation type="unfinished"></translation>
+        <translation>seçenekler</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="181"/>
         <location filename="../Application.cpp" line="205"/>
         <source>database</source>
-        <translation type="unfinished"></translation>
+        <translation>veritabanı</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="181"/>
         <location filename="../Application.cpp" line="207"/>
         <source>project</source>
-        <translation type="unfinished"></translation>
+        <translation>proje</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="182"/>
         <location filename="../Application.cpp" line="209"/>
         <source>csv-file</source>
-        <translation type="unfinished"></translation>
+        <translation>csv dosyası</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="186"/>
         <source>Show command line options</source>
-        <translation type="unfinished"></translation>
+        <translation>Komut satırı seçeneklerini göster</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="188"/>
         <source>Exit application after running scripts</source>
-        <translation type="unfinished"></translation>
+        <translation>Betikleri çalıştırdıktan sonra uygulamadan çıkın</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="189"/>
         <location filename="../Application.cpp" line="191"/>
         <source>file</source>
-        <translation type="unfinished"></translation>
+        <translation>dosya</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="190"/>
         <source>Execute this SQL file after opening the DB</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını açtıktan sonra bu SQL dosyasını çalıştırın</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="192"/>
         <source>Import this CSV file into the passed DB or into a new DB</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu CSV dosyasını geçirilen veritabanına veya yeni bir veritabanına aktarın</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="193"/>
         <source>table</source>
-        <translation type="unfinished"></translation>
+        <translation>tablo</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="194"/>
         <source>Browse this table, or use it as target of a data import</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu tabloya göz atın veya bir veri içe aktarımının hedefi olarak kullanın</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="196"/>
         <source>Open database in read-only mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını salt okunur modunda aç</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="197"/>
         <source>settings_file</source>
-        <translation type="unfinished"></translation>
+        <translation>settings_file</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="198"/>
         <source>Run application based on this settings file</source>
-        <translation type="unfinished"></translation>
+        <translation>Uygulamayı bu ayar dosyasına göre çalıştır</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="199"/>
         <location filename="../Application.cpp" line="201"/>
         <source>group</source>
-        <translation type="unfinished"></translation>
+        <translation>grup</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="199"/>
         <location filename="../Application.cpp" line="201"/>
         <source>settings</source>
-        <translation type="unfinished"></translation>
+        <translation>ayarlar</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="199"/>
         <location filename="../Application.cpp" line="201"/>
         <source>value</source>
-        <translation type="unfinished"></translation>
+        <translation>değer</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="200"/>
         <source>Run application with this setting temporarily set to value</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu ayarı geçici değere ayarlayarak uygulamayı çalıştırın</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="202"/>
         <source>Run application saving this value for this setting</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu ayar için bu değeri kaydederek uygulamayı çalıştırın</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="204"/>
         <source>Display the current version</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut sürümü görüntüle</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="206"/>
         <source>Open this SQLite database</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu SQLite veritabanını açın</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="208"/>
         <source>Open this project file (*.sqbpro)</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu proje dosyasını açın (*.sqbpro)</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="210"/>
         <source>Import this CSV file into an in-memory database</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu CSV dosyasını bellek içi bir veritabanına aktarın</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="218"/>
         <location filename="../Application.cpp" line="225"/>
         <location filename="../Application.cpp" line="230"/>
         <source>The %1 option requires an argument</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 seçeneği bir argüman gerektirir</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="243"/>
         <source>The -S/--settings option requires an argument. The option is ignored.</source>
-        <translation type="unfinished"></translation>
+        <translation>-S/--settings seçeneği bir argüman gerektirir. Seçenek yok sayılır.</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="246"/>
@@ -291,32 +291,32 @@
     <message>
         <location filename="../Application.cpp" line="365"/>
         <source>SQLite Version </source>
-        <translation type="unfinished">SQLite Versiyonu </translation>
+        <translation>SQLite Versiyonu </translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="367"/>
         <source>SQLCipher Version %1 (based on SQLite %2)</source>
-        <translation type="unfinished"></translation>
+        <translation>SQLCipher Sürümü %1 (%2 SQLite&apos;a dayalı)</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="370"/>
         <source>DB Browser for SQLite Version %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>DB Browser for SQLite Versiyon %1.</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="371"/>
         <source>Last commit hash when built: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Derleme sırasında son commit karma değeri: %1</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="372"/>
         <source>Built for %1, running on %2</source>
-        <translation type="unfinished">%1 için derlendi, %2 üzerinde çalışıyor</translation>
+        <translation>%1 için derlendi, %2 üzerinde çalışıyor</translation>
     </message>
     <message>
         <location filename="../Application.cpp" line="373"/>
         <source>Qt Version %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Qt Sürümü %1</translation>
     </message>
 </context>
 <context>
@@ -379,7 +379,7 @@
     <message>
         <location filename="../CipherDialog.ui" line="224"/>
         <source>Plaintext Header Size</source>
-        <translation>Düz Metin Üstbilgi Boyutu</translation>
+        <translation>Düz Metin Üst Bilgi Boyutu</translation>
     </message>
     <message>
         <location filename="../CipherDialog.ui" line="66"/>
@@ -415,17 +415,17 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../ColumnDisplayFormatDialog.ui" line="14"/>
         <source>Choose display format</source>
-        <translation>Görüntüleme formatını seçiniz</translation>
+        <translation>Görüntüleme formatını seçin</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.ui" line="20"/>
         <source>Display format</source>
-        <translation>Görüntüleme formatı</translation>
+        <translation>Formatı görüntüle</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.ui" line="26"/>
         <source>Choose a display format for the column &apos;%1&apos; which is applied to each value prior to showing it.</source>
-        <translation>&apos;%1&apos; sütunu için görüntülemeden önce uygulanacak bir görüntüleme formatı seçin.</translation>
+        <translation>Her değer gösterilmeden önce, &apos;%1&apos; sütunu için uygulanacak bir görüntüleme biçimi seçin.</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="19"/>
@@ -445,7 +445,7 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="23"/>
         <source>Hex blob</source>
-        <translation>Onaltılık ikili veri</translation>
+        <translation>Onaltılık blob</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="24"/>
@@ -465,7 +465,7 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="30"/>
         <source>.NET DateTime.Ticks to date</source>
-        <translation type="unfinished"></translation>
+        <translation>.NET DateTime.Ticks tarihine</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="31"/>
@@ -480,12 +480,12 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="34"/>
         <source>WebKit / Chromium epoch to date</source>
-        <translation type="unfinished"></translation>
+        <translation>WebKit / Chromium&apos;un bugüne kadarki tarihi</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="35"/>
         <source>WebKit / Chromium epoch to local time</source>
-        <translation type="unfinished"></translation>
+        <translation>WebKit / Chromium dönemi yerel zamana göre</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="37"/>
@@ -500,12 +500,12 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="42"/>
         <source>Binary GUID to text</source>
-        <translation type="unfinished"></translation>
+        <translation>İkili GUID&apos;den metne</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="43"/>
         <source>SpatiaLite Geometry to SVG</source>
-        <translation type="unfinished"></translation>
+        <translation>SpatiaLite Geometriden SVG&apos;ye</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="147"/>
@@ -534,7 +534,7 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="26"/>
         <source>Round number</source>
-        <translation>Küsüratsız sayı</translation>
+        <translation>Küsuratsız sayı</translation>
     </message>
     <message>
         <location filename="../ColumnDisplayFormatDialog.cpp" line="32"/>
@@ -587,7 +587,7 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../CondFormatManager.ui" line="55"/>
         <source>&amp;Remove</source>
-        <translation>&amp;Sil</translation>
+        <translation>Kaldı&amp;r</translation>
     </message>
     <message>
         <location filename="../CondFormatManager.ui" line="72"/>
@@ -607,7 +607,7 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../CondFormatManager.ui" line="95"/>
         <source>Move &amp;down</source>
-        <translation>Aşağı &amp;Taşı</translation>
+        <translation>Aşağı &amp;taşı</translation>
     </message>
     <message>
         <location filename="../CondFormatManager.ui" line="158"/>
@@ -617,7 +617,7 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../CondFormatManager.ui" line="161"/>
         <source>Text color</source>
-        <translation>Yazı rengi</translation>
+        <translation>Metin rengi</translation>
     </message>
     <message>
         <location filename="../CondFormatManager.ui" line="166"/>
@@ -696,7 +696,7 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../sqlitedb.cpp" line="883"/>
         <source>Exporting database to SQL file...</source>
-        <translation>veritabanı, SQL dosyası olarak dışa aktarılıyor...</translation>
+        <translation>Veritabanı, SQL dosyası olarak dışa aktarılıyor...</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="884"/>
@@ -727,13 +727,13 @@ Bu veritabanı için herhangi bir başka ayar daha yapılmışsa, bu bilgileri d
     <message>
         <location filename="../sqlitedb.cpp" line="760"/>
         <source>Cannot open destination file: &apos;%1&apos;</source>
-        <translation type="unfinished"></translation>
+        <translation>Hedef dosya açılamıyor: &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="777"/>
         <location filename="../sqlitedb.cpp" line="795"/>
         <source>Cannot backup to file: &apos;%1&apos;. Message: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyaya yedekleme yapılamıyor: &apos;%1&apos;. Mesaj: %2</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="835"/>
@@ -805,37 +805,37 @@ Yürütme durduruluyor %3.</translation>
     <message>
         <location filename="../sqlitedb.cpp" line="1676"/>
         <source>Creating savepoint failed. DB says: %1</source>
-        <translation>Kayıt noktası oluşturulamadı. Veritabanı mesajı: %1</translation>
+        <translation>Kayıt noktası oluşturulamadı. DB mesajı: %1</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="1739"/>
         <source>Renaming the column failed. DB says:
 %1</source>
-        <translation>Sütun yeniden adlandırılamadı. Veritabanı motoru mesajı:
+        <translation>Sütun yeniden adlandırılamadı. DB mesajı:
 %1</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="1767"/>
         <location filename="../sqlitedb.cpp" line="1929"/>
         <source>Releasing savepoint failed. DB says: %1</source>
-        <translation>Kayıt noktası serbest bırakılamadı. Veritabanı motoru mesajı: %1</translation>
+        <translation>Kayıt noktasının serbest bırakılması başarısız. DB mesajı: %1</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="1786"/>
         <source>Creating new table failed. DB says: %1</source>
-        <translation>Veri tabanı oluşturulamadı. Veritabanı mesajı: %1</translation>
+        <translation>Veritabanı oluşturulamadı. DB mesajı: %1</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="1823"/>
         <source>Copying data to new table failed. DB says:
 %1</source>
-        <translation>Yeni tabloya veri kopyalanamadı. Veritabanı mesajı:
+        <translation>Yeni tabloya veri kopyalanamadı. DB mesajı:
 %1</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="1895"/>
         <source>Deleting old table failed. DB says: %1</source>
-        <translation>Eski tablolar silinemedi: Veritabanı mesajı: %1</translation>
+        <translation>Eski tablolar silinemedi: DB mesajı: %1</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="1965"/>
@@ -863,7 +863,7 @@ Veritabanı motoru mesajı:
     <message>
         <location filename="../sqlitedb.cpp" line="2067"/>
         <source>could not get list of databases: %1</source>
-        <translation>veri tabanı listesi alınamadı: %1</translation>
+        <translation>veritabanı listesi alınamadı: %1</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="2179"/>
@@ -873,7 +873,7 @@ Veritabanı motoru mesajı:
     <message>
         <location filename="../sqlitedb.cpp" line="2188"/>
         <source>Error loading built-in extension: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerleşik uzantı yüklenirken hata oluştu: %1</translation>
     </message>
     <message>
         <location filename="../sqlitedb.cpp" line="2214"/>
@@ -906,7 +906,7 @@ Veritabanı motoru mesajı:
     <message>
         <location filename="../DbStructureModel.cpp" line="22"/>
         <source>Type</source>
-        <translation>Tip</translation>
+        <translation>Tür</translation>
     </message>
     <message>
         <location filename="../DbStructureModel.cpp" line="22"/>
@@ -941,7 +941,7 @@ Veritabanı motoru mesajı:
     <message>
         <location filename="../DbStructureModel.cpp" line="356"/>
         <source>Indices (%1)</source>
-        <translation>İndisler (%1)</translation>
+        <translation>İndeksler (%1)</translation>
     </message>
     <message>
         <location filename="../DbStructureModel.cpp" line="361"/>
@@ -995,7 +995,7 @@ Veritabanı motoru mesajı:
     <message>
         <location filename="../EditDialog.ui" line="96"/>
         <source>Evaluation</source>
-        <translation type="unfinished"></translation>
+        <translation>Değerlendirme</translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="104"/>
@@ -1016,22 +1016,22 @@ Veritabanı motoru mesajı:
     <message>
         <location filename="../EditDialog.ui" line="176"/>
         <source>This Qt editor is used for right-to-left scripts, which are not supported by the default Text editor. The presence of right-to-left characters is detected and this editor mode is automatically selected.</source>
-        <translation>Qt editör, varsayılan metin editörü tarafından desteklenmeyen  sağdan sola okunan dillde yazılmış betikleri için kullanılır.</translation>
+        <translation>Qt editör, varsayılan metin editörü tarafından desteklenmeyen  sağdan sola okunan dillde yazılmış betikler için kullanılır.</translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="203"/>
         <source>Identification of the cell currently in the editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Şu anda düzenleyicide bulunan hücrenin tanımlanması</translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="225"/>
         <source>Type and size of data currently in table</source>
-        <translation type="unfinished"></translation>
+        <translation>Tabloda şu anda bulunan verilerin türü ve boyutu</translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="274"/>
         <source>Open preview dialog for printing the data currently stored in the cell</source>
-        <translation>Şu anda hücrede saklanan veriyi yazdırmak için önizleme penceresini aç</translation>
+        <translation>Şu anda hücrede saklanan veriyi yazdırmak için ön izleme penceresini aç</translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="310"/>
@@ -1136,7 +1136,7 @@ Veritabanı motoru mesajı:
     <message>
         <location filename="../EditDialog.ui" line="271"/>
         <source>Open preview dialog for printing displayed text</source>
-        <translation>Görüntülenen yazıyı yazdırmak için önizleme penceresini aç</translation>
+        <translation>Görüntülenen metni yazdırmak için ön izleme penceresini aç</translation>
     </message>
     <message>
         <location filename="../EditDialog.ui" line="289"/>
@@ -1211,28 +1211,33 @@ Veritabanı motoru mesajı:
 Errors are indicated with a red squiggle underline.
 
 In the Evaluation mode, entered SQLite expressions are evaluated and the result applied to the cell.</source>
-        <translation type="unfinished"></translation>
+        <translation>Metin düzenleyici modları, sözdizimi vurgulama, otomatik biçimlendirme ve kaydetmeden önce doğrulama ile düz metinlerin yanı sıra JSON veya XML verilerini düzenlemenize olanak tanır.
+
+Hatalar kırmızı kıvrımlı alt çizgiyle gösterilir.
+
+Değerlendirme modunda, girilen SQLite ifadeleri değerlendirilir ve sonuç hücreye uygulanır.</translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="122"/>
         <source>Unsaved data in the cell editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Hücre düzenleyicide kaydedilmemiş veriler</translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="123"/>
         <source>The cell editor contains data not yet applied to the database.
 Do you want to apply the edited data to row=%1, column=%2?</source>
-        <translation type="unfinished"></translation>
+        <translation>Hücre düzenleyicisi henüz veritabanına uygulanmamış veriler içeriyor.
+Düzenlenen verileri satır=%1, sütun=%2&apos;ye uygulamak ister misiniz?</translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="148"/>
         <source>Editing row=%1, column=%2</source>
-        <translation type="unfinished"></translation>
+        <translation>Satır=%1, sütun=%2 düzenleniyor</translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="151"/>
         <source>No cell active.</source>
-        <translation type="unfinished"></translation>
+        <translation>Hiçbir hücre aktif değil.</translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="302"/>
@@ -1267,44 +1272,44 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
         <location filename="../EditDialog.cpp" line="925"/>
         <location filename="../EditDialog.cpp" line="1105"/>
         <source>Type: NULL; Size: 0 bytes</source>
-        <translation type="unfinished"></translation>
+        <translation>Tür: NULL; Boyut: 0 bayt</translation>
     </message>
     <message numerus="yes">
         <location filename="../EditDialog.cpp" line="927"/>
         <location filename="../EditDialog.cpp" line="1117"/>
         <source>Type: Text / Numeric; Size: %n character(s)</source>
-        <translation type="unfinished">
+        <translation>
             <numerusform></numerusform>
         </translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="1091"/>
         <source>Type: %1 Image; Size: %2x%3 pixel(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tür: %1 Görüntü; Boyut: %2x%3 piksel</translation>
     </message>
     <message numerus="yes">
         <location filename="../EditDialog.cpp" line="1124"/>
         <source>Type: Valid JSON; Size: %n character(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Tür: Geçerli JSON; Boyut: %n karakter</numerusform>
         </translation>
     </message>
     <message numerus="yes">
         <location filename="../EditDialog.cpp" line="1132"/>
         <source>Type: Binary; Size: %n byte(s)</source>
-        <translation type="unfinished">
-            <numerusform></numerusform>
+        <translation>
+            <numerusform>Tür: İkili; Boyut: %n bayt</numerusform>
         </translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="438"/>
         <source>Choose a file to import</source>
-        <translation>İçe aktarmak için dosya seçiniz</translation>
+        <translation>İçe aktarmak için dosya seçin</translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="477"/>
         <source>%1 Image</source>
-        <translation>%1 imajı</translation>
+        <translation>%1 Görüntü</translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="581"/>
@@ -1319,12 +1324,12 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditDialog.cpp" line="1275"/>
         <source>Couldn&apos;t save file: %1.</source>
-        <translation type="unfinished">Dosya kaydedilemedi: %1.</translation>
+        <translation>Dosya kaydedilemedi: %1.</translation>
     </message>
     <message>
         <location filename="../EditDialog.cpp" line="1300"/>
         <source>The data has been saved to a temporary file and has been opened with the default application. You can now edit the file and, when you are ready, apply the saved new data to the cell or cancel any changes.</source>
-        <translation type="unfinished"></translation>
+        <translation>Veriler geçici bir dosyaya kaydedildi ve varsayılan uygulamayla açıldı. Artık dosyayı düzenleyebilir ve hazır olduğunuzda kaydedilen yeni verileri hücreye uygulayabilir veya değişiklikleri iptal edebilirsiniz.</translation>
     </message>
 </context>
 <context>
@@ -1347,7 +1352,7 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditIndexDialog.ui" line="14"/>
         <source>Edit Index Schema</source>
-        <translation>Index Şemasını Düzenle</translation>
+        <translation>İndeks Şemasını Düzenle</translation>
     </message>
     <message>
         <location filename="../EditIndexDialog.ui" line="52"/>
@@ -1357,12 +1362,12 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditIndexDialog.ui" line="69"/>
         <source>For restricting the index to only a part of the table you can specify a WHERE clause here that selects the part of the table that should be indexed</source>
-        <translation>Index&apos;i tablonun yalnızca bir bölümüyle sınırlamak için, burada tablonun dizine alınması gereken kısmını seçen bir WHERE deyimi belirtebilirsiniz</translation>
+        <translation>İndeksi tablonun yalnızca bir bölümüyle sınırlamak için, burada tablonun dizine alınması gereken kısmını seçen bir WHERE deyimi belirtebilirsiniz</translation>
     </message>
     <message>
         <location filename="../EditIndexDialog.ui" line="72"/>
         <source>Partial inde&amp;x clause</source>
-        <translation>Kısmi inde&amp;x hükmü</translation>
+        <translation>Kısmi inde&amp;ks hükmü</translation>
     </message>
     <message>
         <location filename="../EditIndexDialog.ui" line="85"/>
@@ -1377,23 +1382,23 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditIndexDialog.ui" line="135"/>
         <source>Type</source>
-        <translation>Tip</translation>
+        <translation>Tür</translation>
     </message>
     <message>
         <location filename="../EditIndexDialog.ui" line="172"/>
         <source>Add a new expression column to the index. Expression columns contain SQL expression rather than column names.</source>
-        <translation>Index için yeni bir ifade sütunu ekleyin. İfade sütunları, sütun adları değil SQL ifadesi içerir.</translation>
+        <translation>İndeks için yeni bir ifade sütunu ekleyin. İfade sütunları, sütun adları değil SQL ifadesi içerir.</translation>
     </message>
     <message>
         <location filename="../EditIndexDialog.ui" line="232"/>
         <source>Index column</source>
-        <translation>Index sütunu</translation>
+        <translation>İndeks sütunu</translation>
     </message>
     <message>
         <location filename="../EditIndexDialog.cpp" line="270"/>
         <source>Deleting the old index failed:
 %1</source>
-        <translation>Eski index silinemedi:
+        <translation>Eski indeks silinemedi:
 %1</translation>
     </message>
     <message>
@@ -1423,32 +1428,32 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditTableDialog.ui" line="75"/>
         <source>Without Rowid</source>
-        <translation>Satır ID(Rowid) Kullanma</translation>
+        <translation>Rowid olmadan</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="62"/>
         <source>Database sche&amp;ma</source>
-        <translation>Veritabanı &amp;Şeması</translation>
+        <translation>Veritabanı şe&amp;ması</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="85"/>
         <source>Make this a &apos;WITHOUT ROWID&apos; table. Setting this flag requires specifying a PRIMARY KEY (which can be of any type, and can be composite), and forbids the AUTOINCREMENT flag.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bunu &apos;WITHOUT ROWID&apos; tablosu yapın. Bu bayrağı ayarlamak, bir PRIMARY KEY (herhangi bir türde ve bileşik olabilir) belirtmeyi gerektirir ve AUTOINCREMENT bayrağını yasaklar.</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="92"/>
         <source>On Conflict</source>
-        <translation type="unfinished"></translation>
+        <translation>On Conflict</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="133"/>
         <source>Strict</source>
-        <translation type="unfinished"></translation>
+        <translation>Strict</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="143"/>
         <source>When the strict option is enabled SQLite enforces the data types of each column when updating or inserting data.</source>
-        <translation type="unfinished"></translation>
+        <translation>Strict seçeneği etkinleştirildiğinde SQLite, veri güncellerken veya eklerken her sütunun veri türlerini uygular.</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="164"/>
@@ -1467,12 +1472,12 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
         <location filename="../EditTableDialog.ui" line="532"/>
         <location filename="../EditTableDialog.ui" line="622"/>
         <source>Remove</source>
-        <translation>Sil</translation>
+        <translation>Kaldır</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="212"/>
         <source>Move to top</source>
-        <translation>En yukarı taşı</translation>
+        <translation>En üste taşı</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="235"/>
@@ -1487,7 +1492,7 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditTableDialog.ui" line="275"/>
         <source>Move to bottom</source>
-        <translation>En aşağı taşı</translation>
+        <translation>En alta taşı</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="332"/>
@@ -1501,7 +1506,7 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
         <location filename="../EditTableDialog.ui" line="337"/>
         <location filename="../EditTableDialog.ui" line="482"/>
         <source>Type</source>
-        <translation>Tip</translation>
+        <translation>Tür</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="342"/>
@@ -1511,17 +1516,17 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditTableDialog.ui" line="345"/>
         <source>Not null</source>
-        <translation>NULL Olamaz</translation>
+        <translation>NULL değil</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="350"/>
         <source>PK</source>
-        <translation>Birincil Anahtar</translation>
+        <translation>PK</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="353"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/field_key&quot;/&gt; Primary key&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/field_key&quot;/&gt; Birincil anahtar&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="358"/>
@@ -1536,7 +1541,7 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditTableDialog.ui" line="366"/>
         <source>U</source>
-        <translation>Benzersiz</translation>
+        <translation>U</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="369"/>
@@ -1564,7 +1569,7 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditTableDialog.ui" line="385"/>
         <source>Check constraint</source>
-        <translation>Kısıtlama Kontrol</translation>
+        <translation>Kısıtlama kontrolü</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="390"/>
@@ -1579,12 +1584,12 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditTableDialog.ui" line="398"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/field_fk&quot;/&gt; Foreign Key&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;img src=&quot;:/icons/field_fk&quot;/&gt; Yabancı Anahtar&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="407"/>
         <source>Index Constraints</source>
-        <translation type="unfinished"></translation>
+        <translation>İndeks Kısıtlamaları</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="415"/>
@@ -1612,17 +1617,17 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditTableDialog.ui" line="501"/>
         <source>Foreign Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>Yabancı Anahtarlar</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="581"/>
         <source>References</source>
-        <translation type="unfinished"></translation>
+        <translation>Referanslar</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="595"/>
         <source>Check Constraints</source>
-        <translation type="unfinished"></translation>
+        <translation>Kontrol Kısıtlamaları</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.ui" line="685"/>
@@ -1660,7 +1665,7 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
     <message>
         <location filename="../EditTableDialog.cpp" line="560"/>
         <source>There already is a field with that name. Please rename it first or choose a different name for this field.</source>
-        <translation>Bu isme sahip alan zaten var. Lütfen bu alan için farklı bir isim kullanın veya aynı isme sahip alanı yeniden adlandırın.</translation>
+        <translation>Bu isimde bir alan zaten var. Lütfen önce bu alanı yeniden adlandırın veya farklı bir isim seçin.</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.cpp" line="677"/>
@@ -1688,7 +1693,8 @@ Do you want to apply the edited data to row=%1, column=%2?</source>
         <location filename="../EditTableDialog.cpp" line="1223"/>
         <source>Please add a field which meets the following criteria before setting the on conflict action:
  - Primary key flag set</source>
-        <translation type="unfinished"></translation>
+        <translation>Lütfen çakışma eylemini ayarlamadan önce aşağıdaki ölçütleri karşılayan bir alan ekleyin:
+ - Birincil anahtar bayrağı ayarı</translation>
     </message>
     <message>
         <location filename="../EditTableDialog.cpp" line="585"/>
@@ -1721,7 +1727,7 @@ All data currently stored in this field will be lost.</source>
     <message>
         <location filename="../ExportDataDialog.ui" line="22"/>
         <source>Tab&amp;le(s)</source>
-        <translation>Tab&amp;lolar</translation>
+        <translation>Tab&amp;lo(lar)</translation>
     </message>
     <message>
         <location filename="../ExportDataDialog.ui" line="57"/>
@@ -1731,7 +1737,7 @@ All data currently stored in this field will be lost.</source>
     <message>
         <location filename="../ExportDataDialog.ui" line="77"/>
         <source>Fie&amp;ld separator</source>
-        <translation>&amp;Alan ayracı</translation>
+        <translation>A&amp;lan ayracı</translation>
     </message>
     <message>
         <location filename="../ExportDataDialog.ui" line="102"/>
@@ -1793,7 +1799,7 @@ All data currently stored in this field will be lost.</source>
     <message>
         <location filename="../ExportDataDialog.ui" line="288"/>
         <source>Pretty print</source>
-        <translation>Düzenli baskı</translation>
+        <translation>Güzel baskı</translation>
     </message>
     <message>
         <location filename="../ExportDataDialog.cpp" line="202"/>
@@ -1821,7 +1827,7 @@ All data currently stored in this field will be lost.</source>
         <location filename="../ExportDataDialog.cpp" line="195"/>
         <location filename="../ExportDataDialog.cpp" line="300"/>
         <source>Error while writing the file &apos;%1&apos;: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; dosyası yazılırken hata oluştu: %2</translation>
     </message>
     <message>
         <location filename="../ExportDataDialog.cpp" line="215"/>
@@ -1846,7 +1852,7 @@ All data currently stored in this field will be lost.</source>
     <message>
         <location filename="../ExportDataDialog.cpp" line="420"/>
         <source>Export finished with errors.</source>
-        <translation type="unfinished"></translation>
+        <translation>Dışa aktarma hatalarla tamamlandı.</translation>
     </message>
 </context>
 <context>
@@ -1859,7 +1865,7 @@ All data currently stored in this field will be lost.</source>
     <message>
         <location filename="../ExportSqlDialog.ui" line="35"/>
         <source>Tab&amp;le(s)</source>
-        <translation>Tablo&amp;lar</translation>
+        <translation>Tab&amp;lo(lar)</translation>
     </message>
     <message>
         <location filename="../ExportSqlDialog.ui" line="63"/>
@@ -1899,7 +1905,7 @@ All data currently stored in this field will be lost.</source>
     <message>
         <location filename="../ExportSqlDialog.ui" line="148"/>
         <source>Keep original CREATE statements</source>
-        <translation type="unfinished"></translation>
+        <translation>Orijinal CREATE ifadelerini koruyun</translation>
     </message>
     <message>
         <location filename="../ExportSqlDialog.ui" line="109"/>
@@ -2037,7 +2043,7 @@ All data currently stored in this field will be lost.</source>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="291"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation>Kes</translation>
     </message>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="292"/>
@@ -2052,7 +2058,7 @@ All data currently stored in this field will be lost.</source>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="294"/>
         <source>Copy as SQL</source>
-        <translation>SQL olarak Kopyala</translation>
+        <translation>SQL Olarak Kopyala</translation>
     </message>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="295"/>
@@ -2094,7 +2100,7 @@ Do you want to insert it anyway?</source>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="1214"/>
         <source>&lt;p&gt;Not all data has been loaded. &lt;b&gt;Do you want to load all data before selecting all the rows?&lt;/b&gt;&lt;p&gt;&lt;p&gt;Answering &lt;b&gt;No&lt;/b&gt; means that no more data will be loaded and the selection will not be performed.&lt;br/&gt;Answering &lt;b&gt;Yes&lt;/b&gt; might take some time while the data is loaded but the selection will be complete.&lt;/p&gt;Warning: Loading all the data might require a great amount of memory for big tables.</source>
-        <translation>&lt;p&gt; Tüm veriler yüklenmedi. &lt;b&gt;Tüm satırları seçmeden önce tüm verileri yüklemek istiyor musunuz?&lt;/b&gt; &lt;/p&gt; &lt;p&gt;&lt;/p&gt; &lt;p&gt; &lt;b&gt;Hayır&lt;/b&gt; olarak cevaplamak, tüm verileri yüklemeyecek ve seçim işlemini uygulanmayacak. &lt;br /&gt; &lt;b&gt;Evet&lt;/b&gt; seçeneği biraz zaman alabilir ama seçim işlemini gerçekleştirecektir. &lt;/p&gt; Uyarı: Tüm verilerin yüklenmesi büyük tablolar için büyük miktarda bellek gerektirebilir.</translation>
+        <translation>&lt;p&gt; Tüm veriler yüklenmedi. &lt;b&gt;Tüm satırları seçmeden önce tüm verileri yüklemek istiyor musunuz?&lt;/b&gt; &lt;/p&gt; &lt;p&gt;&lt;/p&gt; &lt;p&gt; &lt;b&gt;Hayır&lt;/b&gt; olarak cevaplamak, tüm verileri yüklemeyecek ve seçim işlemini uygulamayacak. &lt;br /&gt; &lt;b&gt;Evet&lt;/b&gt; seçeneği biraz zaman alabilir ama seçim işlemini gerçekleştirecektir. &lt;/p&gt; Uyarı: Tüm verilerin yüklenmesi büyük tablolar için büyük miktarda bellek gerektirebilir.</translation>
     </message>
     <message>
         <location filename="../ExtendedTableWidget.cpp" line="1292"/>
@@ -2127,7 +2133,7 @@ Do you want to insert it anyway?</source>
     <message>
         <location filename="../FileExtensionManager.ui" line="68"/>
         <source>&amp;Remove</source>
-        <translation>&amp;Sil</translation>
+        <translation>&amp;Kaldır</translation>
     </message>
     <message>
         <location filename="../FileExtensionManager.ui" line="94"/>
@@ -2188,7 +2194,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../FilterLineEdit.cpp" line="210"/>
         <source>Use for Conditional Format</source>
-        <translation>Koşullu Biçim için Kullan</translation>
+        <translation>Koşullu Biçim İçin Kullan</translation>
     </message>
     <message>
         <location filename="../FilterLineEdit.cpp" line="215"/>
@@ -2281,7 +2287,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../FindReplaceDialog.ui" line="43"/>
         <source>Fi&amp;nd text:</source>
-        <translation>&amp;Aranan Metin:</translation>
+        <translation>Met&amp;ni bul:</translation>
     </message>
     <message>
         <location filename="../FindReplaceDialog.ui" line="56"/>
@@ -2291,12 +2297,12 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../FindReplaceDialog.ui" line="69"/>
         <source>Match &amp;exact case</source>
-        <translation>Büyük kü&amp;çük harfe duyarlı</translation>
+        <translation>Büyük/küçük harf tam &amp;eşleşme</translation>
     </message>
     <message>
         <location filename="../FindReplaceDialog.ui" line="79"/>
         <source>Match &amp;only whole words</source>
-        <translation>Kelimenin ta&amp;mamını eşleştir</translation>
+        <translation>&amp;Sadece tam kelimeleri eşleştir</translation>
     </message>
     <message>
         <location filename="../FindReplaceDialog.ui" line="86"/>
@@ -2326,7 +2332,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../FindReplaceDialog.ui" line="109"/>
         <source>&amp;Selection only</source>
-        <translation>Sadece se&amp;çimde ara</translation>
+        <translation>Sadece se&amp;çim</translation>
     </message>
     <message>
         <location filename="../FindReplaceDialog.ui" line="116"/>
@@ -2351,7 +2357,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../FindReplaceDialog.ui" line="145"/>
         <source>F3</source>
-        <translation></translation>
+        <translation>F3</translation>
     </message>
     <message>
         <location filename="../FindReplaceDialog.ui" line="152"/>
@@ -2361,7 +2367,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../FindReplaceDialog.ui" line="159"/>
         <source>Highlight all the occurrences of the text in the page</source>
-        <translation>Eşleşen tüm kelimeleri vurgula</translation>
+        <translation>Sayfadaki metnin tüm oluşumlarını vurgula</translation>
     </message>
     <message>
         <location filename="../FindReplaceDialog.ui" line="162"/>
@@ -2371,7 +2377,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../FindReplaceDialog.ui" line="169"/>
         <source>Replace all the occurrences of the text in the page</source>
-        <translation>Sayfadaki bulunan metinlerin tümünü değiştir</translation>
+        <translation>Sayfadaki metnin tüm oluşumlarını değiştir</translation>
     </message>
     <message>
         <location filename="../FindReplaceDialog.ui" line="172"/>
@@ -2386,7 +2392,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../FindReplaceDialog.cpp" line="158"/>
         <source>The searched text was not found.</source>
-        <translation>The searched text was not found.</translation>
+        <translation>Aranan metin bulunamadı.</translation>
     </message>
     <message>
         <location filename="../FindReplaceDialog.cpp" line="164"/>
@@ -2427,32 +2433,32 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../ImageViewer.ui" line="14"/>
         <source>Image Viewer</source>
-        <translation type="unfinished"></translation>
+        <translation>İmaj Görüntüleyici</translation>
     </message>
     <message>
         <location filename="../ImageViewer.ui" line="95"/>
         <source>Reset the scaling to match the original size of the image.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ölçeklemeyi görüntünün orijinal boyutuna uyacak şekilde sıfırla.</translation>
     </message>
     <message>
         <location filename="../ImageViewer.ui" line="106"/>
         <source>Set the scaling to match the size of the viewport.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ölçeklemeyi, görünüm alanının boyutuna uyacak şekilde ayarla.</translation>
     </message>
     <message>
         <location filename="../ImageViewer.ui" line="126"/>
         <source>Print...</source>
-        <translation type="unfinished">Yazdır...</translation>
+        <translation>Yazdır...</translation>
     </message>
     <message>
         <location filename="../ImageViewer.ui" line="129"/>
         <source>Open preview dialog for printing displayed image</source>
-        <translation type="unfinished">Görüntülenen resmi yazdırmak için önizleme penceresini aç</translation>
+        <translation>Görüntülenen resmi yazdırmak için ön izleme penceresini aç</translation>
     </message>
     <message>
         <location filename="../ImageViewer.ui" line="132"/>
         <source>Ctrl+P</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+P</translation>
     </message>
 </context>
 <context>
@@ -2465,7 +2471,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../ImportCsvDialog.ui" line="25"/>
         <source>Table na&amp;me</source>
-        <translation>Tablo İs&amp;mi</translation>
+        <translation>Tablo is&amp;mi</translation>
     </message>
     <message>
         <location filename="../ImportCsvDialog.ui" line="38"/>
@@ -2578,7 +2584,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../ImportCsvDialog.ui" line="322"/>
         <source>Activate this option to stop the import when trying to import an empty value into a NOT NULL column without a default value.</source>
-        <translation>Varsayılan değeri olmayan NOT NULL kısıtına sahip bir sütuna, boş bir değer içe aktarmaya çalışırken içe aktarmayı durdurmak için bu seçeneği etkinleştirin.</translation>
+        <translation>Varsayılan değeri olmayan bir NOT NULL sütununa boş bir değer aktarmaya çalışırken aktarmayı durdurmak için bu seçeneği etkinleştirin.</translation>
     </message>
     <message>
         <location filename="../ImportCsvDialog.ui" line="329"/>
@@ -2598,12 +2604,12 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../ImportCsvDialog.ui" line="356"/>
         <source>Use local number conventions</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel numara kurallarını kullanın</translation>
     </message>
     <message>
         <location filename="../ImportCsvDialog.ui" line="366"/>
         <source>Use decimal and thousands separators according to the system locale.</source>
-        <translation type="unfinished"></translation>
+        <translation>Sistem yerel ayarlarına göre ondalık ve binlik ayraçlarını kullanın.</translation>
     </message>
     <message>
         <location filename="../ImportCsvDialog.ui" line="373"/>
@@ -2674,12 +2680,12 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../ImportCsvDialog.cpp" line="642"/>
         <source>Could not prepare INSERT statement: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>INSERT ifadesi hazırlanamadı: %1</translation>
     </message>
     <message>
         <location filename="../ImportCsvDialog.cpp" line="732"/>
         <source>Unexpected end of file. Please make sure that you have configured the correct quote characters and the file is not malformed.</source>
-        <translation type="unfinished"></translation>
+        <translation>Beklenmeyen dosya sonu. Lütfen tırnak işaretlerini doğru yapılandırdığınızdan ve dosyanın hatalı olmadığından emin olun.</translation>
     </message>
     <message>
         <location filename="../ImportCsvDialog.cpp" line="746"/>
@@ -2707,7 +2713,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../MainWindow.ui" line="2381"/>
         <source>Opens the SQLCipher FAQ in a browser window</source>
-        <translation>SQLCipher Hakkında SSS bölümünü tarayıcı penceresinde açar</translation>
+        <translation>SQLCipher  SSS bölümünü bir tarayıcı penceresinde açar</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2389"/>
@@ -2717,7 +2723,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../MainWindow.ui" line="2404"/>
         <source>Open an existing database file in read only mode</source>
-        <translation>Mevcut bir veritabanı dosyasını salt okunur modda açar</translation>
+        <translation>Mevcut bir veritabanı dosyasını salt okunur modda açın</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1295"/>
@@ -2894,7 +2900,7 @@ x~y	Aralık: değerler x ve y arasında
     <message>
         <location filename="../MainWindow.ui" line="1855"/>
         <source>Compact the database file, removing space wasted by deleted records</source>
-        <translation>Veritabanı dosyasını genişletmek, silinen kayıtlardan dolayı meydana gelen boşlukları temizler</translation>
+        <translation>Veritabanı dosyasını sıkıştırarak silinen kayıtların kapladığı alanı boşaltın</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1858"/>
@@ -3125,7 +3131,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
         <location filename="../MainWindow.ui" line="1757"/>
         <location filename="../MainWindow.ui" line="1760"/>
         <source>Close the current database file</source>
-        <translation>Geçerli veritabano dosyasını kapat</translation>
+        <translation>Geçerli veritabanı dosyasını kapat</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1763"/>
@@ -3151,32 +3157,32 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="1852"/>
         <source>Compact &amp;Database...</source>
-        <translation>Veriabanını &amp;Sıkıştır...</translation>
+        <translation>Veritabanını &amp;Sıkıştır...</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2079"/>
         <source>New &amp;tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni &amp;sekme</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2097"/>
         <source>Execute all/selected SQL</source>
-        <translation>Tüm/seçin SQL sorgusunu yürüt</translation>
+        <translation>Tüm/seçili SQL&apos;i çalıştır</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2100"/>
         <source>This button executes the currently selected SQL statements. If no text is selected, all SQL statements are executed.</source>
-        <translation>Bu buton seçili olan SQL ifadesini yürütür. Hiçbir metin seçilmezse, tüm SQL ifadeleri yürütülür.</translation>
+        <translation>Bu düğme seçili olan SQL ifadesini yürütür. Hiçbir metin seçilmezse tüm SQL ifadeleri yürütülür.</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2112"/>
         <source>Open SQL file(s)</source>
-        <translation type="unfinished"></translation>
+        <translation>SQL dosyasını/dosyalarını açın</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2115"/>
         <source>This button opens files containing SQL statements and loads them in new editor tabs</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu düğme, SQL ifadeleri içeren dosyaları açar ve bunları yeni düzenleyici sekmelerine yükler</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2139"/>
@@ -3186,7 +3192,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2154"/>
         <source>Execute line</source>
-        <translation>Tek satır yürüt</translation>
+        <translation>Satırı yürüt</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2183"/>
@@ -3211,7 +3217,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2222"/>
         <source>Web&amp;site</source>
-        <translation>Web &amp;Sitesi</translation>
+        <translation>Web &amp;sitesi</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2234"/>
@@ -3221,30 +3227,30 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2788"/>
         <source>Close Pro&amp;ject</source>
-        <translation type="unfinished"></translation>
+        <translation>Pro&amp;jeyi Kapat</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2791"/>
         <location filename="../MainWindow.ui" line="2794"/>
         <source>Close project and database files and return to the initial state</source>
-        <translation type="unfinished"></translation>
+        <translation>Proje ve veritabanı dosyalarını kapatın ve başlangıç ​​durumuna dönün</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="483"/>
         <source>Ctrl+Shift+F4</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+F4</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2806"/>
         <location filename="../MainWindow.ui" line="2818"/>
         <source>Detach Database</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını Ayır</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2809"/>
         <location filename="../MainWindow.ui" line="2821"/>
         <source>Detach database file attached to the current database connection</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçerli veritabanı bağlantısına bağlı veritabanı dosyasını ayırın</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2270"/>
@@ -3260,7 +3266,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
         <location filename="../MainWindow.ui" line="2300"/>
         <location filename="../MainWindow.ui" line="2303"/>
         <source>Add another database file to the current database connection</source>
-        <translation>Şu anki veritabanı bağğlantısına başka bir veritabanı dosyası ekle</translation>
+        <translation>Şu anki veritabanı bağlantısına başka bir veritabanı dosyası ekle</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2306"/>
@@ -3285,7 +3291,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2401"/>
         <source>Open Data&amp;base Read Only...</source>
-        <translation>Salt &amp;Okunur Veritabanı Aç...</translation>
+        <translation>Salt Okunur Verita&amp;banı Aç...</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2413"/>
@@ -3311,7 +3317,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
         <location filename="../MainWindow.ui" line="2443"/>
         <location filename="../MainWindow.ui" line="2449"/>
         <source>Find text in SQL editor</source>
-        <translation>SQL editörünte metin ara</translation>
+        <translation>SQL editöründe metin ara</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2446"/>
@@ -3352,7 +3358,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2490"/>
         <source>Export to &amp;CSV</source>
-        <translation>&amp;CSV dosyası olarak dışa aktar</translation>
+        <translation>&amp;CSV&apos;ye aktar</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2500"/>
@@ -3379,248 +3385,248 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
         <location filename="../MainWindow.ui" line="53"/>
         <source>&amp;Database Structure</source>
         <extracomment>This has to be equal to the tab title in all the main tabs</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Veritabanı Yapısı</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="120"/>
         <location filename="../MainWindow.ui" line="123"/>
         <source>&amp;Browse Data</source>
         <extracomment>This has to be equal to the tab title in all the main tabs</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>Verileri &amp;Görüntüle</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="155"/>
         <location filename="../MainWindow.ui" line="158"/>
         <source>Edit P&amp;ragmas</source>
         <extracomment>This has to be equal to the tab title in all the main tabs</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>P&amp;ragmaları Düzenle</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="206"/>
         <source>Temp Store</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçici Depo</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="222"/>
         <source>Secure Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Güvenli Silme</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="264"/>
         <source>Case Sensitive Like</source>
-        <translation type="unfinished"></translation>
+        <translation>Büyük/Küçük Harfe Duyarlı Like İşleci İle</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="358"/>
         <source>Journal Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Günlük Modu</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="374"/>
         <source>Journal Size Limit</source>
-        <translation type="unfinished"></translation>
+        <translation>Günlük Boyut Sınırı</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="390"/>
         <source>Recursive Triggers</source>
-        <translation type="unfinished"></translation>
+        <translation>Özyinelemeli Tetikleyiciler</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="492"/>
         <source>Page Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Sayfa Boyutu</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="541"/>
         <source>Foreign Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>Yabancı Anahtarlar</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="791"/>
         <source>Auto Vacuum</source>
-        <translation type="unfinished"></translation>
+        <translation>Otomatik Vakum</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="814"/>
         <source>Max Page Count</source>
-        <translation type="unfinished"></translation>
+        <translation>Maksimum Sayfa Sayısı</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="870"/>
         <source>Checkpoint Full FSYNC</source>
-        <translation type="unfinished"></translation>
+        <translation>Kontrol Noktası Tam FSYNC</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="429"/>
         <location filename="../MainWindow.ui" line="910"/>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation>Kapalı</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="854"/>
         <location filename="../MainWindow.ui" line="915"/>
         <source>Normal</source>
-        <translation type="unfinished"></translation>
+        <translation>Normal</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="920"/>
         <location filename="../MainWindow.ui" line="1178"/>
         <source>Full</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="929"/>
         <source>Default</source>
-        <translation type="unfinished">Varsayılan</translation>
+        <translation>Varsayılan</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="934"/>
         <source>File</source>
-        <translation type="unfinished">Dosya</translation>
+        <translation>Dosya</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="419"/>
         <location filename="../MainWindow.ui" line="939"/>
         <source>Memory</source>
-        <translation type="unfinished"></translation>
+        <translation>Bellek</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="404"/>
         <source>Delete</source>
-        <translation type="unfinished"></translation>
+        <translation>Sil</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="409"/>
         <source>Truncate</source>
-        <translation type="unfinished"></translation>
+        <translation>Kısalt</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="414"/>
         <source>Persist</source>
-        <translation type="unfinished"></translation>
+        <translation>Sürdür</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="424"/>
         <source>WAL</source>
-        <translation type="unfinished"></translation>
+        <translation>WA</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="859"/>
         <source>Exclusive</source>
-        <translation type="unfinished"></translation>
+        <translation>Özel</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="950"/>
         <source>Automatic Index</source>
-        <translation type="unfinished"></translation>
+        <translation>Otomatik İndeks</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1025"/>
         <source>Ignore Check Constraints</source>
-        <translation type="unfinished"></translation>
+        <translation>Kontrol Kısıtlamalarını Yoksay</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1041"/>
         <source>Full FSYNC</source>
-        <translation type="unfinished"></translation>
+        <translation>Tam FSYNC</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1057"/>
         <source>WAL Auto Checkpoint</source>
-        <translation type="unfinished"></translation>
+        <translation>WAL Oto Kontrol Noktası</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1083"/>
         <source>User Version</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı Sürümü</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1143"/>
         <source>Synchronous</source>
-        <translation type="unfinished"></translation>
+        <translation>Eş zamanlı</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1173"/>
         <source>None</source>
-        <translation type="unfinished">Hiçbiri</translation>
+        <translation>Hiçbiri</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1183"/>
         <source>Incremental</source>
-        <translation type="unfinished"></translation>
+        <translation>Artımlı</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1194"/>
         <source>Locking Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>Kilitleme Modu</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1222"/>
         <location filename="../MainWindow.ui" line="1225"/>
         <source>E&amp;xecute SQL</source>
         <extracomment>This has to be equal to the tab title in all the main tabs</extracomment>
-        <translation type="unfinished"></translation>
+        <translation>SQL&apos;i &amp;çalıştır</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1315"/>
         <source>&amp;Recent Files</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Son Dosyalar</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1703"/>
         <source>&amp;New Database</source>
-        <translation type="unfinished"></translation>
+        <translation>Ye&amp;ni Veritabanı</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1805"/>
         <source>&amp;Undo</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Geri Al</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1808"/>
         <location filename="../MainWindow.ui" line="1811"/>
         <source>Undo last change to the database</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanındaki son değişikliği geri al</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1814"/>
         <source>This action undoes the last change performed to the database in the Database Browser or in Execute SQL. Redoing is not possible.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu işlem, Veritabanı Tarayıcısı&apos;nda veya SQL Çalıştır&apos;da veritabanında gerçekleştirilen son değişikliği geri alır. Yeniden yapılması mümkün değildir.</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1985"/>
         <source>Open the Modify Table wizard, where it is possible to rename an existing table. It is also possible to add or delete fields from a table, as well as modify field names and types.</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut bir tablonun adını değiştirebileceğiniz Tablo Değiştirme sihirbazını açın. Ayrıca, bir tabloya alan ekleyebilir veya silebilir, alan adlarını ve türlerini değiştirebilirsiniz.</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2118"/>
         <source>Ctrl+Shift+T</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+T</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2249"/>
         <source>&amp;Save Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Projeyi &amp;Kaydet</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2258"/>
         <source>This button lets you save all the settings associated to the open DB to a DB Browser for SQLite project file</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu düğme, açık DB ile ilişkili tüm ayarları SQLite proje dosyası için DB Tarayıcısına kaydetmenize olanak tanır</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2273"/>
         <source>Open &amp;Project</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Proje Aç</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2282"/>
         <source>This button lets you open a DB Browser for SQLite project file</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu düğme, SQLite proje dosyası için bir DB Tarayıcısı açmanıza olanak tanır</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2495"/>
         <source>Export to &amp;JSON</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;JSON&apos;a aktar</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2536"/>
@@ -3630,7 +3636,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2548"/>
         <source>&amp;Open Database</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını &amp;Aç</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2565"/>
@@ -3640,13 +3646,13 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2573"/>
         <source>Drag &amp;&amp; Drop SELECT Query</source>
-        <translation type="unfinished"></translation>
+        <translation>Sürükle &amp;&amp; Bırak SEÇ Sorgusu</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2576"/>
         <location filename="../MainWindow.ui" line="2579"/>
         <source>When dragging fields from the same table or a single table, drop a SELECT query into the editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Aynı tablodan veya tek bir tablodan alanları sürüklerken, düzenleyiciye bir SEÇ sorgusu bırakın</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2587"/>
@@ -3668,7 +3674,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
         <location filename="../MainWindow.ui" line="2604"/>
         <location filename="../MainWindow.ui" line="2607"/>
         <source>Use escaped identifiers (e.g. &quot;Table1&quot;) when dragging the objects and dropping them into the editor </source>
-        <translation>Nesneleri sürükleyip editöre bırakırken çıkış karakter belirleyicilerini kullanın(ör. &quot;Tablo1&quot;) kullanın </translation>
+        <translation>Nesneleri sürükleyip düzenleyiciye bırakırken kaçış tanımlayıcıları (örneğin &quot;Tablo1&quot;) kullanın </translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2612"/>
@@ -3698,7 +3704,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2631"/>
         <source>Run a quick integrity check over the open DB</source>
-        <translation>Açık veritabanı üzerinde hızlı bir bütünlük denetimi yapın</translation>
+        <translation>Açık DB üzerinde hızlı bir bütünlük denetimi yapın</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2634"/>
@@ -3739,7 +3745,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2684"/>
         <source>Print the structure of the opened database</source>
-        <translation>Şu anda açık olan veritabanı yapısını yazdırın</translation>
+        <translation>Açılan veritabanının yapısını yazdırın</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2690"/>
@@ -3749,7 +3755,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2744"/>
         <source>&amp;Save Project As...</source>
-        <translation>Projeyi &amp;Farklı Kaydet...</translation>
+        <translation>Projeyi Farklı &amp;Kaydet...</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2747"/>
@@ -3768,7 +3774,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
         <location filename="../MainWindow.ui" line="2768"/>
         <location filename="../MainWindow.ui" line="2771"/>
         <source>Save DB file, project file and opened SQL files</source>
-        <translation>Veritabanı dosyasını, proje dosyasını ve açılan SQL dosyalarını kaydedin</translation>
+        <translation>DB dosyasını, proje dosyasını ve açılan SQL dosyalarını kaydedin</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2774"/>
@@ -3779,47 +3785,47 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
         <location filename="../MainWindow.ui" line="2797"/>
         <location filename="../MainWindow.cpp" line="483"/>
         <source>Ctrl+Shift+W</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+W</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2826"/>
         <source>Table from CSV data in Clipboard...</source>
-        <translation type="unfinished"></translation>
+        <translation>Panodaki CSV verilerinden tablo...</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2829"/>
         <source>This treats the current clipboard contents as a CSV file and opens the same import wizard that is used for importing CSV data from a file.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu, geçerli panonun içeriğini bir CSV dosyası olarak ele alır ve bir dosyadan CSV verilerini içe aktarmak için kullanılan aynı içe aktarma sihirbazını açar.</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2834"/>
         <source>Show &amp;Row Counts</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Satır Sayılarını Göster</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2837"/>
         <source>This shows the number of rows for each table and view in the database.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu, veritabanındaki her tablo ve görünüm için satır sayısını gösterir.</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2849"/>
         <source>Save Database &amp;As...</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını &amp;Farklı Kaydet...</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2852"/>
         <source>Save the current database as a different file</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçerli veritabanını farklı bir dosya olarak kaydedin</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2861"/>
         <source>Refresh</source>
-        <translation type="unfinished">Yenile</translation>
+        <translation>Yenile</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2864"/>
         <source>Reload the database structure</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanı yapısını yeniden yükle</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="1880"/>
@@ -3859,7 +3865,7 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2000"/>
         <source>Create &amp;Index...</source>
-        <translation>&amp;Index Oluştur...</translation>
+        <translation>&amp;İndeks Oluştur...</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2051"/>
@@ -3869,12 +3875,12 @@ SQL deyimlerini Şema sütunundan sürükleyip SQL editörüne veya diğer uygul
     <message>
         <location filename="../MainWindow.ui" line="2062"/>
         <source>&amp;About</source>
-        <translation>&amp;İptal</translation>
+        <translation>&amp;Hakkında</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2082"/>
         <source>This button opens a new tab for the SQL editor</source>
-        <translation>Bu buton SQL editörü için yeni bir sekme açar</translation>
+        <translation>Bu düğme SQL editörü için yeni bir sekme açar</translation>
     </message>
     <message>
         <location filename="../MainWindow.ui" line="2094"/>
@@ -4119,7 +4125,7 @@ Eğer cevabınız hayır ise biz SQL dosyasındaki verileri geçerli veritabanı
     <message>
         <location filename="../MainWindow.cpp" line="1683"/>
         <source>Modify Index</source>
-        <translation>Index&apos;i Düzenle</translation>
+        <translation>İndeksi Düzenle</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="1686"/>
@@ -4168,22 +4174,22 @@ Bunu yapmak istediğinize emin misiniz?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="205"/>
         <source>Ctrl+Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Tab</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="214"/>
         <source>Ctrl+Shift+Tab</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+Shift+Tab</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="240"/>
         <source>Clear List</source>
-        <translation type="unfinished"></translation>
+        <translation>Listeyi Temizle</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="334"/>
         <source>Window Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Pencere Düzeni</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="337"/>
@@ -4193,32 +4199,32 @@ Bunu yapmak istediğinize emin misiniz?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="346"/>
         <source>Simplify Window Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Pencere Düzenini Basitleştirin</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="347"/>
         <source>Alt+Shift+0</source>
-        <translation type="unfinished"></translation>
+        <translation>Alt+Shift+0</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="356"/>
         <source>Dock Windows at Bottom</source>
-        <translation type="unfinished"></translation>
+        <translation>Pencereleri Altta Sabitle</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="360"/>
         <source>Dock Windows at Left Side</source>
-        <translation type="unfinished"></translation>
+        <translation>Pencereleri Sol Tarafa Yerleştir</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="364"/>
         <source>Dock Windows at Top</source>
-        <translation type="unfinished"></translation>
+        <translation>Pencereleri Üstte Sabitle</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="378"/>
         <source>The database is currently busy.</source>
-        <translation>Verştabanı şu anda meşgul.</translation>
+        <translation>Veritabanı şu anda meşgul.</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="384"/>
@@ -4228,7 +4234,7 @@ Bunu yapmak istediğinize emin misiniz?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="482"/>
         <source>Alt+Shift+W</source>
-        <translation type="unfinished"></translation>
+        <translation>Alt+Shift+W</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="582"/>
@@ -4245,12 +4251,12 @@ Nedeni: %1</translation>
     <message>
         <location filename="../MainWindow.cpp" line="702"/>
         <source>Choose a database file to save under</source>
-        <translation type="unfinished"></translation>
+        <translation>Kaydedilecek bir veritabanı dosyası seçin</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="713"/>
         <source>Error while saving the database to the new file.</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını yeni dosyaya kaydederken hata oluştu.</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="906"/>
@@ -4272,7 +4278,7 @@ Tabloyla ilişkili tüm veriler kaybedilecektir.</translation>
     <message>
         <location filename="../MainWindow.cpp" line="912"/>
         <source>Are you sure you want to delete the index &apos;%1&apos;?</source>
-        <translation>&apos;%1&apos; indexsini silmek istediğinizden emin misiniz?</translation>
+        <translation>&apos;%1&apos; indeksini silmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="923"/>
@@ -4292,7 +4298,7 @@ Tabloyla ilişkili tüm veriler kaybedilecektir.</translation>
     <message>
         <location filename="../MainWindow.cpp" line="929"/>
         <source>Error: could not delete the index.</source>
-        <translation>Hata: index silinemedi.</translation>
+        <translation>Hata: indeks silinemedi.</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="931"/>
@@ -4311,12 +4317,12 @@ Veritabanını kaydetmek istediğinizden emin misiniz?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="1005"/>
         <source>Edit View %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Görünümü Düzenle %1</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="1011"/>
         <source>Edit Trigger %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Tetikleyiciyi Düzenle %1</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="1117"/>
@@ -4370,55 +4376,55 @@ Emin misiniz?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="1737"/>
         <source>Opened &apos;%1&apos; in read-only mode from recent file list</source>
-        <translation type="unfinished"></translation>
+        <translation>Son dosya listesinden &apos;%1&apos; salt okunur modunda açıldı</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="1739"/>
         <source>Opened &apos;%1&apos; from recent file list</source>
-        <translation type="unfinished"></translation>
+        <translation>Son dosya listesinden &apos;%1&apos; açıldı</translation>
     </message>
     <message numerus="yes">
         <location filename="../MainWindow.cpp" line="1870"/>
         <source>Select the action to apply to the dropped file(s). &lt;br/&gt;Note: only &apos;Import&apos; will process more than one file.</source>
         <comment>Note for translation: Although there is no %n in the original, you can use the numerus-form to adjust &apos;files(s)&apos; and remove the note when n = 1. Including %n in the translation will also work.</comment>
-        <translation type="unfinished">
-            <numerusform>Bırakılan dosyalara uygulanacak eylemi seçin. &lt;br/&gt;Not: yalnızca &apos;İçe Aktar&apos; birden fazla dosyayı işleyecektir.</numerusform>
+        <translation>
+            <numerusform>Bırakılan dosyalara uygulanacak eylemi seçin. %n Not: yalnızca &apos;İçe Aktar&apos; birden fazla dosyayı işler.</numerusform>
         </translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="2106"/>
         <source>The statements in the tab &apos;%1&apos; are still executing. Closing the tab will stop the execution. This might leave the database in an inconsistent state. Are you sure you want to close the tab?</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; sekmesindeki ifadeler hâlâ yürütülüyor. Sekmeyi kapatmak yürütmeyi durduracaktır. Bu, veritabanını tutarsız bir durumda bırakabilir. Sekmeyi kapatmak istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="2755"/>
         <source>DB file &apos;%1&apos; could not be opened</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanı dosyası &apos;%1&apos; açılamadı</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="2890"/>
         <source>This project file is using an old file format because it was created using DB Browser for SQLite version 3.10 or lower. Loading this file format is no longer fully supported. If you want to load it completely, please use DB Browser for SQLite version 3.12 to convert it to the new file format.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu proje dosyası, DB Browser for SQLite sürüm 3.10 veya daha eski bir sürüm kullanılarak oluşturulduğu için eski bir dosya biçimi kullanıyor. Bu dosya biçiminin yüklenmesi artık tam olarak desteklenmiyor. Dosyayı tamamen yüklemek istiyorsanız lütfen DB Browser for SQLite sürüm 3.12&apos;yi kullanarak yeni dosya biçimine dönüştürün.</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="2909"/>
         <source>Table &apos;%1&apos; not found; settings ignored</source>
-        <translation type="unfinished"></translation>
+        <translation>&apos;%1&apos; tablosu bulunamadı; ayarlar göz ardı edildi</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="3243"/>
         <source>-- Reference to file &quot;%1&quot; (not supported by this version) --</source>
-        <translation type="unfinished"></translation>
+        <translation>-- &quot;%1&quot; dosyasına başvuru (bu sürüm tarafından desteklenmiyor) --</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="3461"/>
         <source>Yes. Don&apos;t ask again</source>
-        <translation type="unfinished"></translation>
+        <translation>Evet. Bir daha sorma</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="3566"/>
         <source>This action will open a new SQL tab with the following statements for you to edit and run:</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu eylem, düzenlemeniz ve çalıştırmanız için aşağıdaki ifadeleri içeren yeni bir SQL sekmesi açacaktır:</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="3772"/>
@@ -4458,12 +4464,12 @@ Emin misiniz?</translation>
     <message>
         <location filename="../MainWindow.cpp" line="237"/>
         <source>Automatically load the last opened DB file at startup</source>
-        <translation type="unfinished"></translation>
+        <translation>Başlangıçta son açılan DB dosyasını otomatik olarak yükle</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="338"/>
         <source>Ctrl+0</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+0</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="1411"/>
@@ -4504,7 +4510,7 @@ Emin misiniz?</translation>
         <location filename="../MainWindow.cpp" line="2474"/>
         <location filename="../MainWindow.cpp" line="2886"/>
         <source>Don&apos;t show again</source>
-        <translation>Bir daha gös&apos;terme</translation>
+        <translation>Bir daha gösterme</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="2477"/>
@@ -4568,7 +4574,7 @@ Bir yedek oluşturun!</translation>
     <message>
         <location filename="../MainWindow.cpp" line="3564"/>
         <source>This action will open a new SQL tab for running:</source>
-        <translation>Bu işlem çalıştırmak için yeni bir SQL sekmesi açar:</translation>
+        <translation>Bu işlem, çalıştırmak için yeni bir SQL sekmesi açar:</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="3570"/>
@@ -4606,12 +4612,12 @@ Bir yedek oluşturun!</translation>
     <message>
         <location filename="../AddRecordDialog.cpp" line="42"/>
         <source>Set to NULL</source>
-        <translation>NULL olarak ayarlar</translation>
+        <translation>NULL olarak ayarla</translation>
     </message>
     <message>
         <location filename="../AddRecordDialog.cpp" line="46"/>
         <source>Alt+Del</source>
-        <translation></translation>
+        <translation>Alt+Del</translation>
     </message>
 </context>
 <context>
@@ -4639,17 +4645,17 @@ Bir yedek oluşturun!</translation>
     <message>
         <location filename="../PlotDock.ui" line="68"/>
         <source>Y1</source>
-        <translation type="unfinished"></translation>
+        <translation>Y1</translation>
     </message>
     <message>
         <location filename="../PlotDock.ui" line="73"/>
         <source>Y2</source>
-        <translation type="unfinished"></translation>
+        <translation>Y2</translation>
     </message>
     <message>
         <location filename="../PlotDock.ui" line="78"/>
         <source>Axis Type</source>
-        <translation>Eksen Tipi</translation>
+        <translation>Eksen Türü</translation>
     </message>
     <message>
         <location filename="../PlotDock.ui" line="90"/>
@@ -4815,7 +4821,7 @@ Yalnızca geçerli yönde sürüklemek ve yakınlaştırmak için eksen veya eks
     <message>
         <location filename="../PlotDock.cpp" line="97"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>Yardım</translation>
     </message>
     <message>
         <location filename="../PlotDock.cpp" line="103"/>
@@ -4830,7 +4836,7 @@ Yalnızca geçerli yönde sürüklemek ve yakınlaştırmak için eksen veya eks
     <message>
         <location filename="../PlotDock.cpp" line="115"/>
         <source>Fixed number format</source>
-        <translation type="unfinished"></translation>
+        <translation>Sabit sayı biçimi</translation>
     </message>
     <message>
         <location filename="../PlotDock.cpp" line="206"/>
@@ -4878,7 +4884,7 @@ Uyarı: Kısmi yükleme mekanizması nedeniyle tüm veriler tablodan henüz alı
     <message>
         <location filename="../PlotDock.cpp" line="706"/>
         <source>Choose a filename to save under</source>
-        <translation>Altına kaydetmek için dosya ismi seçiniz</translation>
+        <translation>Altına kaydetmek için dosya ismi seçin</translation>
     </message>
     <message>
         <location filename="../PlotDock.cpp" line="707"/>
@@ -5008,17 +5014,17 @@ Uyarı: Kısmi yükleme mekanizması nedeniyle tüm veriler tablodan henüz alı
     <message>
         <location filename="../PreferencesDialog.ui" line="675"/>
         <source>Default field type</source>
-        <translation>Varsayılan dosya tipi</translation>
+        <translation>Varsayılan alan türü</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="789"/>
         <source>Font</source>
-        <translation>Yazı</translation>
+        <translation>Yazı Tipi</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="798"/>
         <source>&amp;Font</source>
-        <translation>&amp;Yazı</translation>
+        <translation>&amp;Yazı Tipi</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1179"/>
@@ -5043,7 +5049,7 @@ Uyarı: Kısmi yükleme mekanizması nedeniyle tüm veriler tablodan henüz alı
     <message>
         <location filename="../PreferencesDialog.ui" line="1245"/>
         <source>Enable this option to show a preview of BLOBs containing image data in the cells. This can affect the performance of the data browser, however.</source>
-        <translation>Hücrelerde görüntü verileri içeren BLOB tipindeki verilerin önizlemesini göstermek için bu seçeneği etkinleştirin. Ancak bu, veri görüntüleyicisinin performansını etkileyebilir.</translation>
+        <translation>Hücrelerde görüntü verileri içeren BLOB tipindeki verilerin ön izlemesini göstermek için bu seçeneği etkinleştirin. Ancak bu, veri görüntüleyicisinin performansını etkileyebilir.</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="865"/>
@@ -5063,7 +5069,7 @@ Uyarı: Kısmi yükleme mekanizması nedeniyle tüm veriler tablodan henüz alı
     <message>
         <location filename="../PreferencesDialog.ui" line="1475"/>
         <source>Background</source>
-        <translation>Arka plan</translation>
+        <translation>Arka Plan</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1261"/>
@@ -5082,7 +5088,7 @@ Uyarı: Kısmi yükleme mekanizması nedeniyle tüm veriler tablodan henüz alı
         <location filename="../PreferencesDialog.ui" line="310"/>
         <location filename="../PreferencesDialog.ui" line="466"/>
         <source>Only display the icon</source>
-        <translation>Sadece ikonu göster</translation>
+        <translation>Sadece simgeyi göster</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="165"/>
@@ -5143,17 +5149,17 @@ Uyarı: Kısmi yükleme mekanizması nedeniyle tüm veriler tablodan henüz alı
     <message>
         <location filename="../PreferencesDialog.ui" line="418"/>
         <source>Browse Data</source>
-        <translation>Verileri Görüntüle</translation>
+        <translation>Verilere Göz At</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="431"/>
         <source>Execute SQL</source>
-        <translation>SQL kodunu yürütme</translation>
+        <translation>SQL kodunu yürüt</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="494"/>
         <source>Edit Database Cell</source>
-        <translation>Veritabanı Hücresini Düzenleme</translation>
+        <translation>Veritabanı Hücresini Düzenle</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="513"/>
@@ -5168,12 +5174,12 @@ Uyarı: Kısmi yükleme mekanizması nedeniyle tüm veriler tablodan henüz alı
     <message>
         <location filename="../PreferencesDialog.ui" line="537"/>
         <source>Dark style</source>
-        <translation>Koyu Tema</translation>
+        <translation>Koyu tema</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="542"/>
         <source>Light style</source>
-        <translation type="unfinished"></translation>
+        <translation>Aydınlık stil</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="550"/>
@@ -5183,28 +5189,29 @@ Uyarı: Kısmi yükleme mekanizması nedeniyle tüm veriler tablodan henüz alı
     <message>
         <location filename="../PreferencesDialog.ui" line="560"/>
         <source>This sets the font size for all UI elements which do not have their own font size option.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu, kendi yazı tipi boyutu seçeneği olmayan tüm kullanıcı arayüzü ögelerinin yazı tipi boyutunu ayarlar.</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="563"/>
         <source>Font size</source>
-        <translation type="unfinished"></translation>
+        <translation>Yazı tipi boyutu</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="576"/>
         <source>Max Recent Files</source>
-        <translation type="unfinished"></translation>
+        <translation>En Son Dosyalar</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="596"/>
         <source>Prompt to save SQL tabs
 in new project file</source>
-        <translation type="unfinished"></translation>
+        <translation>SQL sekmelerini  kaydetme istemi
+yeni proje dosyasına</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="607"/>
         <source>If this is turned on, then changes to the SQL editor generate a save a project confirmation dialog when closing the SQL editor tab.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu açıksa SQL düzenleyici sekmesi kapatıldığında SQL düzenleyicide yapılan değişiklikler bir proje kaydetme onay iletişim kutusu oluşturur.</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="698"/>
@@ -5214,17 +5221,17 @@ in new project file</source>
     <message>
         <location filename="../PreferencesDialog.ui" line="729"/>
         <source>Database structure font size</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanı yapısı yazı tipi boyutu</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="821"/>
         <source>Font si&amp;ze</source>
-        <translation>Yazı B&amp;oyutu</translation>
+        <translation>Yazı tipi b&amp;oyutu</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="885"/>
         <source>Formatted</source>
-        <translation type="unfinished"></translation>
+        <translation>Biçimlendirilmiş</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1225"/>
@@ -5232,9 +5239,9 @@ in new project file</source>
 Maximum number of rows in a table for enabling the value completion based on current values in the column.
 Maximum number of indexes in a selection for calculating sum and average.
 Can be set to 0 for disabling the functionalities.</source>
-        <translation>Bu, bazı hesaplama açısından pahalı işlevlerin etkinleştirilmesine izin verilen maksimum öğe sayısıdır:
+        <translation>Bu, bazı hesaplama açısından pahalı işlevlerin etkinleştirilmesine izin verilen maksimum öge sayısıdır:
 Sütundaki geçerli değerlere dayalı olarak değer tamamlamayı etkinleştirmek için bir tablodaki maksimum satır sayısı.
-Toplam ve ortalamayı hesaplamak için bir seçimdeki maksimum index sayısı.
+Toplam ve ortalamayı hesaplamak için bir seçimdeki maksimum indeks sayısı.
 İşlevleri devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     </message>
     <message>
@@ -5247,42 +5254,42 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     <message>
         <location filename="../PreferencesDialog.ui" line="1491"/>
         <source>Selection background</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçim arka planı</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1499"/>
         <source>Selection foreground</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçim ön planı</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1507"/>
         <source>Highlight</source>
-        <translation type="unfinished"></translation>
+        <translation>Vurgu</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1594"/>
         <source>Use tabs for indentation</source>
-        <translation type="unfinished"></translation>
+        <translation>Girinti için sekmeleri kullanın</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1604"/>
         <source>When set, the Tab key will insert tab and space characters for indentation. Otherwise, just spaces will be used.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlandığında, Tab tuşu girinti için sekme ve boşluk karakterleri ekler. Aksi takdirde, yalnızca boşluklar kullanılır.</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1760"/>
         <source>Close button on tabs</source>
-        <translation type="unfinished"></translation>
+        <translation>Sekmelerdeki düğmeyi kapat</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1770"/>
         <source>If enabled, SQL editor tabs will have a close button. In any case, you can use the contextual menu or the keyboard shortcut to close them.</source>
-        <translation type="unfinished"></translation>
+        <translation>Etkinleştirildiğinde, SQL düzenleyici sekmelerinde bir kapatma düğmesi bulunur. Her durumda, bağlam menüsünü veya klavye kısayolunu kullanarak bunları kapatabilirsiniz.</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1852"/>
         <source>Select built-in extensions to load for every database:</source>
-        <translation type="unfinished"></translation>
+        <translation>Her veritabanı için yüklenecek yerleşik uzantıları seçin:</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="2103"/>
@@ -5297,12 +5304,12 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     <message>
         <location filename="../PreferencesDialog.ui" line="2128"/>
         <source>Export Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarları Dışa Aktar</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="2135"/>
         <source>Import Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarları İçe Aktar</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="840"/>
@@ -5340,7 +5347,7 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
         <location filename="../PreferencesDialog.ui" line="1118"/>
         <location filename="../PreferencesDialog.ui" line="1139"/>
         <source>Preview only (N/A)</source>
-        <translation>Sadece önizleme (N/A)</translation>
+        <translation>Sadece ön izleme (N/A)</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1290"/>
@@ -5355,7 +5362,7 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     <message>
         <location filename="../PreferencesDialog.ui" line="1280"/>
         <source>Set the waiting time before a new filter value is applied. Can be set to 0 for disabling waiting.</source>
-        <translation>Yeni bir filtre değeri uygulanmadan önce bekleme süresini ayarlayın. Beklemeyi devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
+        <translation>Yeni bir filtre değeri uygulanmadan önce bekleme süresini ayarla. Beklemeyi devre dışı bırakmak için 0 değeri ayarlanabilir.</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1313"/>
@@ -5415,7 +5422,7 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     <message>
         <location filename="../PreferencesDialog.ui" line="1447"/>
         <source>String</source>
-        <translation>String</translation>
+        <translation>Dize</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1467"/>
@@ -5425,7 +5432,7 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     <message>
         <location filename="../PreferencesDialog.ui" line="1532"/>
         <source>SQL &amp;editor font size</source>
-        <translation>SQL &amp;Editör yazı boyutu</translation>
+        <translation>SQL &amp;editör yazı tipi boyutu</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1571"/>
@@ -5460,7 +5467,7 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     <message>
         <location filename="../PreferencesDialog.ui" line="1648"/>
         <source>&amp;Quotes for identifiers</source>
-        <translation>Tanımlıyıcılar için &amp;tırnaklar</translation>
+        <translation>Tanımlayıcılar için &amp;tırnaklar</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1658"/>
@@ -5531,7 +5538,7 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     <message>
         <location filename="../PreferencesDialog.ui" line="2031"/>
         <source>Subject O</source>
-        <translation>Konu O</translation>
+        <translation>O Konusu</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="2034"/>
@@ -5542,7 +5549,7 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
         <location filename="../PreferencesDialog.ui" line="1943"/>
         <location filename="../PreferencesDialog.ui" line="2039"/>
         <source>Valid from</source>
-        <translation>Şundan tarihten itibaren geçerli</translation>
+        <translation>Şu tarihten itibaren geçerli</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1948"/>
@@ -5589,7 +5596,7 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     <message>
         <location filename="../PreferencesDialog.ui" line="1517"/>
         <source>SQL editor &amp;font</source>
-        <translation>SQL Editör &amp;yazı boyutu</translation>
+        <translation>SQL editör &amp;yazı tipi</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1720"/>
@@ -5599,12 +5606,12 @@ Tamamlamayı devre dışı bırakmak için 0 olarak ayarlanabilir.</translation>
     <message>
         <location filename="../PreferencesDialog.ui" line="1740"/>
         <source>Hori&amp;zontal tiling</source>
-        <translation>Ya&amp;tay Döşeme</translation>
+        <translation>Ya&amp;tay döşeme</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1750"/>
         <source>If enabled the SQL code editor and the result table view are shown side by side instead of one over the other.</source>
-        <translation>Etkinleştirilirse, SQL kod düzenleyicisi ve sonuç tablosu görünümü üst üste yerine yan yana gösterilir.</translation>
+        <translation>Etkinleştirilirse SQL kod düzenleyicisi ve sonuç tablosu görünümü üst üste yerine yan yana gösterilir.</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.ui" line="1683"/>
@@ -5698,35 +5705,37 @@ Tüm tercihleriniz kaybolacak ve varsayılan değerler kullanılacak.</translati
     <message>
         <location filename="../PreferencesDialog.cpp" line="795"/>
         <source>Save Settings File</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlar Dosyasını Kaydet</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.cpp" line="795"/>
         <location filename="../PreferencesDialog.cpp" line="805"/>
         <source>Initialization File (*.ini)</source>
-        <translation type="unfinished"></translation>
+        <translation>Başlatma Dosyası (*.ini)</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.cpp" line="799"/>
         <source>The settings file has been saved in location :
 </source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlar dosyası şu konuma kaydedildi:
+</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.cpp" line="805"/>
         <source>Open Settings File</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlar Dosyasını Aç</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.cpp" line="812"/>
         <source>The settings file was loaded properly.</source>
-        <translation type="unfinished"></translation>
+        <translation>Ayarlar dosyası düzgün bir şekilde yüklendi.</translation>
     </message>
     <message>
         <location filename="../PreferencesDialog.cpp" line="819"/>
         <source>The selected settings file is not a normal settings file.
 Please check again.</source>
-        <translation type="unfinished"></translation>
+        <translation>Seçilen ayar dosyası normal bir ayar dosyası değil.
+ Lütfen tekrar kontrol edin.</translation>
     </message>
 </context>
 <context>
@@ -5739,7 +5748,7 @@ Please check again.</source>
     <message>
         <location filename="../ProxyDialog.ui" line="22"/>
         <source>Pro&amp;xy Type</source>
-        <translation>Pro&amp;xy Tipi</translation>
+        <translation>Pro&amp;xy Türü</translation>
     </message>
     <message>
         <location filename="../ProxyDialog.ui" line="35"/>
@@ -5893,7 +5902,7 @@ Please check again.</source>
     <message>
         <location filename="../FileDialog.h" line="38"/>
         <source>JSON Files (*.json *.js)</source>
-        <translation>JSON dosyaları (*.json *.js)</translation>
+        <translation>JSON Dosyaları (*.json *.js)</translation>
     </message>
     <message>
         <location filename="../FileDialog.h" line="42"/>
@@ -5923,7 +5932,7 @@ Please check again.</source>
     <message>
         <location filename="../FileDialog.h" line="60"/>
         <source>Initialization File (*.ini)</source>
-        <translation type="unfinished"></translation>
+        <translation>Başlatma Dosyası (*.ini)</translation>
     </message>
 </context>
 <context>
@@ -6020,37 +6029,37 @@ Please check again.</source>
     <message>
         <location filename="../RemoteCommitsModel.cpp" line="13"/>
         <source>Commit ID</source>
-        <translation type="unfinished"></translation>
+        <translation>Commit ID</translation>
     </message>
     <message>
         <location filename="../RemoteCommitsModel.cpp" line="13"/>
         <source>Message</source>
-        <translation type="unfinished"></translation>
+        <translation>Mesaj</translation>
     </message>
     <message>
         <location filename="../RemoteCommitsModel.cpp" line="13"/>
         <source>Date</source>
-        <translation type="unfinished">Tarih</translation>
+        <translation>Tarih</translation>
     </message>
     <message>
         <location filename="../RemoteCommitsModel.cpp" line="13"/>
         <source>Author</source>
-        <translation type="unfinished"></translation>
+        <translation>Yazar</translation>
     </message>
     <message>
         <location filename="../RemoteCommitsModel.cpp" line="13"/>
         <source>Size</source>
-        <translation type="unfinished">Boyut</translation>
+        <translation>Boyut</translation>
     </message>
     <message>
         <location filename="../RemoteCommitsModel.cpp" line="65"/>
         <source>Authored and committed by %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 tarafından yazıldı ve işlendi</translation>
     </message>
     <message>
         <location filename="../RemoteCommitsModel.cpp" line="67"/>
         <source>Authored by %1, committed by %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 tarafından yazıldı, %2 tarafından işlendi</translation>
     </message>
 </context>
 <context>
@@ -6090,142 +6099,142 @@ Please check again.</source>
     <message>
         <location filename="../RemoteDock.ui" line="86"/>
         <source>Upload</source>
-        <translation type="unfinished"></translation>
+        <translation>Yükle</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="106"/>
         <source>DBHub.io</source>
-        <translation type="unfinished"></translation>
+        <translation>DBHub.io</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="139"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;In this pane, remote databases from dbhub.io website can be added to DB Browser for SQLite. First you need an identity:&lt;/p&gt;&lt;ol style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Login to the dbhub.io website (use your GitHub credentials or whatever you want)&lt;/li&gt;&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Click the button to &amp;quot;Generate client certificate&amp;quot; (that&apos;s your identity). That&apos;ll give you a certificate file (save it to your local disk).&lt;/li&gt;&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Go to the Remote tab in DB Browser for SQLite Preferences. Click the button to add a new certificate to DB Browser for SQLite and choose the just downloaded certificate file.&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Now the Remote panel shows your identity and you can add remote databases.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bu bölmede, dbhub.io web sitesinden uzak veritabanları SQLite için DB Tarayıcısına eklenebilir. Öncelikle bir kimliğe ihtiyacınız var:&lt;/p&gt;&lt;ol style=&quot;margin-top: 0px; margin-bottom: 0px; margin-left: 0px; margin-right: 0px; -qt-list-indent: 1;&quot;&gt;&lt;li style=&quot; margin-top:12px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;dbhub.io web sitesine giriş yapın (GitHub kimlik bilgilerinizi veya istediğiniz herhangi bir şeyi kullanın)&lt;/li&gt;&lt;li style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&quot;İstemci sertifikası oluştur&quot; düğmesine tıklayın (bu sizin kimliğinizdir). Bu size bir sertifika dosyası verecektir (bunu yerel diskinize kaydedin).&lt;/li&gt;&lt;li style=&quot; margin-top:0px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;SQLite için Veritabanı Tarayıcısı Tercihleri&apos;ndeki Uzak sekmesine gidin. SQLite için Veritabanı Tarayıcısı&apos;na yeni bir sertifika eklemek için düğmeye tıklayın ve az önce indirdiğiniz sertifika dosyasını seçin.&lt;/li&gt;&lt;/ol&gt;&lt;p&gt;Artık Uzak paneli kimliğinizi gösterecek ve uzak veritabanları ekleyebilirsiniz.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="147"/>
         <source>Local</source>
-        <translation type="unfinished"></translation>
+        <translation>Yerel</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="173"/>
         <source>Current Database</source>
-        <translation type="unfinished"></translation>
+        <translation>Güncel Veritabanı</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="231"/>
         <source>Clone</source>
-        <translation type="unfinished"></translation>
+        <translation>Klonla</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="274"/>
         <source>Branch</source>
-        <translation type="unfinished">Branch</translation>
+        <translation>Dal</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="294"/>
         <source>Commits</source>
-        <translation type="unfinished"></translation>
+        <translation>Commitler</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="314"/>
         <source>Commits for</source>
-        <translation type="unfinished"></translation>
+        <translation>Commitler için</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="445"/>
         <source>Delete Database</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını Sil</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="448"/>
         <source>Delete the local clone of this database</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu veritabanının yerel klonunu silin</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="457"/>
         <source>Open in Web Browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Web Tarayıcısında Aç</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="460"/>
         <source>Open the web page for the current database in your browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Tarayıcınızda geçerli veritabanının web sayfasını açın</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="469"/>
         <source>Clone from Link</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlantıdan Klonla</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="472"/>
         <source>Use this to download a remote database for local editing using a URL as provided on the web page of the database.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bunu, veritabanının web sayfasında sağlanan bir URL&apos;yi kullanarak yerel düzenleme için uzak bir veritabanını indirmek için kullanın.</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="481"/>
         <source>Refresh</source>
-        <translation type="unfinished">Yenile</translation>
+        <translation>Yenile</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="484"/>
         <source>Reload all data and update the views</source>
-        <translation type="unfinished"></translation>
+        <translation>Tüm verileri yeniden yükle ve görünümleri güncelle</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="493"/>
         <source>Clone Database</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını Klonla</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="508"/>
         <source>Open Database</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını Aç</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="511"/>
         <source>Open the local copy of this database</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu veritabanının yerel kopyasını açın</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="522"/>
         <source>Check out Commit</source>
-        <translation type="unfinished"></translation>
+        <translation>Commit&apos;i Kontrol Edin</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="525"/>
         <source>Download and open this specific commit</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu özel commiti indirin ve açın</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="540"/>
         <source>Check out Latest Commit</source>
-        <translation type="unfinished"></translation>
+        <translation>En Son Commiti Kontrol Edin</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="543"/>
         <source>Check out the latest commit of the current branch</source>
-        <translation type="unfinished"></translation>
+        <translation>Mevcut dalın en son commitini kontrol edin</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="548"/>
         <source>Save Revision to File</source>
-        <translation type="unfinished"></translation>
+        <translation>Revizyonu Dosyaya Kaydet</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="551"/>
         <source>Saves the selected revision of the database to another file</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanının seçili revizyonunu başka bir dosyaya kaydeder</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="560"/>
         <source>Upload Database</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanını Yükle</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="563"/>
         <source>Upload this database as a new commit</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu veritabanını yeni bir commit olarak yükleyin</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="390"/>
@@ -6235,12 +6244,12 @@ Please check again.</source>
     <message>
         <location filename="../RemoteDock.ui" line="240"/>
         <source>&amp;User</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Kullanıcı</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="257"/>
         <source>&amp;Database</source>
-        <translation type="unfinished">&amp;Veritabanı</translation>
+        <translation>&amp;Veritabanı</translation>
     </message>
     <message>
         <location filename="../RemoteDock.ui" line="400"/>
@@ -6250,12 +6259,12 @@ Please check again.</source>
     <message>
         <location filename="../RemoteDock.cpp" line="151"/>
         <source>Select an identity to connect</source>
-        <translation type="unfinished"></translation>
+        <translation>Bağlanmak için bir kimlik seçin</translation>
     </message>
     <message>
         <location filename="../RemoteDock.cpp" line="163"/>
         <source>Public</source>
-        <translation></translation>
+        <translation>Genel</translation>
     </message>
     <message>
         <location filename="../RemoteDock.cpp" line="216"/>
@@ -6263,43 +6272,47 @@ Please check again.</source>
 Please enter the URL to clone from. You can generate this URL by
 clicking the &apos;Clone Database in DB4S&apos; button on the web page
 of the database.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu, yerel düzenleme için uzak bir sunucudan bir veritabanı indirir.
+Lütfen klonlanacak URL&apos;yi girin. Bu URL&apos;yi, veritabanının web 
+sayfasındaki &apos;DB4S&apos;de Veritabanını Klonla&apos; düğmesine 
+tıklayarak oluşturabilirsiniz.</translation>
     </message>
     <message>
         <location filename="../RemoteDock.cpp" line="231"/>
         <source>Invalid URL: The host name does not match the host name of the current identity.</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçersiz URL: Ana bilgisayar adı, geçerli kimliğin ana bilgisayar adıyla eşleşmiyor.</translation>
     </message>
     <message>
         <location filename="../RemoteDock.cpp" line="236"/>
         <source>Invalid URL: No branch name specified.</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçersiz URL: Herhangi bir dal adı belirtilmedi.</translation>
     </message>
     <message>
         <location filename="../RemoteDock.cpp" line="241"/>
         <source>Invalid URL: No commit ID specified.</source>
-        <translation type="unfinished"></translation>
+        <translation>Geçersiz URL: Belirtilen bir commit kimliği yok.</translation>
     </message>
     <message>
         <location filename="../RemoteDock.cpp" line="289"/>
         <source>You have modified the local clone of the database. Fetching this commit overrides these local changes.
 Are you sure you want to proceed?</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanının yerel klonunu değiştirdiniz. Bu commit&apos;i almak, bu yerel değişiklikleri geçersiz kılar.
+Devam etmek istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <location filename="../RemoteDock.cpp" line="333"/>
         <source>The database has unsaved changes. Are you sure you want to push it before saving?</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanında kaydedilmemiş değişiklikler var. Kaydetmeden önce göndermek istediğinizden emin misiniz?</translation>
     </message>
     <message>
         <location filename="../RemoteDock.cpp" line="543"/>
         <source>The database you are trying to delete is currently opened. Please close it before deleting.</source>
-        <translation type="unfinished"></translation>
+        <translation>Silmeye çalıştığınız veritabanı şu anda açık. Lütfen silmeden önce kapatın.</translation>
     </message>
     <message>
         <location filename="../RemoteDock.cpp" line="549"/>
         <source>This deletes the local version of this database with all the changes you have not committed yet. Are you sure you want to delete this database?</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu, henüz kaydetmediğiniz tüm değişikliklerle birlikte bu veritabanının yerel sürümünü siler. Bu veritabanını silmek istediğinizden emin misiniz?</translation>
     </message>
 </context>
 <context>
@@ -6307,32 +6320,32 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../RemoteLocalFilesModel.cpp" line="20"/>
         <source>Name</source>
-        <translation type="unfinished">İsim</translation>
+        <translation>İsim</translation>
     </message>
     <message>
         <location filename="../RemoteLocalFilesModel.cpp" line="20"/>
         <source>Branch</source>
-        <translation type="unfinished">Branch</translation>
+        <translation>Dal</translation>
     </message>
     <message>
         <location filename="../RemoteLocalFilesModel.cpp" line="20"/>
         <source>Last modified</source>
-        <translation type="unfinished">Son değiştirilme</translation>
+        <translation>Son değiştirilme</translation>
     </message>
     <message>
         <location filename="../RemoteLocalFilesModel.cpp" line="20"/>
         <source>Size</source>
-        <translation type="unfinished">Boyut</translation>
+        <translation>Boyut</translation>
     </message>
     <message>
         <location filename="../RemoteLocalFilesModel.cpp" line="20"/>
         <source>Commit</source>
-        <translation type="unfinished">Commit</translation>
+        <translation>Commit</translation>
     </message>
     <message>
         <location filename="../RemoteLocalFilesModel.cpp" line="20"/>
         <source>File</source>
-        <translation type="unfinished">Dosya</translation>
+        <translation>Dosya</translation>
     </message>
 </context>
 <context>
@@ -6340,42 +6353,42 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../RemoteModel.cpp" line="109"/>
         <source>Name</source>
-        <translation type="unfinished">İsim</translation>
+        <translation>İsim</translation>
     </message>
     <message>
         <location filename="../RemoteModel.cpp" line="109"/>
         <source>Commit</source>
-        <translation type="unfinished">Commit</translation>
+        <translation>Commit</translation>
     </message>
     <message>
         <location filename="../RemoteModel.cpp" line="109"/>
         <source>Last modified</source>
-        <translation type="unfinished">Son değiştirilme</translation>
+        <translation>Son değiştirilme</translation>
     </message>
     <message>
         <location filename="../RemoteModel.cpp" line="109"/>
         <source>Size</source>
-        <translation type="unfinished">Boyut</translation>
+        <translation>Boyut</translation>
     </message>
     <message>
         <location filename="../RemoteModel.cpp" line="231"/>
         <source>Size: </source>
-        <translation type="unfinished"></translation>
+        <translation>Boyut: </translation>
     </message>
     <message>
         <location filename="../RemoteModel.cpp" line="232"/>
         <source>Last Modified: </source>
-        <translation type="unfinished"></translation>
+        <translation>Son Değiştirilme: </translation>
     </message>
     <message>
         <location filename="../RemoteModel.cpp" line="233"/>
         <source>Licence: </source>
-        <translation type="unfinished"></translation>
+        <translation>Lisans: </translation>
     </message>
     <message>
         <location filename="../RemoteModel.cpp" line="234"/>
         <source>Default Branch: </source>
-        <translation type="unfinished"></translation>
+        <translation>Varsayılan Dal: </translation>
     </message>
 </context>
 <context>
@@ -6383,47 +6396,48 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../RemoteNetwork.cpp" line="210"/>
         <source>Choose a location to save the file</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyayı kaydetmek için bir konum seçin</translation>
     </message>
     <message>
         <location filename="../RemoteNetwork.cpp" line="244"/>
         <source>Error opening remote file at %1.
 %2</source>
-        <translation type="unfinished">%1 adresinde bulunan dosya açılamadı. %2</translation>
+        <translation>%1 adresinde bulunan dosya açılamadı. 
+%2</translation>
     </message>
     <message>
         <location filename="../RemoteNetwork.cpp" line="323"/>
         <source>Error: Invalid client certificate specified.</source>
-        <translation type="unfinished">Hata: Geçersiz istemci sertifikası belirtildi.</translation>
+        <translation>Hata: Geçersiz istemci sertifikası belirtildi.</translation>
     </message>
     <message>
         <location filename="../RemoteNetwork.cpp" line="335"/>
         <source>Please enter the passphrase for this client certificate in order to authenticate.</source>
-        <translation type="unfinished">Kimlik doğrulaması için lütfen  istemci sertifikasının parolasını girin.</translation>
+        <translation>Kimlik doğrulaması için lütfen  istemci sertifikasının parolasını girin.</translation>
     </message>
     <message>
         <location filename="../RemoteNetwork.cpp" line="362"/>
         <source>Cancel</source>
-        <translation type="unfinished">İptal</translation>
+        <translation>İptal</translation>
     </message>
     <message>
         <location filename="../RemoteNetwork.cpp" line="367"/>
         <source>Uploading remote database to
 %1</source>
-        <translation type="unfinished">Uzak veritabanı karşıya yükleniyor
+        <translation>Uzak veritabanı karşıya yükleniyor
 %1</translation>
     </message>
     <message>
         <location filename="../RemoteNetwork.cpp" line="369"/>
         <source>Downloading remote database from
 %1</source>
-        <translation type="unfinished">Uzaktaki sunucu indiriliyor:
+        <translation>Uzaktaki sunucu indiriliyor:
 %1</translation>
     </message>
     <message>
         <location filename="../RemoteNetwork.cpp" line="450"/>
         <source>Error: Cannot open the file for sending.</source>
-        <translation type="unfinished">Hata: Dosya gönderim için açılamadı.</translation>
+        <translation>Hata: Dosya gönderim için açılamadı.</translation>
     </message>
 </context>
 <context>
@@ -6431,12 +6445,12 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../RemotePushDialog.ui" line="14"/>
         <source>Push database</source>
-        <translation>Veritabanını aktar</translation>
+        <translation>Veritabanını zorla</translation>
     </message>
     <message>
         <location filename="../RemotePushDialog.ui" line="22"/>
         <source>Database na&amp;me to push to</source>
-        <translation>Aktarılacak veritaba&amp;nı adı</translation>
+        <translation>Gönderilecek veritaba&amp;nı adı</translation>
     </message>
     <message>
         <location filename="../RemotePushDialog.ui" line="39"/>
@@ -6451,22 +6465,22 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../RemotePushDialog.ui" line="83"/>
         <source>Public</source>
-        <translation>Halka açık</translation>
+        <translation>Genel</translation>
     </message>
     <message>
         <location filename="../RemotePushDialog.ui" line="96"/>
         <source>Branch</source>
-        <translation>Branch</translation>
+        <translation>Dal</translation>
     </message>
     <message>
         <location filename="../RemotePushDialog.ui" line="116"/>
         <source>Force push</source>
-        <translation>Aktarmaya zorla</translation>
+        <translation>Zorla itme</translation>
     </message>
     <message>
         <location filename="../RemotePushDialog.ui" line="129"/>
         <source>Username</source>
-        <translation type="unfinished"></translation>
+        <translation>Kullanıcı adı</translation>
     </message>
     <message>
         <location filename="../RemotePushDialog.cpp" line="73"/>
@@ -6517,7 +6531,7 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../SelectItemsPopup.ui" line="105"/>
         <source>Sele&amp;cted</source>
-        <translation>&amp;Seçilen</translation>
+        <translation>&amp;Seçili</translation>
     </message>
 </context>
 <context>
@@ -6540,7 +6554,7 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../SqlExecutionArea.ui" line="91"/>
         <source>Shift+F3</source>
-        <translation></translation>
+        <translation>Shift+F3</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.ui" line="105"/>
@@ -6565,12 +6579,12 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../SqlExecutionArea.ui" line="131"/>
         <source>The found pattern must match in letter case</source>
-        <translation>Bulunan desen büyük küçük harfe duyarlı olmalıdır</translation>
+        <translation>Bulunan desen büyük/küçük harfe duyarlı olmalıdır</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.ui" line="134"/>
         <source>Case Sensitive</source>
-        <translation>Büyük küçük harfe duyarı</translation>
+        <translation>Büyük/küçük harfe duyarı</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.ui" line="141"/>
@@ -6585,7 +6599,7 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../SqlExecutionArea.ui" line="151"/>
         <source>F3</source>
-        <translation></translation>
+        <translation>F3</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.ui" line="158"/>
@@ -6606,7 +6620,7 @@ Are you sure you want to proceed?</source>
         <location filename="../SqlExecutionArea.ui" line="184"/>
         <location filename="../SqlExecutionArea.ui" line="187"/>
         <source>Close Find Bar</source>
-        <translation>Araba çubuğunu kapat</translation>
+        <translation>Bulma Çubuğunu Kapat</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.ui" line="232"/>
@@ -6626,17 +6640,17 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../SqlExecutionArea.cpp" line="37"/>
         <source>Ctrl+PgUp</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+PgUp</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.cpp" line="42"/>
         <source>Ctrl+PgDown</source>
-        <translation type="unfinished"></translation>
+        <translation>Ctrl+PgDown</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.cpp" line="256"/>
         <source>Couldn&apos;t read file &quot;%1&quot;: %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>&quot;%1&quot; dosyası okunamadı: %2.</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.cpp" line="286"/>
@@ -6657,17 +6671,17 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../SqlExecutionArea.cpp" line="335"/>
         <source>Answer &quot;Yes to All&quot; to reload the file on any external update without further prompting.</source>
-        <translation type="unfinished"></translation>
+        <translation>Herhangi bir harici güncellemede fazla soru sormadan dosyayı yeniden yüklemek için &quot;Tümüne Evet&quot; yanıtını verin.</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.cpp" line="337"/>
         <source>Answer &quot;No to All&quot; to ignore any external update without further prompting.</source>
-        <translation type="unfinished"></translation>
+        <translation>Herhangi bir harici güncellemeyi fazla uyarı almadan yok saymak için &quot;Tümüne Hayır&quot; cevabını verin.</translation>
     </message>
     <message>
         <location filename="../SqlExecutionArea.cpp" line="339"/>
         <source>Modifying and saving the file will restore prompting.</source>
-        <translation type="unfinished"></translation>
+        <translation>Dosyayı düzenleyip kaydettiğinizde istem tekrar aktif olacak.</translation>
     </message>
 </context>
 <context>
@@ -6723,7 +6737,7 @@ Are you sure you want to proceed?</source>
     <message>
         <location filename="../SqlUiLexer.cpp" line="87"/>
         <source>(X,Y,Z) The iif(X,Y,Z) function returns the value Y if X is true, and Z otherwise.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X,Y,Z) The iif(X,Y,Z) fonksiyonu, X doğruysa Y değerini, aksi takdirde Z değerini döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="88"/>
@@ -6970,13 +6984,13 @@ Bu işlevin kullanımına Tercihler&apos;den izin verilmelidir.</translation>
     <message>
         <location filename="../SqlUiLexer.cpp" line="142"/>
         <source>(expr,offset) If the offset argument is provided, then it must be a non-negative integer. In this case the value returned is the result of evaluating expr against the row offset rows before the current row within the partition. If offset is 0, then expr is evaluated against the current row. If there is no row offset rows before the current row, NULL is returned.</source>
-        <translation>(expr,offset) Uzaklık değişkeni sağlanırsa, negatif olmayan bir tam sayı olmalıdır. Bu durumda, döndürülen değer, bölüm içindeki geçerli satırdan önce satır ofseti satırlarına göre ifade değerlendirmesinin sonucudur. Ofset 0 ise, ifade geçerli satıra göre değerlendirilir. Geçerli satırdan önce satır kaydırma satırları yoksa, NULL döndürülür.</translation>
+        <translation>(expr,offset) Uzaklık değişkeni sağlanırsa negatif olmayan bir tam sayı olmalıdır. Bu durumda, döndürülen değer, bölüm içindeki geçerli satırdan önce satır ofseti satırlarına göre ifade değerlendirmesinin sonucudur. Ofset 0 ise ifade geçerli satıra göre değerlendirilir. Geçerli satırdan önce satır kaydırma satırları yoksa NULL döndürülür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="143"/>
         <location filename="../SqlUiLexer.cpp" line="146"/>
         <source>(expr,offset,default) If default is also provided, then it is returned instead of NULL if the row identified by offset does not exist.</source>
-        <translation>(expr,offset,default) Varsayılan da sağlanmışsa, ofset ile tanımlanan satır yoksa NULL döndürülür.</translation>
+        <translation>(expr,offset,default) Varsayılan da sağlanmışsa ofset ile tanımlanan satır yoksa NULL döndürülür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="144"/>
@@ -6986,7 +7000,7 @@ Bu işlevin kullanımına Tercihler&apos;den izin verilmelidir.</translation>
     <message>
         <location filename="../SqlUiLexer.cpp" line="145"/>
         <source>(expr,offset) If the offset argument is provided, then it must be a non-negative integer. In this case the value returned is the result of evaluating expr against the row offset rows after the current row within the partition. If offset is 0, then expr is evaluated against the current row. If there is no row offset rows after the current row, NULL is returned.</source>
-        <translation>(expr,offset) Uzaklık değişkeni sağlanırsa, negatif olmayan bir tam sayı olmalıdır. Bu durumda, döndürülen değer, bölüm içindeki geçerli satırdan sonra ifade ofset satırlarına göre ifade değerlendirmesinin sonucudur. Ofset 0 ise, ifade geçerli satıra göre değerlendirilir. Geçerli satırdan sonra satır ofseti satırı yoksa, NULL döndürülür.</translation>
+        <translation>(expr,offset) Uzaklık değişkeni sağlanırsa negatif olmayan bir tam sayı olmalıdır. Bu durumda, döndürülen değer, bölüm içindeki geçerli satırdan sonra ifade ofset satırlarına göre ifade değerlendirmesinin sonucudur. Ofset 0 ise ifade geçerli satıra göre değerlendirilir. Geçerli satırdan sonra satır ofseti satırı yoksa NULL döndürülür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="147"/>
@@ -7001,145 +7015,145 @@ Bu işlevin kullanımına Tercihler&apos;den izin verilmelidir.</translation>
     <message>
         <location filename="../SqlUiLexer.cpp" line="149"/>
         <source>(expr,N) This built-in window function calculates the window frame for each row in the same way as an aggregate window function. It returns the value of expr evaluated against the row N of the window frame. Rows are numbered within the window frame starting from 1 in the order defined by the ORDER BY clause if one is present, or in arbitrary order otherwise. If there is no Nth row in the partition, then NULL is returned.</source>
-        <translation>(expr,N) Bu yerleşik pencere işlevi, her satır için pencere çerçevesini birleştirilmiş pencere işlevi ile aynı şekilde hesaplar. Pencere çerçevesinin N satırına göre değerlendirilen ifade değerini döndürür. Satırlar, pencere çerçevesi içinde 1&apos;den başlayarak, ORDER BY deyimi tarafından varsa veya başka bir şekilde rastgele sırada numaralandırılır. Bölümde N&apos;inci satırı yoksa, NULL döndürülür.</translation>
+        <translation>(expr,N) Bu yerleşik pencere işlevi, her satır için pencere çerçevesini birleştirilmiş pencere işlevi ile aynı şekilde hesaplar. Pencere çerçevesinin N satırına göre değerlendirilen ifade değerini döndürür. Satırlar, pencere çerçevesi içinde 1&apos;den başlayarak, ORDER BY deyimi tarafından varsa veya başka bir şekilde rastgele sırada numaralandırılır. Bölümde N&apos;inci satırı yoksa NULL döndürülür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="155"/>
         <source>(X) Return the arccosine of X. The result is in radians.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in ark kosinüsünü döndür. Sonuç radyan cinsindendir.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="156"/>
         <source>(X) Return the hyperbolic arccosine of X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in hiperbolik ark kosinüsünü döndür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="157"/>
         <source>(X) Return the arcsine of X. The result is in radians.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in ark sinüsünü döndürür. Sonuç radyan cinsindendir.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="158"/>
         <source>(X) Return the hyperbolic arcsine of X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in hiperbolik ark sinüsünü döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="159"/>
         <source>(X) Return the arctangent of X. The result is in radians.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in ark tanjantını döndürür Sonuç radyan cinsindendir.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="160"/>
         <source>(X,Y) Return the arctangent of Y/X. The result is in radians. The result is placed into correct quadrant depending on the signs of X and Y.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X,Y) Y/X&apos;in ark tanjantını döndürür. Sonuç radyan cinsindendir. Sonuç, X ve Y&apos;nin işaretlerine bağlı olarak doğru kadrana yerleştirilir.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="161"/>
         <source>(X) Return the hyperbolic arctangent of X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in hiperbolik ark tanjantını döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="162"/>
         <location filename="../SqlUiLexer.cpp" line="163"/>
         <source>(X) Return the first representable integer value greater than or equal to X. For positive values of X, this routine rounds away from zero. For negative values of X, this routine rounds toward zero.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;ten büyük veya ona eşit ilk temsil edilebilir tam sayı değerini döndürür. X&apos;in pozitif değerleri için bu rutin sıfırdan uzaklaşır. X&apos;in negatif değerleri için bu rutin sıfıra doğru yuvarlar.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="164"/>
         <source>(X) Return the cosine of X. X is in radians.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in kosinüsünü döndürür. X radyan cinsindendir.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="165"/>
         <source>(X) Return the hyperbolic cosine of X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in hiperbolik kosinüsünü döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="166"/>
         <source>(X) Convert value X from radians into degrees.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X değerini radyandan dereceye dönüştürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="167"/>
         <source>(X) Compute e (Euler&apos;s number, approximately 2.71828182845905) raised to the power X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) e&apos;nin (Euler sayısı, yaklaşık 2.71828182845905) X kuvvetine yükseltilmiş halini hesaplayın.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="168"/>
         <source>(X) Return the first representable integer value less than or equal to X. For positive numbers, this function rounds toward zero. For negative numbers, this function rounds away from zero.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;ten küçük veya ona eşit ilk temsil edilebilir tam sayı değerini döndürür. Pozitif sayılar için bu fonksiyon sıfıra doğru yuvarlar. Negatif sayılar için bu fonksiyon sıfırdan uzaklaşır.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="169"/>
         <source>(X) Return the natural logarithm of X.</source>
-        <translation type="unfinished"></translation>
+        <translation>X) X&apos;in doğal logaritmasını döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="170"/>
         <source>(B,X) Return the base-B logarithm of X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(B,X) X&apos;in B tabanındaki logaritmasını döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="171"/>
         <location filename="../SqlUiLexer.cpp" line="172"/>
         <source>(X) Return the base-10 logarithm for X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in 10 tabanlı logaritmasını döndür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="173"/>
         <source>(X) Return the logarithm base-2 for the number X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X sayısının 2 tabanındaki logaritmasını döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="174"/>
         <source>(X,Y) Return the remainder after dividing X by Y.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X,Y) X&apos;i Y&apos;ye böldükten sonra kalanı döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="175"/>
         <source>() Return an approximation for π.</source>
-        <translation type="unfinished"></translation>
+        <translation>() π için bir yaklaşım değeri döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="176"/>
         <location filename="../SqlUiLexer.cpp" line="177"/>
         <source>(X,Y) Compute X raised to the power Y.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X,Y) X&apos;in Y&apos;ye yükseltilmiş değerini hesaplayın.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="178"/>
         <source>(X) Convert X from degrees into radians.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;i dereceden radyana dönüştürün.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="179"/>
         <source>(X) Return the sine of X. X is in radians.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in sinüsünü döndürür. X radyan cinsindendir.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="180"/>
         <source>(X) Return the hyperbolic sine of X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in hiperbolik sinüsünü döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="181"/>
         <source>(X) Return the square root of X. NULL is returned if X is negative.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in karekökünü döndürür. X negatifse NULL döndürülür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="182"/>
         <source>(X) Return the tangent of X. X is in radians.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in tanjantını döndürür. X radyan cinsindendir.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="183"/>
         <source>(X) Return the hyperbolic tangent of X.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X&apos;in hiperbolik tanjantını döndürür.</translation>
     </message>
     <message>
         <location filename="../SqlUiLexer.cpp" line="184"/>
         <source>(X) Return the representable integer in between X and 0 (inclusive) that is furthest away from zero. Or, in other words, return the integer part of X, rounding toward zero.</source>
-        <translation type="unfinished"></translation>
+        <translation>(X) X ile 0 (dahil) arasında sıfırdan en uzak olan gösterilebilir tam sayıyı döndürür. Ya da başka bir deyişle, X&apos;in tam sayı kısmını sıfıra yuvarlayarak döndürür.</translation>
     </message>
 </context>
 <context>
@@ -7216,12 +7230,12 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
  - Ctrl+&apos; for copying the value from the cell above.
  - Standard selection and copy/paste operations.</source>
         <translation>Bu veritabanı tablosu görünümüdür. Aşağıdaki işlemleri yapabilirsiniz:
-&#xa0; - Satır içi değeri düzenlemek için yazmaya başlayın.
+&#xa0; - Değeri satır içi olarak düzenlemek için yazmaya başlayın.
 &#xa0; - İçeriklerini hücre düzenleyici penceresinde düzenlemek için herhangi bir kaydı çift tıklayın.
-&#xa0; - Hücre içeriğini NULL&apos;a dönüştürmek için Alt + Del tuşlarına basın.
-&#xa0; - Geçerli kaydı çoğaltmak için Ctrl + &quot;tuşlarına basın.
+&#xa0;  -Hücre içeriğini NULL olarak silmek için Alt+Del tuşlarına basın.
+&#xa0; - Geçerli kaydı kopyalamak için Ctrl + &quot;tuşlarına basın.
 &#xa0; - Yukarıdaki hücreden değeri kopyalamak için Ctrl + &apos;.
-&#xa0; - Standart seçim ve kopyalama / yapıştırma işlemleri.</translation>
+&#xa0; - Standart seçim ve kopyala / yapıştır işlemleri.</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="254"/>
@@ -7271,7 +7285,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="304"/>
         <source>Case Sensitive</source>
-        <translation>Büyük Küçük Harfe Duyarlı</translation>
+        <translation>Büyük/Küçük Harfe Duyarlı</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="311"/>
@@ -7286,7 +7300,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="321"/>
         <source>Interpret search pattern as a regular expression</source>
-        <translation>Arama desenini düzenliifade olarak yorumlama</translation>
+        <translation>Arama desenini düzenli ifade olarak yorumla</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="324"/>
@@ -7338,44 +7352,44 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="676"/>
         <source>Export to &amp;JSON</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;JSON&apos;a aktar</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="679"/>
         <location filename="../TableBrowser.ui" line="682"/>
         <source>Export the filtered data to JSON</source>
-        <translation type="unfinished"></translation>
+        <translation>Filtrelenmiş verileri JSON&apos;a aktar</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="685"/>
         <source>This button exports the data of the browsed table as currently displayed (after filters, display formats and order column) as a JSON file.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu buton, taranan tablonun verilerini şu anda görüntülendiği şekilde (filtreler, görüntüleme biçimleri ve sıralama sütunundan sonra) JSON dosyası olarak dışa aktarır.</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="754"/>
         <source>Copy column name</source>
-        <translation type="unfinished"></translation>
+        <translation>Sütun adını kopyala</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="757"/>
         <source>Copy the database table column name to your clipboard</source>
-        <translation type="unfinished"></translation>
+        <translation>Veritabanı tablosu sütun adını panonuza kopyalayın</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="826"/>
         <source>New Data Browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Veri Tarayıcısı</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="829"/>
         <location filename="../TableBrowser.ui" line="832"/>
         <source>Add a new docked Data Browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni bir yerleşik Veri Tarayıcısı ekleyin</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="835"/>
         <source>This button adds a new docked Data Browser, which you can detach and arrange in different layouts.</source>
-        <translation type="unfinished"></translation>
+        <translation>Bu düğme, farklı düzenlerde ayırıp düzenleyebileceğiniz yeni bir yerleşik Veri Tarayıcısı ekler.</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="454"/>
@@ -7435,7 +7449,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="515"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clicking this button navigates up to the end in the table view above.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Bu düğmeye tıklandığında yukarıdaki tablo görünümünde en sona gidilir.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="518"/>
@@ -7455,7 +7469,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="548"/>
         <source>Go to:</source>
-        <translation>Bu kayda gidin:</translation>
+        <translation>Git:</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="555"/>
@@ -7465,7 +7479,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="558"/>
         <source>Type a record number in this area and click the Go to: button to display the record in the database view</source>
-        <translation>Bu alana veritabanı görünümünde görüntülemek istediğiniz kayıt numarasını giriniz ve Bu kayda gidin butonuna tıklayınız</translation>
+        <translation>Bu alana veritabanı görünümünde görüntülemek istediğiniz kayıt numarasını giriniz ve Git butonuna tıklayınız</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="561"/>
@@ -7475,7 +7489,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="573"/>
         <source>Show rowid column</source>
-        <translation>rowid sütununu göster</translation>
+        <translation>Rowid sütununu göster</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="576"/>
@@ -7609,7 +7623,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="725"/>
         <source>Hide selected column(s)</source>
-        <translation>Seçilen sütunları gizle</translation>
+        <translation>Seçili sütunları gizle</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="730"/>
@@ -7625,22 +7639,22 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
         <location filename="../TableBrowser.ui" line="738"/>
         <location filename="../TableBrowser.cpp" line="1506"/>
         <source>Set encoding</source>
-        <translation>Kodlama seç</translation>
+        <translation>Kodlamayı ayarla</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="741"/>
         <source>Change the encoding of the text in the table cells</source>
-        <translation>Tablo hücrelerindeki metnin kodlamasını değiştirme</translation>
+        <translation>Tablo hücrelerindeki metnin kodlamasını değiştir</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="746"/>
         <source>Set encoding for all tables</source>
-        <translation>Tüm tablolar için kodlama seç</translation>
+        <translation>Tüm tablolar için kodlama ayarla</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="749"/>
         <source>Change the default encoding assumed for all tables in the database</source>
-        <translation>Veritabanındaki tüm tablolar için varsayılan kodlamayı değiştirme</translation>
+        <translation>Veritabanındaki tüm tablolar için varsayılan kodlamayı değiştir</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="766"/>
@@ -7687,7 +7701,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="811"/>
         <source>Print currently browsed table data. Print selection if more than one cell is selected.</source>
-        <translation>Şu anda görüntülenen tablo verilerini yazdırın. Birden fazla hücre seçilirse seçimi yazdırın.</translation>
+        <translation>Şu anda görüntülenen tablo verilerini yazdır. Birden fazla hücre seçilirse seçimi yazdır.</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="814"/>
@@ -7727,12 +7741,12 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.ui" line="1091"/>
         <source>Freeze columns</source>
-        <translation type="unfinished"></translation>
+        <translation>Sütunları dondur</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="1094"/>
         <source>Make all columns from the first column up to this column not move when scrolling horizontally</source>
-        <translation type="unfinished"></translation>
+        <translation>Yatay kaydırma sırasında ilk sütundan bu sütuna kadar olan tüm sütunların hareket etmemesini sağlayın</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="883"/>
@@ -7817,7 +7831,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
         <location filename="../TableBrowser.ui" line="1024"/>
         <location filename="../TableBrowser.ui" line="1027"/>
         <source>Font Color</source>
-        <translation>Yazı Rengi</translation>
+        <translation>Yazı Tipi Rengi</translation>
     </message>
     <message>
         <location filename="../TableBrowser.ui" line="1036"/>
@@ -7859,7 +7873,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.cpp" line="43"/>
         <source>Filter in any column</source>
-        <translation type="unfinished"></translation>
+        <translation>Herhangi bir sütunda filtreleme yapın</translation>
     </message>
     <message>
         <location filename="../TableBrowser.cpp" line="113"/>
@@ -7898,17 +7912,17 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.cpp" line="769"/>
         <source>%L1 - %L2 of &gt;= %L3</source>
-        <translation type="unfinished"></translation>
+        <translation>%L1 - %L2 of &gt;= %L3</translation>
     </message>
     <message>
         <location filename="../TableBrowser.cpp" line="772"/>
         <source>%L1 - %L2 of %L3</source>
-        <translation type="unfinished"></translation>
+        <translation>%L1 - %L2 of %L3</translation>
     </message>
     <message>
         <location filename="../TableBrowser.cpp" line="774"/>
         <source> (clipped at %L1 rows)</source>
-        <translation type="unfinished"></translation>
+        <translation> (%L1 satırlarında kesildi)</translation>
     </message>
     <message>
         <location filename="../TableBrowser.cpp" line="1026"/>
@@ -7933,12 +7947,12 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.cpp" line="1293"/>
         <source>Ctrl+&quot;</source>
-        <translation></translation>
+        <translation>Ctrl+&quot;</translation>
     </message>
     <message>
         <location filename="../TableBrowser.cpp" line="1312"/>
         <source>Adjust rows to contents</source>
-        <translation>Satırları içeriklere göre ayarlama</translation>
+        <translation>Satırları içeriklere göre ayarla</translation>
     </message>
     <message>
         <location filename="../TableBrowser.cpp" line="1376"/>
@@ -7950,7 +7964,7 @@ Buraya atlamak için %3Shift&apos;e basılı tutun ve tıklayın</translation>
     <message>
         <location filename="../TableBrowser.cpp" line="1381"/>
         <source>Please select a record first</source>
-        <translation>Lütfen öncelikle kaydı seçiniz</translation>
+        <translation>Lütfen önce bir kayıt seçin</translation>
     </message>
     <message>
         <location filename="../TableBrowser.cpp" line="1502"/>
@@ -7985,22 +7999,22 @@ Veritabanı kodlamasını kullanmak için alanı boş bırakın.</translation>
     <message>
         <location filename="../TableBrowserDock.cpp" line="72"/>
         <source>New Data Browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Yeni Veri Tarayıcısı</translation>
     </message>
     <message>
         <location filename="../TableBrowserDock.cpp" line="76"/>
         <source>Rename Data Browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Veri Tarayıcısını Yeniden Adlandır</translation>
     </message>
     <message>
         <location filename="../TableBrowserDock.cpp" line="82"/>
         <source>Close Data Browser</source>
-        <translation type="unfinished"></translation>
+        <translation>Veri Tarayıcısını Kapat</translation>
     </message>
     <message>
         <location filename="../TableBrowserDock.cpp" line="99"/>
         <source>Set a new name for the data browser. Use the &apos;&amp;&amp;&apos; character to allow using the following character as a keyboard shortcut.</source>
-        <translation type="unfinished"></translation>
+        <translation>Veri tarayıcısı için yeni bir ad belirleyin. Aşağıdaki karakteri klavye kısayolu olarak kullanabilmek için &apos;&amp;&amp;&apos; karakterini kullanın.</translation>
     </message>
 </context>
 <context>
@@ -8018,7 +8032,7 @@ Veritabanı kodlamasını kullanmak için alanı boş bırakın.</translation>
     <message>
         <location filename="../VacuumDialog.ui" line="39"/>
         <source>Please select the databases to co&amp;mpact:</source>
-        <translation>Sıkıştır&amp;mak istediğiniz veritabanını seçiniz:</translation>
+        <translation>Sıkıştır&amp;mak istediğiniz veritabanını seçin:</translation>
     </message>
 </context>
 </TS>


### PR DESCRIPTION
Remarks:
1) Untranslated line entries have been completed.
2) Punctuation and typo corrections have been made.
3) The gray areas in the image(1) cannot be manipulated. Are these the lines that need to be deleted? I think they're disabled. I couldn't find an option to update these lines in QT Linguist 6.9.1.
4) Furthermore, despite the complete translation, there are phrases in the program's interface that appear in English.
imaje(2)
<img width="682" height="354" alt="imaje 1" src="https://github.com/user-attachments/assets/03e149bd-7538-4e1b-aa26-659805cd9d89" />
<img width="571" height="407" alt="imaje 2" src="https://github.com/user-attachments/assets/eb56da56-cb97-401f-9ed9-2d4dfaf6c261" />
