### PR TITLE
Fix appstream warnings

### DIFF
--- a/distri/sqlitebrowser.desktop.appdata.xml
+++ b/distri/sqlitebrowser.desktop.appdata.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>sqlitebrowser.desktop</id>
+  <id>org.sqlitebrowser.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>MPL-2.0 and GPL-3.0+</project_license>
-  <developer_name>DB Browser for SQLite developers</developer_name>
+  <developer id="org.sqlitebrowser">
+    <name>DB Browser for SQLite developers</name>
+  </developer>
   <name>DB Browser for SQLite</name>
-  <summary>light GUI editor for SQLite databases</summary>
+  <summary>Light GUI editor for SQLite databases</summary>
   <description>
     <p>DB Browser for SQLite is a high quality, visual, open source tool to create, design, and edit database files compatible with SQLite.</p>
     <p>It is for users and developers wanting to create databases, search, and edit data. It uses a familiar spreadsheet-like interface, and you don't need to learn complicated SQL commands.</p>


### PR DESCRIPTION
Hello,

While working on the Debian packaging, I noticed the following AppStream warnings:
```
% appstreamcli validate distri/sqlitebrowser.desktop.appdata.xml
W: sqlitebrowser.desktop:3: cid-desktopapp-is-not-rdns sqlitebrowser.desktop
I: sqlitebrowser.desktop:6: developer-name-tag-deprecated
I: sqlitebrowser.desktop:8: summary-first-word-not-capitalized
I: sqlitebrowser.desktop:~: developer-info-missing

? Validation failed: warnings: 1, infos: 3
```

This PR makes `appstreamcli validate` happy.