### PR TITLE
Add keywords to sqlitebrowser.desktop

### DIFF
--- a/distri/sqlitebrowser.desktop
+++ b/distri/sqlitebrowser.desktop
@@ -4,6 +4,7 @@ Comment=DB Browser for SQLite is a light GUI editor for SQLite databases
 Comment[de]=DB Browser for SQLite ist ein GUI-Editor für SQLite-Datenbanken
 Comment[fr]=Un éditeur graphique léger pour les bases de données SQLite
 Comment[es]=«DB Browser for SQLite» es un editor gráfico de bases de datos SQLite
+Keywords=sqlite;database;browser;
 Exec=sqlitebrowser %f
 Icon=sqlitebrowser
 Terminal=false


### PR DESCRIPTION
Lintian (the packaging quality tool of Debian) complains that the `.desktop` file of sqlitebrowser [doesn't have a `Keywords` entry](https://lintian.debian.org/tags/desktop-entry-lacks-keywords-entry).

So, this PR adds few keywords that came to my mind.