### PR TITLE
Fix virtual table sql file export typo

### DIFF
--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -913,9 +913,14 @@ bool DBBrowserDB::dump(const QString& filePath,
                 else {
                     QString statement = QString::fromStdString(it->originalSql());
                     if(keepOldSchema) {
-                        // The statement is guaranteed by SQLite to start with "CREATE TABLE"
-                        const int createTableLength = 12;
-                        statement.replace(0, createTableLength, "CREATE TABLE IF NOT EXISTS");
+                        if (statement.startsWith("CREATE VIRTUAL TABLE", Qt::CaseInsensitive)) {
+                            const int createTableLength = 20;
+                            statement.replace(0, createTableLength, "CREATE VIRTUAL TABLE IF NOT EXISTS");
+                        } else {
+                            // The statement is guaranteed by SQLite to start with "CREATE TABLE"
+                            const int createTableLength = 12;
+                            statement.replace(0, createTableLength, "CREATE TABLE IF NOT EXISTS");
+                        }
                     }
                     stream << statement << ";\n";
                 }


### PR DESCRIPTION
**Problem**
Exporting a database with virtual tables and "Keep old schema" enabled would result in invalid SQL like the one below
```
BEGIN TRANSACTION;
CREATE TABLE IF NOT EXISTSAL TABLE ...
```

**Changes**
Add conditional-if to handle virtual tables in DBBrowserDB::dump sqlitedb.cpp when generating/exporting the sql dump.