### PR TITLE
Update AppStream versions

### DIFF
--- a/distri/sqlitebrowser.desktop.appdata.xml
+++ b/distri/sqlitebrowser.desktop.appdata.xml
@@ -47,9 +47,11 @@
   <url type="homepage">https://sqlitebrowser.org/</url>
   <url type="bugtracker">https://github.com/sqlitebrowser/sqlitebrowser/issues</url>
   <releases>
-    <release version="3.13.0-rc1" date="2023-11-11" />
+    <release version="3.13.1" date="2024-10-16" />
+    <release version="3.13.0" date="2024-07-23" />
     <release version="3.12.2" date="2021-05-17" />
     <release version="3.12.1" date="2020-11-09" />
+    <release version="3.12.0" date="2020-06-25" />
   </releases>
   <launchable type="desktop-id">sqlitebrowser.desktop</launchable>
 </component>


### PR DESCRIPTION
I took the recent releases and omitted the pre-releases. Not updating means people constantly complain that the @flatpak is outdated even though it is not.
* https://github.com/flathub/org.sqlitebrowser.sqlitebrowser/issues/43
* https://github.com/flathub/org.sqlitebrowser.sqlitebrowser/issues/44