### PR TITLE
Fix: Preserve leading spaces in database structure view (Issue #3893)

### DIFF
--- a/src/DbStructureModel.cpp
+++ b/src/DbStructureModel.cpp
@@ -55,7 +55,7 @@ QVariant DbStructureModel::data(const QModelIndex& index, int role) const
         if(index.column() == ColumnName && item->parent() == browsablesRootItem)
             return QString::fromStdString(sqlb::ObjectIdentifier(item->text(ColumnSchema).toStdString(), item->text(ColumnName).toStdString()).toDisplayString());
         else
-            return Settings::getValue("db", "hideschemalinebreaks").toBool() ? item->text(index.column()).simplified() : item->text(index.column());
+            return Settings::getValue("db", "hideschemalinebreaks").toBool() ? item->text(index.column()).trimmed() : item->text(index.column());
     case Qt::EditRole:
         return item->text(index.column());
     case Qt::ToolTipRole: {


### PR DESCRIPTION
## Summary
Fixes issue #3893 where leading spaces in table and column names are being collapsed in the database structure view.

## Changes
- Changed `simplified()` to `trimmed()` on line 58 of DbStructureModel.cpp
- `simplified()` collapses all whitespace (including leading/trailing and internal)
- `trimmed()` only removes leading and trailing whitespace, preserving internal spaces

## Related Issues
Closes #3893