### PR TITLE
Fix: Prevent create table interface crashing bug (Issue #2779)

### DIFF
--- a/src/sql/sqlitetypes.cpp
+++ b/src/sql/sqlitetypes.cpp
@@ -461,8 +461,8 @@ void Table::addKeyToConstraint(std::shared_ptr<UniqueConstraint> constraint, con
             auto new_columns = it->first;
             new_columns.emplace_back(key, false);
 
-            m_indexConstraints.insert(std::make_pair(new_columns, it->second));
             it = m_indexConstraints.erase(it);
+            m_indexConstraints.insert(std::make_pair(new_columns, constraint));
         }
         else
         {
@@ -482,12 +482,15 @@ void Table::removeKeyFromConstraint(std::shared_ptr<UniqueConstraint> constraint
             std::copy_if(it->first.begin(), it->first.end(), std::back_inserter(new_columns), [key](const auto& c) { return c != key; });
 
             // If the column list is empty now, remove the entire constraint. Otherwise save the updated column list
-            if(new_columns.empty())
+            if (new_columns.empty())
             {
                 it = m_indexConstraints.erase(it);
-            } else {
-                m_indexConstraints.insert(std::make_pair(new_columns, it->second));
+            }
+            else
+            {
+                auto savedConstraint = it->second;
                 it = m_indexConstraints.erase(it);
+                m_indexConstraints.insert(std::make_pair(new_columns, savedConstraint));
             }
         } else {
             ++it;
@@ -510,8 +513,8 @@ void Table::removeKeyFromAllConstraints(const std::string& key)
             {
                 it = container.erase(it);
             } else {
-                container.insert(std::make_pair(new_columns, it->second));
                 it = container.erase(it);
+                container.insert(std::make_pair(new_columns, it->second));
             }
         } else {
             ++it;


### PR DESCRIPTION
Fixed a MacOS bug that caused the app to crash when removing one of mutiple primary keys in the create table wizard, which was likely causing [issue 2779](https://github.com/sqlitebrowser/sqlitebrowser/issues/2779).

Crash Log:
```
Thread 0 Crashed:
0   DB Browser for SQLite         	       0x102dcfb94 sqlb::Table::removeKeyFromConstraint(std::__1::shared_ptr<sqlb::UniqueConstraint>, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) + 884
```