### PR TITLE
Fix crash in SQL query results when stale editor positions are used

### DIFF
--- a/distri/sqlitebrowser.desktop.appdata.xml
+++ b/distri/sqlitebrowser.desktop.appdata.xml
@@ -46,6 +46,11 @@
   </screenshots>
   <url type="homepage">https://sqlitebrowser.org/</url>
   <url type="bugtracker">https://github.com/sqlitebrowser/sqlitebrowser/issues</url>
+  <url type="donation">https://www.patreon.com/db4s</url>
+  <url type="faq">https://github.com/sqlitebrowser/sqlitebrowser/wiki/Frequently-Asked-Questions</url>
+  <url type="translate">https://github.com/sqlitebrowser/sqlitebrowser/wiki/Translations</url>
+  <url type="contribute">https://github.com/sqlitebrowser/sqlitebrowser/wiki#for-developers</url>
+  <url type="vcs-browser">https://github.com/sqlitebrowser/sqlitebrowser</url>
   <releases>
     <release version="3.13.0-rc1" date="2023-11-11" />
     <release version="3.12.2" date="2021-05-17" />

--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -257,10 +257,7 @@ ExtendedTableWidget::ExtendedTableWidget(QWidget* parent) :
     m_frozen_column_count(0),
     m_item_border_delegate(new ItemBorderDelegate(this))
 {
-    // Fix behaviour for ElideMode
-    if(Settings::getValue("databrowser", "cell_word_wrap").toBool()) {
-        setWordWrap(false);
-    }
+    setWordWrap(Settings::getValue("databrowser", "cell_word_wrap").toBool());
 
     setHorizontalScrollMode(ExtendedTableWidget::ScrollPerPixel);
     // Force ScrollPerItem, so scrolling shows all table rows
@@ -517,9 +514,7 @@ void ExtendedTableWidget::reloadSettings()
     if(m_frozen_table_view)
         m_frozen_table_view->reloadSettings();
 
-    bool word_wrap = Settings::getValue("databrowser", "cell_word_wrap").toBool();
-    if(wordWrap() ^ word_wrap)
-        setWordWrap(word_wrap);
+    setWordWrap(Settings::getValue("databrowser", "cell_word_wrap").toBool());
 }
 
 bool ExtendedTableWidget::copyMimeData(const QModelIndexList& fromIndices, QMimeData* mimeData, const bool withHeaders, const bool inSQL)

--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -257,6 +257,9 @@ ExtendedTableWidget::ExtendedTableWidget(QWidget* parent) :
     m_frozen_column_count(0),
     m_item_border_delegate(new ItemBorderDelegate(this))
 {
+    // Fix behaviour for ElideMode
+    setWordWrap(false);
+
     setHorizontalScrollMode(ExtendedTableWidget::ScrollPerPixel);
     // Force ScrollPerItem, so scrolling shows all table rows
     setVerticalScrollMode(ExtendedTableWidget::ScrollPerItem);

--- a/src/ExtendedTableWidget.cpp
+++ b/src/ExtendedTableWidget.cpp
@@ -258,7 +258,9 @@ ExtendedTableWidget::ExtendedTableWidget(QWidget* parent) :
     m_item_border_delegate(new ItemBorderDelegate(this))
 {
     // Fix behaviour for ElideMode
-    setWordWrap(false);
+    if(Settings::getValue("databrowser", "cell_word_wrap").toBool()) {
+        setWordWrap(false);
+    }
 
     setHorizontalScrollMode(ExtendedTableWidget::ScrollPerPixel);
     // Force ScrollPerItem, so scrolling shows all table rows
@@ -514,6 +516,10 @@ void ExtendedTableWidget::reloadSettings()
     verticalHeader()->setDefaultSectionSize(fontMetrics.height()+10);
     if(m_frozen_table_view)
         m_frozen_table_view->reloadSettings();
+
+    bool word_wrap = Settings::getValue("databrowser", "cell_word_wrap").toBool();
+    if(wordWrap() ^ word_wrap)
+        setWordWrap(word_wrap);
 }
 
 bool ExtendedTableWidget::copyMimeData(const QModelIndexList& fromIndices, QMimeData* mimeData, const bool withHeaders, const bool inSQL)

--- a/src/ImportCsvDialog.cpp
+++ b/src/ImportCsvDialog.cpp
@@ -17,6 +17,7 @@
 #include <QTextStream>
 #include <QFileInfo>
 #include <memory>
+#include <regex>
 
 // Enable this line to show basic performance stats after each imported CSV file. Please keep in mind that while these
 // numbers might help to estimate the performance of the algorithm, this is not a proper benchmark.
@@ -71,11 +72,13 @@ ImportCsvDialog::ImportCsvDialog(const std::vector<QString>& filenames, DBBrowse
     ui->comboSeparator->blockSignals(true);
     ui->comboQuote->blockSignals(true);
     ui->comboEncoding->blockSignals(true);
+    ui->checkReplaceNonAlnum->blockSignals(true);
 
     ui->checkboxHeader->setChecked(Settings::getValue("importcsv", "firstrowheader").toBool());
     ui->checkBoxTrimFields->setChecked(Settings::getValue("importcsv", "trimfields").toBool());
     ui->checkBoxSeparateTables->setChecked(Settings::getValue("importcsv", "separatetables").toBool());
     ui->checkLocalConventions->setChecked(Settings::getValue("importcsv", "localconventions").toBool());
+    ui->checkReplaceNonAlnum->setChecked(Settings::getValue("importcsv", "replacenonalnum").toBool());
     setSeparatorChar(getSettingsChar("importcsv", "separator"));
     setQuoteChar(getSettingsChar("importcsv", "quotecharacter"));
     setEncoding(Settings::getValue("importcsv", "encoding").toString());
@@ -87,6 +90,7 @@ ImportCsvDialog::ImportCsvDialog(const std::vector<QString>& filenames, DBBrowse
     ui->comboSeparator->blockSignals(false);
     ui->comboQuote->blockSignals(false);
     ui->comboEncoding->blockSignals(false);
+    ui->checkReplaceNonAlnum->blockSignals(false);
 
     // Prepare and show interface depending on how many files are selected
     if (csvFilenames.size() > 1)
@@ -193,6 +197,7 @@ void ImportCsvDialog::accept()
     Settings::setValue("importcsv", "separatetables", ui->checkBoxSeparateTables->isChecked());
     Settings::setValue("importcsv", "localconventions", ui->checkLocalConventions->isChecked());
     Settings::setValue("importcsv", "encoding", currentEncoding());
+    Settings::setValue("importcsv", "replacenonalnum", ui->checkReplaceNonAlnum->isChecked());
 
     // Get all the selected files and start the import
     if (ui->filePickerBlock->isVisible())
@@ -425,6 +430,13 @@ sqlb::FieldVector ImportCsvDialog::generateFieldList(const QString& filename) co
             {
                 // Take field name from CSV
                 fieldname = std::string(rowData.fields[i].data, rowData.fields[i].data_length);
+
+                // Replace any non-nlphanumeric characters with an underscore
+                if(ui->checkReplaceNonAlnum->isChecked())
+                {
+                    std::regex pattern("[^a-zA-Z0-9_]");
+                    fieldname = std::regex_replace(fieldname, pattern, "_");
+                }
             }
 
             // If we don't have a field name by now, generate one
@@ -879,6 +891,8 @@ void ImportCsvDialog::toggleAdvancedSection(bool show)
     ui->checkIgnoreDefaults->setVisible(show);
     ui->labelOnConflictStrategy->setVisible(show);
     ui->comboOnConflictStrategy->setVisible(show);
+    ui->labelReplaceNonAlnum->setVisible(show);
+    ui->checkReplaceNonAlnum->setVisible(show);
 }
 
 char32_t ImportCsvDialog::toUtf8(const QString& s) const

--- a/src/ImportCsvDialog.ui
+++ b/src/ImportCsvDialog.ui
@@ -399,6 +399,23 @@
        </property>
       </widget>
      </item>
+     <item row="13" column="1">
+      <widget class="QCheckBox" name="checkReplaceNonAlnum">
+       <property name="toolTip">
+        <string>Replace non-alphanumeric characters in column name with an underscore.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="13" column="0">
+      <widget class="QLabel" name="labelReplaceNonAlnum">
+       <property name="text">
+        <string>Replace non-alphanumeric in column name</string>
+       </property>
+       <property name="buddy">
+        <cstring>checkReplaceNonAlnum</cstring>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -792,6 +809,12 @@
      <y>358</y>
     </hint>
    </hints>
+  </connection>
+  <connection>
+   <sender>checkReplaceNonAlnum</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>ImportCsvDialog</receiver>
+   <slot>updatePreview()</slot>
   </connection>
  </connections>
  <slots>

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -583,7 +583,11 @@ bool MainWindow::fileOpen(const QString& fileName, bool openFromProject, bool re
                     loadPragmas();
 
                 refreshTableBrowsers();
-
+                if (db.readOnly()) {
+                    if (!fileSystemWatch.files().isEmpty())
+                        fileSystemWatch.removePaths(fileSystemWatch.files());
+                    fileSystemWatch.addPath(wFile);
+                }
                 retval = true;
             } else {
                 QMessageBox::warning(this, qApp->applicationName(), tr("Could not open database file.\nReason: %1").arg(db.lastError()));
@@ -700,6 +704,10 @@ void MainWindow::refreshTableBrowsers(bool all)
     QApplication::restoreOverrideCursor();
 }
 
+void MainWindow::refreshDb() {
+    refreshTableBrowsers();
+}
+
 bool MainWindow::fileSaveAs() {
 
     QString fileName =  FileDialog::getSaveFileName(
@@ -743,6 +751,8 @@ bool MainWindow::fileClose()
     if(!db.close())
         return false;
 
+    if (!fileSystemWatch.files().isEmpty())
+        fileSystemWatch.removePaths(fileSystemWatch.files());
     TableBrowser::resetSharedSettings();
     setCurrentFile(QString());
     loadPragmas();
@@ -2462,6 +2472,14 @@ void MainWindow::reloadSettings()
 
     ui->actionDropQualifiedCheck->setChecked(Settings::getValue("SchemaDock", "dropQualifiedNames").toBool());
     ui->actionEnquoteNamesCheck->setChecked(Settings::getValue("SchemaDock", "dropEnquotedNames").toBool());
+
+    if (Settings::getValue("db", "watcher").toBool())
+        connect(&fileSystemWatch, &QFileSystemWatcher::fileChanged, this, &MainWindow::refreshDb, Qt::UniqueConnection);
+    else {
+        disconnect(&fileSystemWatch, &QFileSystemWatcher::fileChanged, nullptr, nullptr);
+        if (!fileSystemWatch.files().isEmpty())
+            fileSystemWatch.removePaths(fileSystemWatch.files());
+    }
 }
 
 void MainWindow::checkNewVersion(const bool automatic)

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1245,26 +1245,50 @@ void MainWindow::executeQuery()
     // Prepare a lambda function for logging the results of a query
     auto logged_queries = std::make_shared<QString>();
     auto query_logger = [sqlWidget, editor, logged_queries](bool ok, const QString& status_message, int from_position, int to_position) {
+        int editor_length = editor->length();
+        int lines = editor->lines();
+        if(editor_length == 0 || lines == 0)
+        {
+            sqlWidget->finishExecution(status_message, ok);
+            return;
+        }
+
+        from_position = qBound(0, from_position, editor_length);
+        to_position = qBound(0, to_position, editor_length);
+
+        // Clamp a (line, index) pair from lineIndexFromPosition to valid editor bounds.
+        auto clampToEditor = [&](int& line, int& index) {
+            line = qMin(line, lines - 1);
+            index = qMin(index, editor->text(line).size());
+        };
+
         int execute_from_line, execute_from_index;
         editor->lineIndexFromPosition(from_position, &execute_from_line, &execute_from_index);
+        clampToEditor(execute_from_line, execute_from_index);
 
         // Special case: if the start position is at the end of a line, then move to the beginning of next line.
         // Otherwise for the typical case, the line reference is one less than expected.
         // Note that execute_from_index uses character positions and not byte positions, so at() can be used.
-        QChar char_at_index = editor->text(execute_from_line).at(execute_from_index);
-        if (char_at_index == '\r' || char_at_index == '\n') {
-            execute_from_line++;
-            // The next lines could be empty, so skip all of them too.
-            while(editor->text(execute_from_line).trimmed().isEmpty())
+        QString line_text = editor->text(execute_from_line);
+        if(execute_from_index < line_text.size())
+        {
+            QChar char_at_index = line_text.at(execute_from_index);
+            if (char_at_index == '\r' || char_at_index == '\n') {
                 execute_from_line++;
-            execute_from_index = 0;
+                // The next lines could be empty, so skip all of them too.
+                while(execute_from_line < lines && editor->text(execute_from_line).trimmed().isEmpty())
+                    execute_from_line++;
+                execute_from_index = 0;
+            }
         }
+        clampToEditor(execute_from_line, execute_from_index);
 
         // If there was an error highlight the erroneous SQL statement
         if(!ok)
         {
             int end_of_current_statement_line, end_of_current_statement_index;
             editor->lineIndexFromPosition(to_position, &end_of_current_statement_line, &end_of_current_statement_index);
+            clampToEditor(end_of_current_statement_line, end_of_current_statement_index);
             editor->setErrorIndicator(execute_from_line, execute_from_index, end_of_current_statement_line, end_of_current_statement_index);
 
             editor->setCursorPosition(execute_from_line, execute_from_index);
@@ -1272,7 +1296,9 @@ void MainWindow::executeQuery()
 
         // Log the query and the result message.
         // The query takes the last placeholder as it may itself contain the sequence '%' + number.
-        QString query = editor->text(from_position, to_position);
+        QString query;
+        if(from_position < to_position)
+            query = editor->text(from_position, to_position);
         QString log_message = "-- " + tr("At line %1:").arg(execute_from_line+1) + "\n" + query.trimmed() + "\n-- " + tr("Result: %1").arg(status_message);
         logged_queries->append(log_message + "\n");
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -6,7 +6,9 @@
 
 #include <memory>
 #include <vector>
+
 #include <QMainWindow>
+#include <QFileSystemWatcher>
 
 struct BrowseDataTableSettings;
 class DbStructureModel;
@@ -121,6 +123,8 @@ private:
     QString currentProjectFilename;
     bool isProjectModified;
 
+    QFileSystemWatcher fileSystemWatch;
+
     void init();
     void clearCompleterModelsFields();
 
@@ -176,6 +180,7 @@ private slots:
     void fileNewInMemoryDatabase(bool open_create_dialog = true);
     // Refresh visible table browsers. When all is true, refresh all browsers.
     void refreshTableBrowsers(bool all = false);
+    void refreshDb();
     bool fileClose();
     bool fileSaveAs();
     void createTable();

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -99,6 +99,7 @@ void PreferencesDialog::loadSettings()
     }
 
     ui->spinStructureFontSize->setValue(Settings::getValue("db", "fontsize").toInt());
+    ui->watcherCheckBox->setChecked(Settings::getValue("db", "watcher").toBool());
 
     // Gracefully handle the preferred Data Browser font not being available
     int matchingFont = ui->comboDataBrowserFont->findText(Settings::getValue("databrowser", "font").toString(), Qt::MatchExactly);
@@ -197,6 +198,7 @@ void PreferencesDialog::saveSettings(bool accept)
     Settings::setValue("db", "defaultsqltext", ui->editDatabaseDefaultSqlText->text());
     Settings::setValue("db", "defaultfieldtype", ui->defaultFieldTypeComboBox->currentIndex());
     Settings::setValue("db", "fontsize", ui->spinStructureFontSize->value());
+    Settings::setValue("db", "watcher", ui->watcherCheckBox->isChecked());
 
     Settings::setValue("checkversion", "enabled", ui->checkUpdates->isChecked());
 

--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -119,6 +119,7 @@ void PreferencesDialog::loadSettings()
     ui->spinSymbolLimit->setValue(Settings::getValue("databrowser", "symbol_limit").toInt());
     ui->spinCompleteThreshold->setValue(Settings::getValue("databrowser", "complete_threshold").toInt());
     ui->checkShowImagesInline->setChecked(Settings::getValue("databrowser", "image_preview").toBool());
+    ui->checkCellWordWrap->setChecked(Settings::getValue("databrowser", "cell_word_wrap").toBool());
     ui->txtNull->setText(Settings::getValue("databrowser", "null_text").toString());
     ui->txtBlob->setText(Settings::getValue("databrowser", "blob_text").toString());
     ui->editFilterEscape->setText(Settings::getValue("databrowser", "filter_escape").toString());
@@ -202,6 +203,7 @@ void PreferencesDialog::saveSettings(bool accept)
     Settings::setValue("databrowser", "font", ui->comboDataBrowserFont->currentText());
     Settings::setValue("databrowser", "fontsize", ui->spinDataBrowserFontSize->value());
     Settings::setValue("databrowser", "image_preview", ui->checkShowImagesInline->isChecked());
+    Settings::setValue("databrowser", "cell_word_wrap", ui->checkCellWordWrap->isChecked());
     saveColorSetting(ui->fr_null_fg, "null_fg");
     saveColorSetting(ui->fr_null_bg, "null_bg");
     saveColorSetting(ui->fr_reg_fg, "reg_fg");

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -739,6 +739,29 @@ in new project file</string>
          <item row="5" column="1">
           <widget class="QSpinBox" name="spinStructureFontSize"/>
          </item>
+         <item row="6" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="toolTip">
+            <string>When the database is open in readonly mode, watch the database file and refresh when it is updated.</string>
+           </property>
+           <property name="text">
+            <string>&amp;When readonly, refresh on changed file</string>
+           </property>
+           <property name="buddy">
+            <cstring>watcherCheckBox</cstring>
+           </property>
+          </widget>
+         </item>
+       <item row="6" column="1">
+        <widget class="QCheckBox" name="watcherCheckBox">
+         <property name="text">
+          <string>enabled</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
         </layout>
        </item>
        <item>

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -1212,6 +1212,16 @@ in new project file</string>
               </property>
              </widget>
             </item>
+            <item row="3" column="0">
+             <widget class="QLabel" name="labelCellWordWrap">
+              <property name="text">
+               <string>Disable word wrap in cell</string>
+              </property>
+              <property name="buddy">
+               <cstring>checkCellWordWrap</cstring>
+              </property>
+             </widget>
+            </item>
             <item row="0" column="1">
              <widget class="QSpinBox" name="spinSymbolLimit">
               <property name="correctionMode">
@@ -1252,6 +1262,13 @@ Can be set to 0 for disabling completion.</string>
              <widget class="QCheckBox" name="checkShowImagesInline">
               <property name="toolTip">
                <string>Enable this option to show a preview of BLOBs containing image data in the cells. This can affect the performance of the data browser, however.</string>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1">
+             <widget class="QCheckBox" name="checkCellWordWrap">
+              <property name="toolTip">
+               <string>Enable this option to turn off word wrap in the cells.</string>
               </property>
              </widget>
             </item>
@@ -1981,6 +1998,7 @@ Can be set to 0 for disabling completion.</string>
   <tabstop>spinSymbolLimit</tabstop>
   <tabstop>spinCompleteThreshold</tabstop>
   <tabstop>checkShowImagesInline</tabstop>
+  <tabstop>checkCellWordWrap</tabstop>
   <tabstop>spinFilterDelay</tabstop>
   <tabstop>editFilterEscape</tabstop>
   <tabstop>treeSyntaxHighlighting</tabstop>

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -1215,7 +1215,7 @@ in new project file</string>
             <item row="3" column="0">
              <widget class="QLabel" name="labelCellWordWrap">
               <property name="text">
-               <string>Disable word wrap in cell</string>
+               <string>Enable word wrap in cell</string>
               </property>
               <property name="buddy">
                <cstring>checkCellWordWrap</cstring>
@@ -1268,7 +1268,7 @@ Can be set to 0 for disabling completion.</string>
             <item row="3" column="1">
              <widget class="QCheckBox" name="checkCellWordWrap">
               <property name="toolTip">
-               <string>Enable this option to turn off word wrap in the cells.</string>
+               <string>Enable this option to turn on word wrap in the cells.</string>
               </property>
              </widget>
             </item>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -304,7 +304,7 @@ QVariant Settings::getDefaultValue(const std::string& group, const std::string& 
         if(name == "image_preview")
             return false;
         if(name == "cell_word_wrap")
-            return false;
+            return true;
         if(name == "indent_compact")
             return false;
         if (name == "sort_keys")

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -303,6 +303,8 @@ QVariant Settings::getDefaultValue(const std::string& group, const std::string& 
             return 1000;
         if(name == "image_preview")
             return false;
+        if(name == "cell_word_wrap")
+            return false;
         if(name == "indent_compact")
             return false;
         if (name == "sort_keys")

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -159,6 +159,10 @@ QVariant Settings::getDefaultValue(const std::string& group, const std::string& 
     if(group == "db" && name == "fontsize")
         return 10;
 
+    // db/watcher?
+    if(group == "db" && name == "watcher")
+        return false;
+
     // exportcsv/firstrowheader?
     if(group == "exportcsv" && name == "firstrowheader")
         return true;

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -913,9 +913,14 @@ bool DBBrowserDB::dump(const QString& filePath,
                 else {
                     QString statement = QString::fromStdString(it->originalSql());
                     if(keepOldSchema) {
-                        // The statement is guaranteed by SQLite to start with "CREATE TABLE"
-                        const int createTableLength = 12;
-                        statement.replace(0, createTableLength, "CREATE TABLE IF NOT EXISTS");
+                        if (statement.startsWith("CREATE VIRTUAL TABLE", Qt::CaseInsensitive)) {
+                            const int createTableLength = 20;
+                            statement.replace(0, createTableLength, "CREATE VIRTUAL TABLE IF NOT EXISTS");
+                        } else {
+                            // The statement is guaranteed by SQLite to start with "CREATE TABLE"
+                            const int createTableLength = 12;
+                            statement.replace(0, createTableLength, "CREATE TABLE IF NOT EXISTS");
+                        }
                     }
                     stream << statement << ";\n";
                 }

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -25,6 +25,32 @@
 #include <cstring>
 #include <functional>
 
+namespace {
+
+bool equalsIgnoreCase(const std::string& lhs, const std::string& rhs)
+{
+    if(lhs.size() != rhs.size())
+        return false;
+
+    return std::equal(lhs.begin(), lhs.end(), rhs.begin(), rhs.end(), [](unsigned char a, unsigned char b) {
+        return std::tolower(a) == std::tolower(b);
+    });
+}
+
+template<typename MapType>
+typename MapType::const_iterator findCaseInsensitive(const MapType& map, const std::string& key)
+{
+    auto it = map.find(key);
+    if(it != map.end())
+        return it;
+
+    return std::find_if(map.begin(), map.end(), [&key](const auto& entry) {
+        return equalsIgnoreCase(entry.first, key);
+    });
+}
+
+}
+
 const QStringList DBBrowserDB::journalModeValues = {"DELETE", "TRUNCATE", "PERSIST", "MEMORY", "WAL", "OFF"};
 const QStringList DBBrowserDB::lockingModeValues = {"NORMAL", "EXCLUSIVE"};
 
@@ -2223,6 +2249,66 @@ std::vector<std::pair<std::string, std::string>> DBBrowserDB::queryColumnInforma
     }
 
     return result;
+}
+
+const sqlb::TablePtr DBBrowserDB::getTableByName(const sqlb::ObjectIdentifier& name) const
+{
+    if(schemata.empty() || name.schema().empty() || name.name().empty())
+        return sqlb::TablePtr{};
+
+    const auto schemaIt = findCaseInsensitive(schemata, name.schema());
+    if(schemaIt == schemata.end())
+        return sqlb::TablePtr{};
+
+    const auto& tables = schemaIt->second.tables;
+    if(tables.empty())
+        return sqlb::TablePtr{};
+
+    const auto tableIt = findCaseInsensitive(tables, name.name());
+    if(tableIt == tables.end())
+        return sqlb::TablePtr{};
+
+    return tableIt->second;
+}
+
+const sqlb::IndexPtr DBBrowserDB::getIndexByName(const sqlb::ObjectIdentifier& name) const
+{
+    if(schemata.empty() || name.schema().empty() || name.name().empty())
+        return sqlb::IndexPtr{};
+
+    const auto schemaIt = findCaseInsensitive(schemata, name.schema());
+    if(schemaIt == schemata.end())
+        return sqlb::IndexPtr{};
+
+    const auto& indices = schemaIt->second.indices;
+    if(indices.empty())
+        return sqlb::IndexPtr{};
+
+    const auto indexIt = findCaseInsensitive(indices, name.name());
+    if(indexIt == indices.end())
+        return sqlb::IndexPtr{};
+
+    return indexIt->second;
+}
+
+const sqlb::TriggerPtr DBBrowserDB::getTriggerByName(const sqlb::ObjectIdentifier& name) const
+{
+    if(schemata.empty() || name.schema().empty() || name.name().empty())
+        return sqlb::TriggerPtr{};
+
+    const auto schemaIt = findCaseInsensitive(schemata, name.schema());
+    if(schemaIt == schemata.end())
+        return sqlb::TriggerPtr{};
+
+    const auto& triggers = schemaIt->second.triggers;
+    if(triggers.empty())
+        return sqlb::TriggerPtr{};
+
+    const auto triggerIt = findCaseInsensitive(triggers, name.name());
+    if(triggerIt == triggers.end())
+        return sqlb::TriggerPtr{};
+
+    return triggerIt->second;
 }
 
 std::string DBBrowserDB::generateSavepointName(const std::string& identifier) const

--- a/src/sqlitedb.h
+++ b/src/sqlitedb.h
@@ -228,35 +228,14 @@ public:
      */
     bool alterTable(const sqlb::ObjectIdentifier& tablename, const sqlb::Table& new_table, AlterTableTrackColumns track_columns, std::string newSchemaName = std::string());
 
-    const sqlb::TablePtr getTableByName(const sqlb::ObjectIdentifier& name) const
-    {
-        if(schemata.empty() || name.schema().empty() || !schemata.count(name.schema()))
-            return sqlb::TablePtr{};
-        const auto& schema = schemata.at(name.schema());
-        if(schema.tables.count(name.name()))
-            return schema.tables.at(name.name());
-        return sqlb::TablePtr{};
-    }
+    // Given that sqlite3 does not allow case-differing identifiers, and in some
+    // situations the stored name in `schemata` may differ only in case from the name used in
+    // the stored SQL create statement (like issue #4110), the search of these get*Name
+    // functions is case-insensitive, if not found as is.
 
-    const sqlb::IndexPtr getIndexByName(const sqlb::ObjectIdentifier& name) const
-    {
-        if(schemata.empty() || name.schema().empty())
-            return sqlb::IndexPtr{};
-        const auto& schema = schemata.at(name.schema());
-        if(schema.indices.count(name.name()))
-            return schema.indices.at(name.name());
-        return sqlb::IndexPtr{};
-    }
-
-    const sqlb::TriggerPtr getTriggerByName(const sqlb::ObjectIdentifier& name) const
-    {
-        if(schemata.empty() || name.schema().empty())
-            return sqlb::TriggerPtr{};
-        const auto& schema = schemata.at(name.schema());
-        if(schema.triggers.count(name.name()))
-            return schema.triggers.at(name.name());
-        return sqlb::TriggerPtr{};
-    }
+    const sqlb::TablePtr getTableByName(const sqlb::ObjectIdentifier& name) const;
+    const sqlb::IndexPtr getIndexByName(const sqlb::ObjectIdentifier& name) const;
+    const sqlb::TriggerPtr getTriggerByName(const sqlb::ObjectIdentifier& name) const;
 
     bool isOpen() const;
     bool encrypted() const { return isEncrypted; }


### PR DESCRIPTION
Fixes #4109

## Summary

Random crash when a cell with ordinary text is selected in the SQL query results table.

**Root cause:** The query_logger lambda in MainWindow.cpp captures the SQL editor state and is invoked via Qt::QueuedConnection. By the time it executes asynchronously, the editor content may have changed, making from_position/to_position stale. This triggers a Scintilla assertion failure in SCI_GETTEXTRANGE when positions are out of bounds.

**Fix:**
- Added a clampToEditor helper that clamps line and index values to valid editor bounds
- Applied clamping to all position calculations used in the query_logger lambda
- Ensured sqlWidget->finishExecution() is called before any early return to avoid hanging the UI

## Testing

- Built successfully on Windows 11 with MSVC 2026, Qt 5.15.2
- Manually tested SQL query execution - no crashes when selecting cells in results