### PR TITLE
Fix: always prompt when closing a single SQL tab with unsaved content…

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2096,11 +2096,17 @@ bool MainWindow::askSaveSqlTab(int index, bool& ignoreUnattachedBuffers, bool si
 
     if(sqlExecArea->getEditor()->isModified()) {
         if(sqlExecArea->fileName().isEmpty() && !ignoreUnattachedBuffers && (singleTabClose || isPromptSQLTabsInNewProject)) {
-            // Once the project is saved, remaining SQL tabs will not be modified, so this is only expected to be asked once.
-            QString message = currentProjectFilename.isEmpty() ?
-                tr("Do you want to save the changes made to SQL tabs in a new project file?") :
-                tr("Do you want to save the changes made to SQL tabs in the project file '%1'?").
-                arg(QFileInfo(currentProjectFilename).fileName());
+            // For single-tab closes, always prompt with singular wording.
+            // For bulk closes, only asked once after project save.
+            QString message = singleTabClose ?
+                (currentProjectFilename.isEmpty() ?
+                    tr("Do you want to save the changes made to this SQL tab in a new project file?") :
+                    tr("Do you want to save the changes made to this SQL tab in the project file '%1'?").
+                    arg(QFileInfo(currentProjectFilename).fileName())) :
+                (currentProjectFilename.isEmpty() ?
+                    tr("Do you want to save the changes made to SQL tabs in a new project file?") :
+                    tr("Do you want to save the changes made to SQL tabs in the project file '%1'?").
+                    arg(QFileInfo(currentProjectFilename).fileName()));
             QMessageBox::StandardButton reply = QMessageBox::question(nullptr,
                                                                       QApplication::applicationName(),
                                                                       message,

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2089,13 +2089,13 @@ void MainWindow::logSql(const QString& sql, int msgtype)
 // Ask user to save the buffer in the specified tab index.
 // ignoreUnattachedBuffers is used to store answer about buffers not linked to files, so user is only asked once about them.
 // Return true unless user wants to cancel the invoking action.
-bool MainWindow::askSaveSqlTab(int index, bool& ignoreUnattachedBuffers)
+bool MainWindow::askSaveSqlTab(int index, bool& ignoreUnattachedBuffers, bool singleTabClose)
 {
     SqlExecutionArea* sqlExecArea = qobject_cast<SqlExecutionArea*>(ui->tabSqlAreas->widget(index));
     const bool isPromptSQLTabsInNewProject = Settings::getValue("General", "promptsqltabsinnewproject").toBool();
 
     if(sqlExecArea->getEditor()->isModified()) {
-        if(sqlExecArea->fileName().isEmpty() && !ignoreUnattachedBuffers && isPromptSQLTabsInNewProject) {
+        if(sqlExecArea->fileName().isEmpty() && !ignoreUnattachedBuffers && (singleTabClose || isPromptSQLTabsInNewProject)) {
             // Once the project is saved, remaining SQL tabs will not be modified, so this is only expected to be asked once.
             QString message = currentProjectFilename.isEmpty() ?
                 tr("Do you want to save the changes made to SQL tabs in a new project file?") :
@@ -2154,7 +2154,7 @@ void MainWindow::closeSqlTab(int index, bool force, bool askSaving)
     }
     // Ask for saving and comply with cancel answer.
     bool ignoreUnattachedBuffers = false;
-    if (askSaving && !askSaveSqlTab(index, ignoreUnattachedBuffers))
+    if (askSaving && !askSaveSqlTab(index, ignoreUnattachedBuffers, true))
         return;
     // Remove the tab and delete the widget
     QWidget* w = ui->tabSqlAreas->widget(index);

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -142,7 +142,7 @@ private:
     QString saveOpenTabs();
     void saveProject(const QString& currentFilename);
     bool closeProject();
-    bool askSaveSqlTab(int index, bool& ignoreUnattachedBuffers);
+    bool askSaveSqlTab(int index, bool& ignoreUnattachedBuffers, bool singleTabClose = false);
     void focusSqlEditor();
     void moveDocksTo(Qt::DockWidgetArea area);
 


### PR DESCRIPTION
Fixes #4128

## Problem
When closing an individual SQL tab that belongs to a saved project,
the save prompt was gated behind the `promptsqltabsinnewproject`
preference setting. If a user had that setting disabled, closing a
single tab would silently discard its content with no warning.

The root cause: `askSaveSqlTab()` was called the same way whether
closing the entire app (bulk path via `closeFiles()`) or closing a
single tab (via `closeSqlTab()`). The preference makes sense for
the bulk path but not for a deliberate single-tab close.

## Fix
Added a `singleTabClose` parameter (default `false`) to
`askSaveSqlTab()`. When `closeSqlTab()` calls it, it passes `true`,
bypassing the preference check and always prompting if the tab
has unsaved content. The `closeFiles()` bulk path is unchanged.

## How to test
1. Open a database → Execute SQL tab → type any query
2. File → Save Project → save as test.sqbpro
3. Type new content in the SQL tab
4. Click ✕ to close the tab
5. ✅ "Do you want to save?" prompt appears
6. Repeat but close the entire app after saving → ✅ no prompt