### PR TITLE
Add walking up parent directories when loading dotenv files

### DIFF
--- a/src/PreferencesDialog.cpp
+++ b/src/PreferencesDialog.cpp
@@ -100,6 +100,7 @@ void PreferencesDialog::loadSettings()
 
     ui->spinStructureFontSize->setValue(Settings::getValue("db", "fontsize").toInt());
     ui->watcherCheckBox->setChecked(Settings::getValue("db", "watcher").toBool());
+    ui->checkSQLCipherParentDotenvLookup->setChecked(Settings::getValue("db", "sqlcipherparentdotenvlookup").toBool());
 
     // Gracefully handle the preferred Data Browser font not being available
     int matchingFont = ui->comboDataBrowserFont->findText(Settings::getValue("databrowser", "font").toString(), Qt::MatchExactly);
@@ -199,6 +200,7 @@ void PreferencesDialog::saveSettings(bool accept)
     Settings::setValue("db", "defaultfieldtype", ui->defaultFieldTypeComboBox->currentIndex());
     Settings::setValue("db", "fontsize", ui->spinStructureFontSize->value());
     Settings::setValue("db", "watcher", ui->watcherCheckBox->isChecked());
+    Settings::setValue("db", "sqlcipherparentdotenvlookup", ui->checkSQLCipherParentDotenvLookup->isChecked());
 
     Settings::setValue("checkversion", "enabled", ui->checkUpdates->isChecked());
 

--- a/src/PreferencesDialog.ui
+++ b/src/PreferencesDialog.ui
@@ -752,16 +752,36 @@ in new project file</string>
            </property>
           </widget>
          </item>
-       <item row="6" column="1">
-        <widget class="QCheckBox" name="watcherCheckBox">
-         <property name="text">
-          <string>enabled</string>
-         </property>
-         <property name="checked">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
+         <item row="6" column="1">
+          <widget class="QCheckBox" name="watcherCheckBox">
+           <property name="text">
+            <string>enabled</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="0">
+          <widget class="QLabel" name="labelSQLCipherParentDotenvLookup">
+           <property name="toolTip">
+            <string>When enabled, DB4S searches parent folders for .db4s.env files, which can slow down opening encrypted databases.</string>
+           </property>
+           <property name="text">
+            <string>Search parent folders for .db4s.env SQLCipher passwords</string>
+           </property>
+           <property name="buddy">
+            <cstring>checkSQLCipherParentDotenvLookup</cstring>
+           </property>
+          </widget>
+         </item>
+         <item row="7" column="1">
+          <widget class="QCheckBox" name="checkSQLCipherParentDotenvLookup">
+           <property name="text">
+            <string>enabled</string>
+           </property>
+          </widget>
+         </item>
         </layout>
        </item>
        <item>

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -163,6 +163,10 @@ QVariant Settings::getDefaultValue(const std::string& group, const std::string& 
     if(group == "db" && name == "watcher")
         return false;
 
+    // db/sqlcipherparentdotenvlookup?
+    if(group == "db" && name == "sqlcipherparentdotenvlookup")
+        return false;
+
     // exportcsv/firstrowheader?
     if(group == "exportcsv" && name == "firstrowheader")
         return true;

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -479,8 +479,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
 
             // Being in a while loop, we don't want to check the same file multiple times
             if (!isDotenvChecked) {
-                QFile databaseFile(filePath);
-                QFileInfo databaseFileInfo(databaseFile);
+                QFileInfo databaseFileInfo(filePath);
 
                 QString databaseDirectoryPath = databaseFileInfo.dir().path();
                 QString databaseFileName(databaseFileInfo.fileName());

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -16,6 +16,7 @@
 #include <QDebug>
 #include <QThread>
 #include <QRegularExpression>
+#include <QSettings>
 
 #include <algorithm>
 #include <array>

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -479,31 +479,31 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
 
             // Being in a while loop, we don't want to check the same file multiple times
             if (!isDotenvChecked) {
-                QFileInfo databaseFileInfo(filePath);
+                const QFileInfo databaseFileInfo(filePath);
 
-                QString databaseDirectoryPath = databaseFileInfo.dir().path();
-                QString databaseFileName(databaseFileInfo.fileName());
+                const QString databaseDirectoryPath = databaseFileInfo.dir().path();
+                const QString databaseFileName(databaseFileInfo.fileName());
 
-                QString dotenvFilePath = databaseDirectoryPath + "/.env";
-                QSettings dotenv(dotenvFilePath, QSettings::IniFormat);
+                const QString dotenvFilePath = databaseDirectoryPath + "/.env";
+                const QSettings dotenv(dotenvFilePath, QSettings::IniFormat);
 
-                QVariant passwordValue = dotenv.value(databaseFileName);
+                const QVariant passwordValue = dotenv.value(databaseFileName);
 
                 foundDotenvPassword = !passwordValue.isNull();
                 isDotenvChecked = true;
 
                 if (foundDotenvPassword)
                 {
-                    std::string password = passwordValue.toString().toStdString();
+                    const std::string password = passwordValue.toString().toStdString();
 
-                    QVariant keyFormatValue = dotenv.value(databaseFileName + "_keyFormat", QVariant(CipherSettings::KeyFormats::Passphrase));
-                    CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(keyFormatValue.toInt());
+                    const QVariant keyFormatValue = dotenv.value(databaseFileName + "_keyFormat", QVariant(CipherSettings::KeyFormats::Passphrase));
+                    const CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(keyFormatValue.toInt());
 
-                    int pageSize = dotenv.value(databaseFileName + "_pageSize", enc_default_page_size).toInt();
-                    int kdfIterations = dotenv.value(databaseFileName + "_kdfIter", enc_default_kdf_iter).toInt();
-                    int plaintextHeaderSize = dotenv.value(databaseFileName + "_plaintextHeaderSize", enc_default_plaintext_header_size).toInt();
-                    std::string hmacAlgorithm = dotenv.value(databaseFileName + "_hmacAlgorithm", QString::fromStdString(enc_default_hmac_algorithm)).toString().toStdString();
-                    std::string kdfAlgorithm = dotenv.value(databaseFileName + "_kdfAlgorithm", QString::fromStdString(enc_default_kdf_algorithm)).toString().toStdString();
+                    const int pageSize = dotenv.value(databaseFileName + "_pageSize", enc_default_page_size).toInt();
+                    const int kdfIterations = dotenv.value(databaseFileName + "_kdfIter", enc_default_kdf_iter).toInt();
+                    const int plaintextHeaderSize = dotenv.value(databaseFileName + "_plaintextHeaderSize", enc_default_plaintext_header_size).toInt();
+                    const std::string hmacAlgorithm = dotenv.value(databaseFileName + "_hmacAlgorithm", QString::fromStdString(enc_default_hmac_algorithm)).toString().toStdString();
+                    const std::string kdfAlgorithm = dotenv.value(databaseFileName + "_kdfAlgorithm", QString::fromStdString(enc_default_kdf_algorithm)).toString().toStdString();
 
                     cipherSettings->setKeyFormat(keyFormat);
                     cipherSettings->setPassword(password);

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -526,13 +526,17 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                     // Deprecated: legacy .env in the database directory only. Remove once .db4s.env is adopted.
                     foundDotenvPassword = tryLoadDotenv(databaseDirectory.filePath(".env"));
 
-                    QDir searchDirectory(databaseDirectory);
-                    while (!foundDotenvPassword && searchDirectory.cdUp())
+                    // Parent folder search is opt-in because it can slow down opening encrypted databases.
+                    if (!foundDotenvPassword && Settings::getValue("db", "sqlcipherparentdotenvlookup").toBool())
                     {
-                        if (tryLoadDotenv(searchDirectory.filePath(".db4s.env")))
+                        QDir searchDirectory(databaseDirectory);
+                        while (searchDirectory.cdUp())
                         {
-                            foundDotenvPassword = true;
-                            break;
+                            if (tryLoadDotenv(searchDirectory.filePath(".db4s.env")))
+                            {
+                                foundDotenvPassword = true;
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -481,7 +481,7 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
             if (!isDotenvChecked) {
                 const QFileInfo databaseFileInfo(filePath);
 
-                QDir searchDirectory(databaseFileInfo.absoluteDir());
+                const QDir databaseDirectory(databaseFileInfo.absoluteDir());
                 const QString databaseFileName(databaseFileInfo.fileName());
 
                 auto tryLoadDotenv = [&](const QString& dotenvFilePath) -> bool {
@@ -516,17 +516,25 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                     return true;
                 };
 
-                while (true)
-                {
-                    const QString dotenvFilePath = searchDirectory.filePath(".env");
-                    if (tryLoadDotenv(dotenvFilePath))
-                    {
-                        foundDotenvPassword = true;
-                        break;
-                    }
+                const QString db4sEnvPath = databaseDirectory.filePath(".db4s.env");
+                const bool hasDB4SEnv = QFile::exists(db4sEnvPath);
 
-                    if (!searchDirectory.cdUp())
-                        break;
+                if (hasDB4SEnv)
+                {
+                    foundDotenvPassword = tryLoadDotenv(db4sEnvPath);
+                } else {
+                    // Deprecated: legacy .env in the database directory only. Remove once .db4s.env is adopted.
+                    foundDotenvPassword = tryLoadDotenv(databaseDirectory.filePath(".env"));
+
+                    QDir searchDirectory(databaseDirectory);
+                    while (!foundDotenvPassword && searchDirectory.cdUp())
+                    {
+                        if (tryLoadDotenv(searchDirectory.filePath(".db4s.env")))
+                        {
+                            foundDotenvPassword = true;
+                            break;
+                        }
+                    }
                 }
 
                 isDotenvChecked = true;

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -484,39 +484,45 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                 QDir searchDirectory(databaseFileInfo.absoluteDir());
                 const QString databaseFileName(databaseFileInfo.fileName());
 
+                auto tryLoadDotenv = [&](const QString& dotenvFilePath) -> bool {
+                    if (!QFile::exists(dotenvFilePath))
+                        return false;
+
+                    const QSettings dotenv(dotenvFilePath, QSettings::IniFormat);
+                    const QVariant passwordValue = dotenv.value(databaseFileName);
+
+                    if (passwordValue.isNull())
+                        return false;
+
+                    const std::string password = passwordValue.toString().toStdString();
+
+                    const QVariant keyFormatValue = dotenv.value(databaseFileName + "_keyFormat", QVariant(CipherSettings::KeyFormats::Passphrase));
+                    const CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(keyFormatValue.toInt());
+
+                    const int pageSize = dotenv.value(databaseFileName + "_pageSize", enc_default_page_size).toInt();
+                    const int kdfIterations = dotenv.value(databaseFileName + "_kdfIter", enc_default_kdf_iter).toInt();
+                    const int plaintextHeaderSize = dotenv.value(databaseFileName + "_plaintextHeaderSize", enc_default_plaintext_header_size).toInt();
+                    const std::string hmacAlgorithm = dotenv.value(databaseFileName + "_hmacAlgorithm", QString::fromStdString(enc_default_hmac_algorithm)).toString().toStdString();
+                    const std::string kdfAlgorithm = dotenv.value(databaseFileName + "_kdfAlgorithm", QString::fromStdString(enc_default_kdf_algorithm)).toString().toStdString();
+
+                    cipherSettings->setKeyFormat(keyFormat);
+                    cipherSettings->setPassword(password);
+                    cipherSettings->setPageSize(pageSize);
+                    cipherSettings->setKdfIterations(kdfIterations);
+                    cipherSettings->setHmacAlgorithm("HMAC_" + hmacAlgorithm);
+                    cipherSettings->setKdfAlgorithm("PBKDF2_HMAC_" + kdfAlgorithm);
+                    cipherSettings->setPlaintextHeaderSize(plaintextHeaderSize);
+
+                    return true;
+                };
+
                 while (true)
                 {
                     const QString dotenvFilePath = searchDirectory.filePath(".env");
-                    if (QFile::exists(dotenvFilePath))
+                    if (tryLoadDotenv(dotenvFilePath))
                     {
-                        const QSettings dotenv(dotenvFilePath, QSettings::IniFormat);
-                        const QVariant passwordValue = dotenv.value(databaseFileName);
-
-                        foundDotenvPassword = !passwordValue.isNull();
-
-                        if (foundDotenvPassword)
-                        {
-                            const std::string password = passwordValue.toString().toStdString();
-
-                            const QVariant keyFormatValue = dotenv.value(databaseFileName + "_keyFormat", QVariant(CipherSettings::KeyFormats::Passphrase));
-                            const CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(keyFormatValue.toInt());
-
-                            const int pageSize = dotenv.value(databaseFileName + "_pageSize", enc_default_page_size).toInt();
-                            const int kdfIterations = dotenv.value(databaseFileName + "_kdfIter", enc_default_kdf_iter).toInt();
-                            const int plaintextHeaderSize = dotenv.value(databaseFileName + "_plaintextHeaderSize", enc_default_plaintext_header_size).toInt();
-                            const std::string hmacAlgorithm = dotenv.value(databaseFileName + "_hmacAlgorithm", QString::fromStdString(enc_default_hmac_algorithm)).toString().toStdString();
-                            const std::string kdfAlgorithm = dotenv.value(databaseFileName + "_kdfAlgorithm", QString::fromStdString(enc_default_kdf_algorithm)).toString().toStdString();
-
-                            cipherSettings->setKeyFormat(keyFormat);
-                            cipherSettings->setPassword(password);
-                            cipherSettings->setPageSize(pageSize);
-                            cipherSettings->setKdfIterations(kdfIterations);
-                            cipherSettings->setHmacAlgorithm("HMAC_" + hmacAlgorithm);
-                            cipherSettings->setKdfAlgorithm("PBKDF2_HMAC_" + kdfAlgorithm);
-                            cipherSettings->setPlaintextHeaderSize(plaintextHeaderSize);
-
-                            break;
-                        }
+                        foundDotenvPassword = true;
+                        break;
                     }
 
                     if (!searchDirectory.cdUp())

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -485,33 +485,36 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
                 const QString databaseFileName(databaseFileInfo.fileName());
 
                 const QString dotenvFilePath = databaseDirectoryPath + "/.env";
-                const QSettings dotenv(dotenvFilePath, QSettings::IniFormat);
 
-                const QVariant passwordValue = dotenv.value(databaseFileName);
+                if (QFile::exists(dotenvFilePath)) {
+                    const QSettings dotenv(dotenvFilePath, QSettings::IniFormat);
 
-                foundDotenvPassword = !passwordValue.isNull();
-                isDotenvChecked = true;
+                    const QVariant passwordValue = dotenv.value(databaseFileName);
 
-                if (foundDotenvPassword)
-                {
-                    const std::string password = passwordValue.toString().toStdString();
+                    foundDotenvPassword = !passwordValue.isNull();
+                    isDotenvChecked = true;
 
-                    const QVariant keyFormatValue = dotenv.value(databaseFileName + "_keyFormat", QVariant(CipherSettings::KeyFormats::Passphrase));
-                    const CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(keyFormatValue.toInt());
+                    if (foundDotenvPassword)
+                    {
+                        const std::string password = passwordValue.toString().toStdString();
 
-                    const int pageSize = dotenv.value(databaseFileName + "_pageSize", enc_default_page_size).toInt();
-                    const int kdfIterations = dotenv.value(databaseFileName + "_kdfIter", enc_default_kdf_iter).toInt();
-                    const int plaintextHeaderSize = dotenv.value(databaseFileName + "_plaintextHeaderSize", enc_default_plaintext_header_size).toInt();
-                    const std::string hmacAlgorithm = dotenv.value(databaseFileName + "_hmacAlgorithm", QString::fromStdString(enc_default_hmac_algorithm)).toString().toStdString();
-                    const std::string kdfAlgorithm = dotenv.value(databaseFileName + "_kdfAlgorithm", QString::fromStdString(enc_default_kdf_algorithm)).toString().toStdString();
+                        const QVariant keyFormatValue = dotenv.value(databaseFileName + "_keyFormat", QVariant(CipherSettings::KeyFormats::Passphrase));
+                        const CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(keyFormatValue.toInt());
 
-                    cipherSettings->setKeyFormat(keyFormat);
-                    cipherSettings->setPassword(password);
-                    cipherSettings->setPageSize(pageSize);
-                    cipherSettings->setKdfIterations(kdfIterations);
-                    cipherSettings->setHmacAlgorithm("HMAC_" + hmacAlgorithm);
-                    cipherSettings->setKdfAlgorithm("PBKDF2_HMAC_" + kdfAlgorithm);
-                    cipherSettings->setPlaintextHeaderSize(plaintextHeaderSize);
+                        const int pageSize = dotenv.value(databaseFileName + "_pageSize", enc_default_page_size).toInt();
+                        const int kdfIterations = dotenv.value(databaseFileName + "_kdfIter", enc_default_kdf_iter).toInt();
+                        const int plaintextHeaderSize = dotenv.value(databaseFileName + "_plaintextHeaderSize", enc_default_plaintext_header_size).toInt();
+                        const std::string hmacAlgorithm = dotenv.value(databaseFileName + "_hmacAlgorithm", QString::fromStdString(enc_default_hmac_algorithm)).toString().toStdString();
+                        const std::string kdfAlgorithm = dotenv.value(databaseFileName + "_kdfAlgorithm", QString::fromStdString(enc_default_kdf_algorithm)).toString().toStdString();
+
+                        cipherSettings->setKeyFormat(keyFormat);
+                        cipherSettings->setPassword(password);
+                        cipherSettings->setPageSize(pageSize);
+                        cipherSettings->setKdfIterations(kdfIterations);
+                        cipherSettings->setHmacAlgorithm("HMAC_" + hmacAlgorithm);
+                        cipherSettings->setKdfAlgorithm("PBKDF2_HMAC_" + kdfAlgorithm);
+                        cipherSettings->setPlaintextHeaderSize(plaintextHeaderSize);
+                    }
                 }
             }
 

--- a/src/sqlitedb.cpp
+++ b/src/sqlitedb.cpp
@@ -481,41 +481,49 @@ bool DBBrowserDB::tryEncryptionSettings(const QString& filePath, bool* encrypted
             if (!isDotenvChecked) {
                 const QFileInfo databaseFileInfo(filePath);
 
-                const QString databaseDirectoryPath = databaseFileInfo.dir().path();
+                QDir searchDirectory(databaseFileInfo.absoluteDir());
                 const QString databaseFileName(databaseFileInfo.fileName());
 
-                const QString dotenvFilePath = databaseDirectoryPath + "/.env";
-
-                if (QFile::exists(dotenvFilePath)) {
-                    const QSettings dotenv(dotenvFilePath, QSettings::IniFormat);
-
-                    const QVariant passwordValue = dotenv.value(databaseFileName);
-
-                    foundDotenvPassword = !passwordValue.isNull();
-                    isDotenvChecked = true;
-
-                    if (foundDotenvPassword)
+                while (true)
+                {
+                    const QString dotenvFilePath = searchDirectory.filePath(".env");
+                    if (QFile::exists(dotenvFilePath))
                     {
-                        const std::string password = passwordValue.toString().toStdString();
+                        const QSettings dotenv(dotenvFilePath, QSettings::IniFormat);
+                        const QVariant passwordValue = dotenv.value(databaseFileName);
 
-                        const QVariant keyFormatValue = dotenv.value(databaseFileName + "_keyFormat", QVariant(CipherSettings::KeyFormats::Passphrase));
-                        const CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(keyFormatValue.toInt());
+                        foundDotenvPassword = !passwordValue.isNull();
 
-                        const int pageSize = dotenv.value(databaseFileName + "_pageSize", enc_default_page_size).toInt();
-                        const int kdfIterations = dotenv.value(databaseFileName + "_kdfIter", enc_default_kdf_iter).toInt();
-                        const int plaintextHeaderSize = dotenv.value(databaseFileName + "_plaintextHeaderSize", enc_default_plaintext_header_size).toInt();
-                        const std::string hmacAlgorithm = dotenv.value(databaseFileName + "_hmacAlgorithm", QString::fromStdString(enc_default_hmac_algorithm)).toString().toStdString();
-                        const std::string kdfAlgorithm = dotenv.value(databaseFileName + "_kdfAlgorithm", QString::fromStdString(enc_default_kdf_algorithm)).toString().toStdString();
+                        if (foundDotenvPassword)
+                        {
+                            const std::string password = passwordValue.toString().toStdString();
 
-                        cipherSettings->setKeyFormat(keyFormat);
-                        cipherSettings->setPassword(password);
-                        cipherSettings->setPageSize(pageSize);
-                        cipherSettings->setKdfIterations(kdfIterations);
-                        cipherSettings->setHmacAlgorithm("HMAC_" + hmacAlgorithm);
-                        cipherSettings->setKdfAlgorithm("PBKDF2_HMAC_" + kdfAlgorithm);
-                        cipherSettings->setPlaintextHeaderSize(plaintextHeaderSize);
+                            const QVariant keyFormatValue = dotenv.value(databaseFileName + "_keyFormat", QVariant(CipherSettings::KeyFormats::Passphrase));
+                            const CipherSettings::KeyFormats keyFormat = CipherSettings::getKeyFormat(keyFormatValue.toInt());
+
+                            const int pageSize = dotenv.value(databaseFileName + "_pageSize", enc_default_page_size).toInt();
+                            const int kdfIterations = dotenv.value(databaseFileName + "_kdfIter", enc_default_kdf_iter).toInt();
+                            const int plaintextHeaderSize = dotenv.value(databaseFileName + "_plaintextHeaderSize", enc_default_plaintext_header_size).toInt();
+                            const std::string hmacAlgorithm = dotenv.value(databaseFileName + "_hmacAlgorithm", QString::fromStdString(enc_default_hmac_algorithm)).toString().toStdString();
+                            const std::string kdfAlgorithm = dotenv.value(databaseFileName + "_kdfAlgorithm", QString::fromStdString(enc_default_kdf_algorithm)).toString().toStdString();
+
+                            cipherSettings->setKeyFormat(keyFormat);
+                            cipherSettings->setPassword(password);
+                            cipherSettings->setPageSize(pageSize);
+                            cipherSettings->setKdfIterations(kdfIterations);
+                            cipherSettings->setHmacAlgorithm("HMAC_" + hmacAlgorithm);
+                            cipherSettings->setKdfAlgorithm("PBKDF2_HMAC_" + kdfAlgorithm);
+                            cipherSettings->setPlaintextHeaderSize(plaintextHeaderSize);
+
+                            break;
+                        }
                     }
+
+                    if (!searchDirectory.cdUp())
+                        break;
                 }
+
+                isDotenvChecked = true;
             }
 
             if(foundDotenvPassword)


### PR DESCRIPTION
Previously, only a `.env` file next to the database was checked.
Now parent directories are searched until a matching password entry
is found.

Related-to: 3cdc65a6 (#1404).