### PR TITLE
Feat: add logarithmic scale option for X and Y axes in Plot window

### DIFF
--- a/src/PlotDock.cpp
+++ b/src/PlotDock.cpp
@@ -43,6 +43,8 @@ PlotDock::PlotDock(QWidget* parent)
       m_showLegend(false),
       m_stackedBars(false),
       m_fixedFormat(false),
+      m_logScaleX(false),
+      m_logScaleY(false),
       m_xtype(QVariant::Invalid)
 {
     ui->setupUi(this);
@@ -116,11 +118,24 @@ PlotDock::PlotDock(QWidget* parent)
     fixedFormatsAction->setCheckable(true);
     m_contextMenu->addAction(fixedFormatsAction);
 
-    connect(fixedFormatsAction, &QAction::toggled, this,
-      [=](bool fixed) {
-          m_fixedFormat = fixed;
-          adjustAxisFormat();
-          ui->plotWidget->replot();
+   QAction* logScaleXAction = new QAction(tr("Logarithmic scale (X)"), m_contextMenu);
+    logScaleXAction->setCheckable(true);
+    m_contextMenu->addAction(logScaleXAction);
+
+    connect(logScaleXAction, &QAction::toggled, this, [=](bool log) {
+        m_logScaleX = log;
+        updateLogScale();
+        ui->plotWidget->replot();
+    });
+
+    QAction* logScaleYAction = new QAction(tr("Logarithmic scale (Y)"), m_contextMenu);
+    logScaleYAction->setCheckable(true);
+    m_contextMenu->addAction(logScaleYAction);
+
+    connect(logScaleYAction, &QAction::toggled, this, [=](bool log) {
+        m_logScaleY = log;
+        updateLogScale();
+        ui->plotWidget->replot();
     });
 
     connect(ui->plotWidget, &QTableView::customContextMenuRequested, this,
@@ -544,6 +559,7 @@ void PlotDock::updatePlot(SqliteTableModel* model, BrowseDataTableSettings* sett
         }
 
         ui->plotWidget->rescaleAxes(true);
+        updateLogScale();
         ui->plotWidget->legend->setVisible(m_showLegend);
         // Legend with slightly transparent background brush:
         ui->plotWidget->legend->setBrush(QColor(255, 255, 255, 150));
@@ -1048,7 +1064,26 @@ void PlotDock::adjustAxisFormat()
     adjustOneAxisFormat(ui->plotWidget->yAxis, m_fixedFormat);
     adjustOneAxisFormat(ui->plotWidget->yAxis2, m_fixedFormat);
 }
+void PlotDock::updateLogScale()
+{
+    // Set scale type for X axis
+    ui->plotWidget->xAxis->setScaleType(
+        m_logScaleX ? QCPAxis::stLogarithmic : QCPAxis::stLinear);
 
+    // Set scale type for both Y axes
+    yAxes[0]->setScaleType(
+        m_logScaleY ? QCPAxis::stLogarithmic : QCPAxis::stLinear);
+    yAxes[1]->setScaleType(
+        m_logScaleY ? QCPAxis::stLogarithmic : QCPAxis::stLinear);
+
+    // Log scale breaks on zero/negative values — clamp range minimum to small positive
+    if(m_logScaleX && ui->plotWidget->xAxis->range().lower <= 0)
+        ui->plotWidget->xAxis->setRangeLower(1e-3);
+    if(m_logScaleY && yAxes[0]->range().lower <= 0)
+        yAxes[0]->setRangeLower(1e-3);
+    if(m_logScaleY && yAxes[1]->range().lower <= 0)
+        yAxes[1]->setRangeLower(1e-3);
+}
 void PlotDock::toggleStackedBars(bool stacked)
 {
     m_stackedBars = stacked;

--- a/src/PlotDock.cpp
+++ b/src/PlotDock.cpp
@@ -117,6 +117,13 @@ PlotDock::PlotDock(QWidget* parent)
     QAction* fixedFormatsAction = new QAction(tr("Fixed number format"), m_contextMenu);
     fixedFormatsAction->setCheckable(true);
     m_contextMenu->addAction(fixedFormatsAction);
+    
+    connect(fixedFormatsAction, &QAction::toggled, this,
+    [=](bool fixed) {
+        m_fixedFormat = fixed;
+        adjustAxisFormat();
+        ui->plotWidget->replot();
+    });
 
    QAction* logScaleXAction = new QAction(tr("Logarithmic scale (X)"), m_contextMenu);
     logScaleXAction->setCheckable(true);

--- a/src/PlotDock.cpp
+++ b/src/PlotDock.cpp
@@ -1076,12 +1076,22 @@ void PlotDock::updateLogScale()
     // Set scale type for X axis
     ui->plotWidget->xAxis->setScaleType(
         m_logScaleX ? QCPAxis::stLogarithmic : QCPAxis::stLinear);
+    ui->plotWidget->xAxis->setTicker(m_logScaleX
+        ? QSharedPointer<QCPAxisTicker>(new QCPAxisTickerLog)
+        : QSharedPointer<QCPAxisTicker>(new QCPAxisTicker));
 
     // Set scale type for both Y axes
     yAxes[0]->setScaleType(
         m_logScaleY ? QCPAxis::stLogarithmic : QCPAxis::stLinear);
+    yAxes[0]->setTicker(m_logScaleY
+        ? QSharedPointer<QCPAxisTicker>(new QCPAxisTickerLog)
+        : QSharedPointer<QCPAxisTicker>(new QCPAxisTicker));
+
     yAxes[1]->setScaleType(
         m_logScaleY ? QCPAxis::stLogarithmic : QCPAxis::stLinear);
+    yAxes[1]->setTicker(m_logScaleY
+        ? QSharedPointer<QCPAxisTicker>(new QCPAxisTickerLog)
+        : QSharedPointer<QCPAxisTicker>(new QCPAxisTicker));
 
     // Log scale breaks on zero/negative values — clamp range minimum to small positive
     if(m_logScaleX && ui->plotWidget->xAxis->range().lower <= 0)

--- a/src/PlotDock.h
+++ b/src/PlotDock.h
@@ -98,6 +98,8 @@ private:
     bool m_showLegend;
     bool m_stackedBars;
     bool m_fixedFormat;
+    bool m_logScaleX;
+    bool m_logScaleY;
     Palette m_graphPalette;
     std::vector<QCPAxis *> yAxes;
     std::vector<int> PlotColumnY;
@@ -112,6 +114,7 @@ private:
     QVariant::Type guessDataType(SqliteTableModel* model, int column) const;
     void adjustBars();
     void adjustAxisFormat();
+    void updateLogScale();
 
 private slots:
     void columnItemChanged(QTreeWidgetItem* item, int column);


### PR DESCRIPTION
Closes #4111

## What this PR does
Adds logarithmic scale support for the X and Y axes in the Plot window,
accessible via two new options in the plot's right-click context menu:
- "Logarithmic scale (X)"
- "Logarithmic scale (Y)"

## Implementation
Follows the same pattern as existing toggleable plot options
(Show legend, Stacked bars, Fixed number format):

- Added `m_logScaleX` and `m_logScaleY` bool members to `PlotDock`
- Added `updateLogScale()` function that calls `QCPAxis::setScaleType()`
  on xAxis, yAxis, and yAxis2
- Added two checkable `QAction` entries to the context menu
- Called `updateLogScale()` after `rescaleAxes()` in `updatePlot()` so
  the scale type is reapplied whenever the plot data changes
- Guards against log(0): clamps axis range minimum to 1e-3 when
  switching to log scale with a non-positive lower bound

## How to test
1. Open a database with numeric data
2. Go to Browse Data → Plot tab
3. Select a numeric column as X and another as Y1
4. Right-click the plot → toggle "Logarithmic scale (Y)"
5. Y axis switches to logarithmic spacing 
6. Toggle off → returns to linear 
7. Same works for "Logarithmic scale (X)" 