### PR TITLE
ci: pin vedantmgoyal9/winget-releaser to a SHA (v2) instead of @main

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -11,7 +11,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: vedantmgoyal9/winget-releaser@main
+      - uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
         with:
           identifier: DBBrowserForSQLite.DBBrowserForSQLite
           installers-regex: '\.msi$'  # Only .msi files


### PR DESCRIPTION
## What this does

`.github/workflows/winget.yml` runs the third-party action `vedantmgoyal9/winget-releaser@main` in the release-publish job that holds `secrets.WINGET_TOKEN` (a PAT for winget-pkgs submissions). This pins it to the `v2` release commit instead of the moving `@main` branch:

```yaml
- uses: vedantmgoyal9/winget-releaser@4ffc7888bffd451b357355dc214d43bb9f23917e # v2
```

## Why

`@main` resolves to whatever that branch's HEAD is at run time. If it were force-moved or compromised (the class of thing that happened with `tj-actions/changed-files` in 2025), the injected code would run with `WINGET_TOKEN` in scope. Every other third-party action in the repo's workflows is already tag-pinned — this was the one on a mutable branch. Pinning to the SHA of the `v2` release keeps behavior identical while making updates deliberate.

One-line change. I confirmed `4ffc788` is the commit the `v2` release tag points to.

---

*Disclosure: I used an AI tool to help spot this and prepare the change; I verified the workflow and the pinned SHA myself and take responsibility for it.*
