### PR TITLE
Update base and other Qt translations for installers

### DIFF
--- a/.github/workflows/cppcmake-ubuntu.yml
+++ b/.github/workflows/cppcmake-ubuntu.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install and cache dependencies
         uses: awalsh128/cache-apt-pkgs-action@v1.6.0
         with:
-          packages: libfuse2 libqcustomplot-dev libqscintilla2-qt5-dev libqt5svg5 ninja-build qttools5-dev
+          packages: libfuse2 libqcustomplot-dev libqscintilla2-qt5-dev libqt5svg5 ninja-build qttools5-dev qttranslations5-l10n
           version: ${{ matrix.os }}
 
       - if: matrix.bundle == 'SQLCipher'
@@ -80,6 +80,61 @@ jobs:
       - name: Tests
         working-directory: ./appbuild
         run: ninja test
+
+      - name: Checkout Missing Translations
+        uses: actions/checkout@v7
+        with:
+          repository: 'qt/qttranslations'
+          ref: '5.15-tr'
+          path: 'src/translations/qttranslations'
+
+          sparse-checkout-cone-mode: false
+
+          sparse-checkout: |
+            /translations/qt_pt_BR.ts
+            /translations/qtbase_pt_BR.ts
+            /translations/qtmultimedia_pt_BR.ts
+            /translations/qtscript_pt_BR.ts
+            /translations/qtxmlpatterns_pt_BR.ts
+            /translations/qt_sv.ts
+            /translations/qtbase_sv.ts
+            /translations/qtmultimedia_sv.ts
+            /translations/qtscript_sv.ts
+            /translations/qtxmlpatterns_sv.ts
+            /translations/qt_zh_CN.ts
+            /translations/qtbase_zh_CN.ts
+            /translations/qtmultimedia_zh_CN.ts
+            /translations/qtscript_zh_CN.ts
+            /translations/qtxmlpatterns_zh_CN.ts
+
+      - name: Compile Missing Translations
+        run: |
+          set -euxo pipefail
+
+          source_dir="$GITHUB_WORKSPACE/src/translations/qttranslations/translations"
+          output_dir="$GITHUB_WORKSPACE/appdir/usr/translations"
+
+          mkdir -p "$output_dir"
+
+          catalogs=(qt qtbase qtmultimedia qtscript qtxmlpatterns)
+          locales=(ar cs de en es fr id it ja ko nl pl pt_BR ro ru sv tr uk zh_CN zh_TW)
+
+          for locale in "${locales[@]}"; do
+            for catalog in "${catalogs[@]}"; do
+              translation="/usr/share/qt5/translations/${catalog}_${locale}.qm"
+              if [[ -f "$translation" ]]; then
+                cp -v "$translation" "$output_dir/"
+              fi
+            done
+          done
+
+          for source in "$source_dir"/*.ts; do
+            output_name="$(basename "${source%.ts}").qm"
+            lrelease "$source" -qm "$output_dir/$output_name"
+          done
+
+          cp -v "$output_dir/qt_zh_CN.qm" \
+                "$output_dir/qt_zh.qm"
 
       - name: Build AppImage
         run: |

--- a/.github/workflows/cppcmake-windows.yml
+++ b/.github/workflows/cppcmake-windows.yml
@@ -57,6 +57,58 @@ jobs:
           cache-key-prefix: "cache"
           version: 5.15.2
 
+      - name: Checkout Missing Translations
+        uses: actions/checkout@v7
+        with:
+          repository: 'qt/qttranslations'
+          ref: '5.15-tr'
+          path: 'src/translations/qttranslations'
+
+          sparse-checkout-cone-mode: false
+
+          sparse-checkout: |
+            translations/qt_pt_BR.ts
+            translations/qtbase_pt_BR.ts
+            translations/qtmultimedia_pt_BR.ts
+            translations/qtscript_pt_BR.ts
+            translations/qtxmlpatterns_pt_BR.ts
+            translations/qt_sv.ts
+            translations/qtbase_sv.ts
+            translations/qtmultimedia_sv.ts
+            translations/qtscript_sv.ts
+            translations/qtxmlpatterns_sv.ts
+            translations/qt_zh_CN.ts
+            translations/qtbase_zh_CN.ts
+            translations/qtmultimedia_zh_CN.ts
+            translations/qtscript_zh_CN.ts
+            translations/qtxmlpatterns_zh_CN.ts
+
+      - name: Compile Missing Translations
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $sourceDir = "$env:GITHUB_WORKSPACE\src\translations\qttranslations\translations"
+          $outputDir = "$env:QT_ROOT_DIR\translations"
+
+          New-Item -ItemType Directory -Force -Path $outputDir | Out-Null
+
+          Get-ChildItem "$sourceDir\*.ts" | ForEach-Object {
+            $outputName = "$($_.BaseName).qm"
+
+            if ($_.BaseName -eq "qt_zh_CN") {
+              $outputName = "qt_zh.qm"
+            }
+
+            & "$env:QT_ROOT_DIR\bin\lrelease.exe" `
+              $_.FullName `
+              -qm (Join-Path $outputDir $outputName)
+
+            if ($LASTEXITCODE -ne 0) {
+              throw "Failed to compile $($_.Name)"
+            }
+          }
+
       - name: Install VS2019
         run: choco install visualstudio2019community --package-parameters "--add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 --add Microsoft.VisualStudio.Component.Windows10SDK.19041 --add Microsoft.VisualStudio.Component.VC.Redist.MSM"
 

--- a/installer/windows/translations.wxs
+++ b/installer/windows/translations.wxs
@@ -20,11 +20,9 @@
             Notes:
                 - Arabic and Turkish are missing their respective "qtxmlpatterns" qm files but seems to work without a problem.
 
-				- Chinese (Taiwan) is missing "qtscript_zh_TW.qm" but seems to work without a problem.
+                - Chinese (Taiwan) is missing "qtscript_zh_TW.qm" but seems to work without a problem.
 
-                - Chinese (China), Portuguese have only one file (qt_<language_code>.qm), so
-                  the default buttons are not translated for these languages.
-
+                - Chinese (China), Brazilian Portuguese and Swedish translations are compiled from the Qt translation sources during the Windows workflow.
             -->
 
             <Directory Id="translations" Name="translations">
@@ -36,7 +34,11 @@
                 <Component><File Source="$(var.QtPath)\translations\qtscript_ar.qm" /></Component>
 
                 <!-- Chinese (China) -->
-                <Component><File Source="$(var.QtPath)\translations\qt_zh_CN.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qt_zh.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtbase_zh_CN.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtmultimedia_zh_CN.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtscript_zh_CN.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtxmlpatterns_zh_CN.qm" /></Component>
 
                 <!-- Chinese (Taiwan) -->
                 <Component><File Source="$(var.QtPath)\translations\qt_zh_TW.qm" /></Component>
@@ -101,7 +103,11 @@
                 <Component><File Source="$(var.QtPath)\translations\qtxmlpatterns_pl.qm" /></Component>
 
                 <!-- Brazilian Portuguese -->
-                <Component><File Source="$(var.QtPath)\translations\qt_pt.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qt_pt_BR.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtbase_pt_BR.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtmultimedia_pt_BR.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtscript_pt_BR.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtxmlpatterns_pt_BR.qm" /></Component>
 
                 <!-- Russian -->
                 <Component><File Source="$(var.QtPath)\translations\qt_ru.qm" /></Component>
@@ -117,6 +123,13 @@
                 <Component><File Source="$(var.QtPath)\translations\qtscript_es.qm" /></Component>
                 <Component><File Source="$(var.QtPath)\translations\qtxmlpatterns_es.qm" /></Component>
 
+                <!-- Swedish -->
+                <Component><File Source="$(var.QtPath)\translations\qt_sv.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtbase_sv.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtmultimedia_sv.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtscript_sv.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtxmlpatterns_sv.qm" /></Component>
+
                 <!-- Turkish -->
                 <Component><File Source="$(var.QtPath)\translations\qt_tr.qm" /></Component>
                 <Component><File Source="$(var.QtPath)\translations\qtbase_tr.qm" /></Component>
@@ -129,7 +142,6 @@
                 <Component><File Source="$(var.QtPath)\translations\qtmultimedia_uk.qm" /></Component>
                 <Component><File Source="$(var.QtPath)\translations\qtscript_uk.qm" /></Component>
                 <Component><File Source="$(var.QtPath)\translations\qtxmlpatterns_uk.qm" /></Component>
-
             </Directory>
 
         </DirectoryRef>
@@ -143,7 +155,11 @@
             <ComponentRef Id="qtscript_ar.qm" />
 
             <!-- Chinese (China) -->
-            <ComponentRef Id="qt_zh_CN.qm" />
+            <ComponentRef Id="qt_zh.qm" />
+            <ComponentRef Id="qtbase_zh_CN.qm" />
+            <ComponentRef Id="qtmultimedia_zh_CN.qm" />
+            <ComponentRef Id="qtscript_zh_CN.qm" />
+            <ComponentRef Id="qtxmlpatterns_zh_CN.qm" />
 
             <!-- Chinese (Taiwan) -->
             <ComponentRef Id="qt_zh_TW.qm" />
@@ -208,7 +224,11 @@
             <ComponentRef Id="qtxmlpatterns_pl.qm" />
 
             <!-- Brazilian Portuguese -->
-            <ComponentRef Id="qt_pt.qm" />
+            <ComponentRef Id="qt_pt_BR.qm" />
+            <ComponentRef Id="qtbase_pt_BR.qm" />
+            <ComponentRef Id="qtmultimedia_pt_BR.qm" />
+            <ComponentRef Id="qtscript_pt_BR.qm" />
+            <ComponentRef Id="qtxmlpatterns_pt_BR.qm" />
 
             <!-- Russian -->
             <ComponentRef Id="qt_ru.qm" />
@@ -224,6 +244,13 @@
             <ComponentRef Id="qtscript_es.qm" />
             <ComponentRef Id="qtxmlpatterns_es.qm" />
 
+            <!-- Swedish -->
+            <ComponentRef Id="qt_sv.qm" />
+            <ComponentRef Id="qtbase_sv.qm" />
+            <ComponentRef Id="qtmultimedia_sv.qm" />
+            <ComponentRef Id="qtscript_sv.qm" />
+            <ComponentRef Id="qtxmlpatterns_sv.qm" />
+
             <!-- Turkish -->
             <ComponentRef Id="qt_tr.qm" />
             <ComponentRef Id="qtbase_tr.qm" />
@@ -236,7 +263,6 @@
             <ComponentRef Id="qtmultimedia_uk.qm" />
             <ComponentRef Id="qtscript_uk.qm" />
             <ComponentRef Id="qtxmlpatterns_uk.qm" />
-
         </ComponentGroup>
 
     </Fragment>

--- a/installer/windows/translations.wxs
+++ b/installer/windows/translations.wxs
@@ -8,7 +8,7 @@
         <DirectoryRef Id='INSTALLDIR'>
 
             <!--
-            Each language requires 6 *.qm files to work properly.
+            Each language requires 5 *.qm files to work properly.
             
             The list of the required files:
                 - qt_<language_code>.qm
@@ -18,12 +18,13 @@
                 - qtxmlpatterns_<language_code>.qm
 
             Notes:
-                - Arabic is missing "qtxmlpatterns_ar.qm" but seems to work without a problem.
+                - Arabic and Turkish are missing their respective "qtxmlpatterns" qm files but seems to work without a problem.
 
-                - Chinese (China), Chinese (Taiwan), and Portuguese have only one file (qt_<language_code>.qm), so
+				- Chinese (Taiwan) is missing "qtscript_zh_TW.qm" but seems to work without a problem.
+
+                - Chinese (China), Portuguese have only one file (qt_<language_code>.qm), so
                   the default buttons are not translated for these languages.
 
-                - Turkish language doesn't have any *.qm files at all, so no default buttons translation also.
             -->
 
             <Directory Id="translations" Name="translations">
@@ -39,6 +40,9 @@
 
                 <!-- Chinese (Taiwan) -->
                 <Component><File Source="$(var.QtPath)\translations\qt_zh_TW.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtbase_zh_TW.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtmultimedia_zh_TW.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtxmlpatterns_zh_TW.qm" /></Component>
 
                 <!-- Czech -->
                 <Component><File Source="$(var.QtPath)\translations\qt_cs.qm" /></Component>
@@ -114,6 +118,10 @@
                 <Component><File Source="$(var.QtPath)\translations\qtxmlpatterns_es.qm" /></Component>
 
                 <!-- Turkish -->
+                <Component><File Source="$(var.QtPath)\translations\qt_tr.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtbase_tr.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtmultimedia_tr.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtscript_tr.qm" /></Component>
 
                 <!-- Ukrainian -->
                 <Component><File Source="$(var.QtPath)\translations\qt_uk.qm" /></Component>
@@ -139,6 +147,9 @@
 
             <!-- Chinese (Taiwan) -->
             <ComponentRef Id="qt_zh_TW.qm" />
+            <ComponentRef Id="qtbase_zh_TW.qm" />
+            <ComponentRef Id="qtmultimedia_zh_TW.qm" />
+            <ComponentRef Id="qtxmlpatterns_zh_TW.qm" />
 
             <!-- Czech -->
             <ComponentRef Id="qt_cs.qm" />
@@ -214,6 +225,10 @@
             <ComponentRef Id="qtxmlpatterns_es.qm" />
 
             <!-- Turkish -->
+            <ComponentRef Id="qt_tr.qm" />
+            <ComponentRef Id="qtbase_tr.qm" />
+            <ComponentRef Id="qtmultimedia_tr.qm" />
+            <ComponentRef Id="qtscript_tr.qm" />
 
             <!-- Ukrainian -->
             <ComponentRef Id="qt_uk.qm" />

--- a/installer/windows_on_arm/translations.wxs
+++ b/installer/windows_on_arm/translations.wxs
@@ -8,18 +8,11 @@
         <DirectoryRef Id='INSTALLDIR'>
 
             <!--
-            Each language requires 5 *.qm files to work properly.
-            
-            The list of the required files:
-                - qt_<language_code>.qm
-                - qtbase_<language_code>.qm
-                - qtmultimedia_<language_code>.qm
-                - qtscript_<language_code>.qm
-                - qtxmlpatterns_<language_code>.qm
+            Qt 6 translations can be either a standalone qt_<language_code>.qm catalog or a meta catalog
+            with qtbase_<language_code>.qm and qtmultimedia_<language_code>.qm dependencies.
 
             Notes:
-                - Chinese (China) and Portuguese have only one file (qt_<language_code>.qm), so
-                  the default buttons are not translated for these languages.
+                - The Chinese (China) Qt catalog is installed as qt_zh.qm to match the DB Browser locale code.
 
             -->
 
@@ -31,7 +24,9 @@
                 <Component><File Source="$(var.QtPath)\translations\qtmultimedia_ar.qm" /></Component>
 
                 <!-- Chinese (China) -->
-                <Component><File Source="$(var.QtPath)\translations\qt_zh_CN.qm" /></Component>
+                <Component Id="qt_zh.qm"><File Source="$(var.QtPath)\translations\qt_zh_CN.qm" Name="qt_zh.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtbase_zh_CN.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtmultimedia_zh_CN.qm" /></Component>
 
                 <!-- Chinese (Taiwan) -->
                 <Component><File Source="$(var.QtPath)\translations\qt_zh_TW.qm" /></Component>
@@ -80,6 +75,8 @@
 
                 <!-- Brazilian Portuguese -->
                 <Component><File Source="$(var.QtPath)\translations\qt_pt_BR.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtbase_pt_BR.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtmultimedia_pt_BR.qm" /></Component>
 
                 <!-- Russian -->
                 <Component><File Source="$(var.QtPath)\translations\qt_ru.qm" /></Component>
@@ -90,6 +87,9 @@
                 <Component><File Source="$(var.QtPath)\translations\qt_es.qm" /></Component>
                 <Component><File Source="$(var.QtPath)\translations\qtbase_es.qm" /></Component>
                 <Component><File Source="$(var.QtPath)\translations\qtmultimedia_es.qm" /></Component>
+
+                <!-- Swedish -->
+                <Component><File Source="$(var.QtPath)\translations\qt_sv.qm" /></Component>
 
                 <!-- Turkish -->
                 <Component><File Source="$(var.QtPath)\translations\qt_tr.qm" /></Component>
@@ -113,7 +113,9 @@
             <ComponentRef Id="qtmultimedia_ar.qm" />
 
             <!-- Chinese (China) -->
-            <ComponentRef Id="qt_zh_CN.qm" />
+            <ComponentRef Id="qt_zh.qm" />
+            <ComponentRef Id="qtbase_zh_CN.qm" />
+            <ComponentRef Id="qtmultimedia_zh_CN.qm" />
 
             <!-- Chinese (Taiwan) -->
             <ComponentRef Id="qt_zh_TW.qm" />
@@ -162,6 +164,8 @@
 
             <!-- Brazilian Portuguese -->
             <ComponentRef Id="qt_pt_BR.qm" />
+            <ComponentRef Id="qtbase_pt_BR.qm" />
+            <ComponentRef Id="qtmultimedia_pt_BR.qm" />
 
             <!-- Russian -->
             <ComponentRef Id="qt_ru.qm" />
@@ -172,6 +176,9 @@
             <ComponentRef Id="qt_es.qm" />
             <ComponentRef Id="qtbase_es.qm" />
             <ComponentRef Id="qtmultimedia_es.qm" />
+
+            <!-- Swedish -->
+            <ComponentRef Id="qt_sv.qm" />
 
             <!-- Turkish -->
             <ComponentRef Id="qt_tr.qm" />

--- a/installer/windows_on_arm/translations.wxs
+++ b/installer/windows_on_arm/translations.wxs
@@ -8,7 +8,7 @@
         <DirectoryRef Id='INSTALLDIR'>
 
             <!--
-            Each language requires 6 *.qm files to work properly.
+            Each language requires 5 *.qm files to work properly.
             
             The list of the required files:
                 - qt_<language_code>.qm
@@ -18,12 +18,9 @@
                 - qtxmlpatterns_<language_code>.qm
 
             Notes:
-                - Arabic is missing "qtxmlpatterns_ar.qm" but seems to work without a problem.
-
-                - Chinese (China), Chinese (Taiwan), and Portuguese have only one file (qt_<language_code>.qm), so
+                - Chinese (China) and Portuguese have only one file (qt_<language_code>.qm), so
                   the default buttons are not translated for these languages.
 
-                - Turkish language doesn't have any *.qm files at all, so no default buttons translation also.
             -->
 
             <Directory Id="translations" Name="translations">
@@ -38,6 +35,8 @@
 
                 <!-- Chinese (Taiwan) -->
                 <Component><File Source="$(var.QtPath)\translations\qt_zh_TW.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtbase_zh_TW.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtmultimedia_zh_TW.qm" /></Component>
 
                 <!-- Czech -->
                 <Component><File Source="$(var.QtPath)\translations\qt_cs.qm" /></Component>
@@ -93,6 +92,9 @@
                 <Component><File Source="$(var.QtPath)\translations\qtmultimedia_es.qm" /></Component>
 
                 <!-- Turkish -->
+                <Component><File Source="$(var.QtPath)\translations\qt_tr.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtbase_tr.qm" /></Component>
+                <Component><File Source="$(var.QtPath)\translations\qtmultimedia_tr.qm" /></Component>
 
                 <!-- Ukrainian -->
                 <Component><File Source="$(var.QtPath)\translations\qt_uk.qm" /></Component>
@@ -115,6 +117,8 @@
 
             <!-- Chinese (Taiwan) -->
             <ComponentRef Id="qt_zh_TW.qm" />
+            <ComponentRef Id="qtbase_zh_TW.qm" />
+            <ComponentRef Id="qtmultimedia_zh_TW.qm" />
 
             <!-- Czech -->
             <ComponentRef Id="qt_cs.qm" />
@@ -170,6 +174,9 @@
             <ComponentRef Id="qtmultimedia_es.qm" />
 
             <!-- Turkish -->
+            <ComponentRef Id="qt_tr.qm" />
+            <ComponentRef Id="qtbase_tr.qm" />
+            <ComponentRef Id="qtmultimedia_tr.qm" />
 
             <!-- Ukrainian -->
             <ComponentRef Id="qt_uk.qm" />


### PR DESCRIPTION
Base qt translations for Turkish, Brazilian Portuguese, Swedish and Chinese (China) were missing or incomplete from windows, win64arm and ubuntu installers.

<img width="1917" height="1020" alt="Screenshot 2026-08-11 210325" src="https://github.com/user-attachments/assets/0bdf932e-4cd3-4a48-819f-5553e098d0cb" />

Updated the translations.wxs files to include missing translation files but installers were still not putting portuguese, swedish and chinese files to translations folder for some reason. So I updated the workflow steps for windows and ubuntu which checkouts the missing qm files from [5.15-tr](https://github.com/qt/qttranslations/tree/5.15-tr) branch of qt translations and then builds them through lrelease and adds them to translations folder. 

Windows on ARM was using Qt 6.8.3 so just updating the translations.wxs for it was enough.

After:
<img width="1917" height="1022" alt="image" src="https://github.com/user-attachments/assets/30eee94e-a9f2-4c05-a823-e5e60e78d45a" />

Partially solves #1626 I think but I couldn't do it for OSX installer but I'm sure the same solution can be done with the macos cmake workflow.
