### PR TITLE
Added a SearchColumnNames button to TableBrowser

### DIFF
--- a/src/TableBrowser.cpp
+++ b/src/TableBrowser.cpp
@@ -1773,7 +1773,10 @@ void TableBrowser::findNextColumn(bool forward, bool checkCurrentColumn)
 
     static int lastFoundIndex = -1;
     auto tryMatch = [&](int i) -> bool
-    {
+    {         
+        if (ui->dataTable->isColumnHidden(i))
+            return false;
+
         const QString columnName = m_model->headerData(i, Qt::Horizontal, Qt::EditRole).toString();
         if (!columnName.contains(searchText, caseSensitivity))
             return false;

--- a/src/TableBrowser.cpp
+++ b/src/TableBrowser.cpp
@@ -309,6 +309,8 @@ TableBrowser::TableBrowser(DBBrowserDB* _db, QWidget* parent) :
     connect(ui->actionFind, &QAction::triggered, this, [this](bool checked) {
        if(checked)
        {
+           ui->frameColumnSearch->hide();
+           ui->actionFindColumn->setChecked(false);
            ui->widgetReplace->hide();
            ui->frameFind->show();
            ui->editFindExpression->setFocus();
@@ -323,6 +325,8 @@ TableBrowser::TableBrowser(DBBrowserDB* _db, QWidget* parent) :
     connect(ui->actionReplace, &QAction::triggered, this, [this](bool checked) {
        if(checked)
        {
+           ui->frameColumnSearch->hide();
+           ui->actionFindColumn->setChecked(false);
            ui->widgetReplace->show();
            ui->frameFind->show();
            ui->editFindExpression->setFocus();
@@ -393,6 +397,39 @@ TableBrowser::TableBrowser(DBBrowserDB* _db, QWidget* parent) :
 
     // Connect slots
     connect(m_model, &SqliteTableModel::finishedFetch, this, &TableBrowser::fetchedData);
+
+    // Set up column search frame
+    ui->frameColumnSearch->hide();
+
+    connect(ui->actionFindColumn, &QAction::triggered, this, [this](bool checked) {
+        if(checked) {
+            ui->frameFind->hide();
+            ui->actionFind->setChecked(false);
+            ui->actionReplace->setChecked(false);
+            ui->frameColumnSearch->show();
+            ui->editColumnSearchExpression->setFocus();
+        } else {
+            ui->frameColumnSearch->hide();
+        } 
+    });
+
+    connect(ui->buttonColumnSearchClose, &QToolButton::clicked, this, [this]() {
+        ui->frameColumnSearch->hide();
+        ui->actionFindColumn->setChecked(false); 
+    });
+
+    connect(ui->editColumnSearchExpression, &QLineEdit::returnPressed, ui->buttonColumnSearchNext, &QToolButton::click);
+    connect(ui->editColumnSearchExpression, &QLineEdit::textChanged, this, [this]() {
+        findNextColumn(true, true); 
+    });
+
+    connect(ui->buttonColumnSearchNext, &QToolButton::clicked, this, [this]() {
+        findNextColumn(true, false); 
+    });
+
+    connect(ui->buttonColumnSearchPrevious, &QToolButton::clicked, this, [this]() {
+        findNextColumn(false, false); 
+    });
 
     // Load initial settings
     reloadSettings();
@@ -1712,6 +1749,74 @@ void TableBrowser::find(const QString& expr, bool forward, bool include_first, R
             ui->editFindExpression->setStyleSheet("QLineEdit {color: white; background-color: rgb(255, 102, 102)}");
     } break;
     }
+}
+
+void TableBrowser::findNextColumn(bool forward, bool checkCurrentColumn)
+{
+    if (!m_model)
+        return;
+
+    const QString searchText = ui->editColumnSearchExpression->text();
+    if (searchText.isEmpty())
+    {
+        ui->editColumnSearchExpression->setStyleSheet(QString());
+        return;
+    }
+
+    const Qt::CaseSensitivity caseSensitivity = ui->checkColumnSearchCaseSensitive->isChecked()
+                                                    ? Qt::CaseSensitive
+                                                    : Qt::CaseInsensitive;
+
+    const int columnCount = m_model->columnCount();
+    if (columnCount <= 0)
+        return;
+
+    static int lastFoundIndex = -1;
+    auto tryMatch = [&](int i) -> bool
+    {
+        const QString columnName = m_model->headerData(i, Qt::Horizontal, Qt::EditRole).toString();
+        if (!columnName.contains(searchText, caseSensitivity))
+            return false;
+
+        lastFoundIndex = i;
+        ui->editColumnSearchExpression->setStyleSheet(QString());
+
+        QModelIndex top = m_model->index(0, i);
+        QModelIndex bottom = m_model->index(m_model->rowCount() - 1, i);
+        ui->dataTable->selectionModel()->select(QItemSelection(top, bottom), 
+            QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Columns);   
+
+        ui->dataTable->horizontalScrollBar()->setValue(ui->dataTable->horizontalHeader()->sectionViewportPosition(i));
+        return true;
+    };
+    
+    if (lastFoundIndex < 0 || lastFoundIndex >= columnCount)
+        lastFoundIndex = forward ? -1 : columnCount;
+    else if (checkCurrentColumn && tryMatch(lastFoundIndex))
+        return;
+
+    if (forward)
+    {
+        for (int i = lastFoundIndex + 1; i < columnCount; i++)
+            if (tryMatch(i))
+                return;
+
+        for (int i = 0; i < lastFoundIndex; i++)
+            if (tryMatch(i))
+                return;
+    }
+    else
+    {
+        for (int i = lastFoundIndex - 1; i >= 0; i--)
+            if (tryMatch(i))
+                return;
+
+        for (int i = columnCount - 1; i > lastFoundIndex; i--)
+            if (tryMatch(i))
+                return;
+    }
+    
+    ui->editColumnSearchExpression->setStyleSheet("QLineEdit {color: white; background-color: rgb(255, 102, 102)}");
 }
 
 void TableBrowser::fetchedData()

--- a/src/TableBrowser.cpp
+++ b/src/TableBrowser.cpp
@@ -32,7 +32,8 @@ TableBrowser::TableBrowser(DBBrowserDB* _db, QWidget* parent) :
     dbStructureModel(nullptr),
     m_model(nullptr),
     m_adjustRows(false),
-    m_columnsResized(false)
+    m_columnsResized(false),
+    m_columnSearchLastFoundIndex(-1)
 {
     ui->setupUi(this);
 
@@ -600,6 +601,9 @@ void TableBrowser::refresh()
     applyModelSettings(storedData, buildQuery(storedData, tablename));
     applyViewportSettings(storedData, tablename);
     emit updatePlot(ui->dataTable, m_model, &m_settings[tablename], true);
+    
+    // Reset the last found index for column search
+    m_columnSearchLastFoundIndex = -1;
 }
 
 void TableBrowser::clearFilters()
@@ -1771,9 +1775,8 @@ void TableBrowser::findNextColumn(bool forward, bool checkCurrentColumn)
     if (columnCount <= 0)
         return;
 
-    static int lastFoundIndex = -1;
     auto tryMatch = [&](int i) -> bool
-    {         
+    {
         if (ui->dataTable->isColumnHidden(i))
             return false;
 
@@ -1781,44 +1784,44 @@ void TableBrowser::findNextColumn(bool forward, bool checkCurrentColumn)
         if (!columnName.contains(searchText, caseSensitivity))
             return false;
 
-        lastFoundIndex = i;
+        m_columnSearchLastFoundIndex = i;
         ui->editColumnSearchExpression->setStyleSheet(QString());
 
         QModelIndex top = m_model->index(0, i);
         QModelIndex bottom = m_model->index(m_model->rowCount() - 1, i);
-        ui->dataTable->selectionModel()->select(QItemSelection(top, bottom), 
-            QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Columns);   
+        ui->dataTable->selectionModel()->select(QItemSelection(top, bottom),
+            QItemSelectionModel::ClearAndSelect | QItemSelectionModel::Columns);
 
         ui->dataTable->horizontalScrollBar()->setValue(ui->dataTable->horizontalHeader()->sectionViewportPosition(i));
         return true;
     };
-    
-    if (lastFoundIndex < 0 || lastFoundIndex >= columnCount)
-        lastFoundIndex = forward ? -1 : columnCount;
-    else if (checkCurrentColumn && tryMatch(lastFoundIndex))
+
+    if (m_columnSearchLastFoundIndex < 0 || m_columnSearchLastFoundIndex >= columnCount)
+        m_columnSearchLastFoundIndex = forward ? -1 : columnCount;
+    else if (checkCurrentColumn && tryMatch(m_columnSearchLastFoundIndex))
         return;
 
     if (forward)
     {
-        for (int i = lastFoundIndex + 1; i < columnCount; i++)
+        for (int i = m_columnSearchLastFoundIndex + 1; i < columnCount; i++)
             if (tryMatch(i))
                 return;
 
-        for (int i = 0; i < lastFoundIndex; i++)
+        for (int i = 0; i < m_columnSearchLastFoundIndex; i++)
             if (tryMatch(i))
                 return;
     }
     else
     {
-        for (int i = lastFoundIndex - 1; i >= 0; i--)
+        for (int i = m_columnSearchLastFoundIndex - 1; i >= 0; i--)
             if (tryMatch(i))
                 return;
 
-        for (int i = columnCount - 1; i > lastFoundIndex; i--)
+        for (int i = columnCount - 1; i > m_columnSearchLastFoundIndex; i--)
             if (tryMatch(i))
                 return;
     }
-    
+
     ui->editColumnSearchExpression->setStyleSheet("QLineEdit {color: white; background-color: rgb(255, 102, 102)}");
 }
 

--- a/src/TableBrowser.h
+++ b/src/TableBrowser.h
@@ -169,6 +169,7 @@ private:
     Palette m_condFormatPalette;
     bool m_adjustRows;
     bool m_columnsResized;
+    int m_columnSearchLastFoundIndex;
 
     void modifySingleFormat(const bool isRowIdFormat, const QString& filter, const QModelIndex refIndex,
                             std::function<void(CondFormat&)> changeFunction);

--- a/src/TableBrowser.h
+++ b/src/TableBrowser.h
@@ -147,8 +147,8 @@ private:
         ReplaceAll,
     };
     void find(const QString& expr, bool forward, bool include_first = false, ReplaceMode replace = ReplaceMode::NoReplace);
+    void findNextColumn(bool forward, bool checkCurrentColumn);
 
-private:
     Ui::TableBrowser* ui;
     QIntValidator* gotoValidator;
     QMenu* popupNewRecordMenu;

--- a/src/TableBrowser.ui
+++ b/src/TableBrowser.ui
@@ -88,6 +88,7 @@
        <addaction name="actionToggleFormatToolbar"/>
        <addaction name="actionFind"/>
        <addaction name="actionReplace"/>
+       <addaction name="actionFindColumn"/>
       </widget>
      </item>
      <item>
@@ -427,6 +428,126 @@
             </size>
            </property>
           </spacer>
+         </item>
+        </layout>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="frameColumnSearch">
+     <property name="maximumSize">
+      <size>
+       <width>16777215</width>
+       <height>62</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QVBoxLayout">
+      <property name="spacing">
+       <number>1</number>
+      </property>
+      <property name="leftMargin">
+       <number>1</number>
+      </property>
+      <property name="topMargin">
+       <number>1</number>
+      </property>
+      <property name="rightMargin">
+       <number>1</number>
+      </property>
+      <property name="bottomMargin">
+       <number>1</number>
+      </property>
+      <item>
+       <widget class="QWidget" name="widgetColumnSearch" native="true">
+        <layout class="QHBoxLayout" name="layoutColumnSearch">
+         <property name="spacing">
+          <number>3</number>
+         </property>
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="topMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLineEdit" name="editColumnSearchExpression">
+           <property name="placeholderText">
+            <string>Enter column name</string>
+           </property>
+           <property name="clearButtonEnabled">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="buttonColumnSearchNext">
+           <property name="toolTip">
+            <string>Find next column</string>
+           </property>
+           <property name="icon">
+            <iconset resource="icons/icons.qrc">
+             <normaloff>:/icons/up</normaloff>:/icons/up</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="buttonColumnSearchPrevious">
+           <property name="toolTip">
+            <string>Find previous column</string>
+           </property>
+           <property name="icon">
+            <iconset resource="icons/icons.qrc">
+             <normaloff>:/icons/down</normaloff>:/icons/down</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="checkColumnSearchCaseSensitive">
+           <property name="text">
+            <string>Case Sensitive</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_columnSearch">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QToolButton" name="buttonColumnSearchClose">
+           <property name="toolTip">
+            <string>Close column search</string>
+           </property>
+           <property name="icon">
+            <iconset resource="icons/icons.qrc">
+             <normaloff>:/icons/close</normaloff>:/icons/close</iconset>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>
@@ -1081,6 +1202,21 @@
    </property>
    <property name="toolTip">
     <string>Replace text in cells</string>
+   </property>
+  </action>
+  <action name="actionFindColumn">
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   <property name="icon">
+    <iconset resource="icons/icons.qrc">
+     <normaloff>:/icons/find_column</normaloff>:/icons/find_column</iconset>
+   </property>
+   <property name="text">
+    <string>Find Column</string>
+   </property>
+   <property name="toolTip">
+    <string>Search for column names</string>
    </property>
   </action>
   <action name="actionFreezeColumns">

--- a/src/TableBrowser.ui
+++ b/src/TableBrowser.ui
@@ -494,24 +494,24 @@
           </widget>
          </item>
          <item>
-          <widget class="QToolButton" name="buttonColumnSearchNext">
-           <property name="toolTip">
-            <string>Find next column</string>
-           </property>
-           <property name="icon">
-            <iconset resource="icons/icons.qrc">
-             <normaloff>:/icons/up</normaloff>:/icons/up</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
           <widget class="QToolButton" name="buttonColumnSearchPrevious">
            <property name="toolTip">
             <string>Find previous column</string>
            </property>
            <property name="icon">
             <iconset resource="icons/icons.qrc">
-             <normaloff>:/icons/down</normaloff>:/icons/down</iconset>
+             <normaloff>:/icons/left</normaloff>:/icons/left</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="buttonColumnSearchNext">
+           <property name="toolTip">
+            <string>Find next column</string>
+           </property>
+           <property name="icon">
+            <iconset resource="icons/icons.qrc">
+             <normaloff>:/icons/right</normaloff>:/icons/right</iconset>
            </property>
           </widget>
          </item>

--- a/src/icons/bullet_arrow_left.svg
+++ b/src/icons/bullet_arrow_left.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="bullet_arrow_left.svg"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs5" />
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="49"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5" />
+  <linearGradient
+     id="a"
+     x1="-3.2071349"
+     x2="2.4053512"
+     y1="-3.1180478"
+     y2="2.4944383"
+     gradientTransform="scale(1.2472191,0.80178373)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#c4c4c4"
+       id="stop1" />
+    <stop
+       offset="1"
+       stop-color="#6f6f6f"
+       id="stop2" />
+  </linearGradient>
+  <linearGradient
+     id="b"
+     x1="-2.1213203"
+     x2="1.4142136"
+     y1="-1.979899"
+     y2="1.5556349"
+     gradientTransform="scale(1.4142136,0.70710678)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#c6c6c6"
+       id="stop3" />
+    <stop
+       offset="1"
+       stop-color="#b1b1b1"
+       id="stop4" />
+  </linearGradient>
+  <g
+     transform="matrix(0,1,1,0,8,8.25)"
+     id="g5">
+    <path
+       d="M -4,2 H 3 V 1 L -0.5,-2.5 -4,1 Z"
+       fill="url(#a)"
+       id="path4"
+       style="fill:url(#a)" />
+    <path
+       d="M -3,1.1 H 2 L -0.5,-1.4 Z"
+       fill="url(#b)"
+       id="path5"
+       style="fill:url(#b)" />
+  </g>
+</svg>

--- a/src/icons/bullet_arrow_right.svg
+++ b/src/icons/bullet_arrow_right.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg5"
+   sodipodi:docname="bullet_arrow_right.svg"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs5" />
+  <sodipodi:namedview
+     id="namedview5"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="49"
+     inkscape:cx="8"
+     inkscape:cy="8"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5" />
+  <linearGradient
+     id="a"
+     x1="-3.2071349"
+     x2="2.4053512"
+     y1="-3.1180478"
+     y2="2.4944383"
+     gradientTransform="scale(1.2472191,0.80178373)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#c4c4c4"
+       id="stop1" />
+    <stop
+       offset="1"
+       stop-color="#6f6f6f"
+       id="stop2" />
+  </linearGradient>
+  <linearGradient
+     id="b"
+     x1="-2.1213203"
+     x2="1.4142136"
+     y1="-1.979899"
+     y2="1.5556349"
+     gradientTransform="scale(1.4142136,0.70710678)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#c6c6c6"
+       id="stop3" />
+    <stop
+       offset="1"
+       stop-color="#b1b1b1"
+       id="stop4" />
+  </linearGradient>
+  <g
+     transform="rotate(90,0,8.25)"
+     id="g5">
+    <path
+       d="M -4,2 H 3 V 1 L -0.5,-2.5 -4,1 Z"
+       fill="url(#a)"
+       id="path4"
+       style="fill:url(#a)" />
+    <path
+       d="M -3,1.1 H 2 L -0.5,-1.4 Z"
+       fill="url(#b)"
+       id="path5"
+       style="fill:url(#b)" />
+  </g>
+</svg>

--- a/src/icons/icons.qrc
+++ b/src/icons/icons.qrc
@@ -8,6 +8,8 @@
         <file alias="down">bullet_arrow_down.svg</file>
         <file alias="arrow_top">bullet_arrow_top.svg</file>
         <file alias="up">bullet_arrow_up.svg</file>
+        <file alias="right">bullet_arrow_right.svg</file>
+        <file alias="left">bullet_arrow_left.svg</file>
         <file alias="cancel">cancel.svg</file>
         <file alias="function">chart_curve.svg</file>
         <file alias="clear_filters">funnel_delete.svg</file>

--- a/src/icons/icons.qrc
+++ b/src/icons/icons.qrc
@@ -48,6 +48,7 @@
         <file alias="field_delete">page_delete.svg</file>
         <file alias="field_edit">page_edit.svg</file>
         <file alias="find">page_find.svg</file>
+        <file alias="find_column">page_find_column.svg</file>
         <file alias="field">page_green.svg</file>
         <file alias="field_key">page_key.svg</file>
         <file alias="browser_open">world_link.svg</file>

--- a/src/icons/page_find_column.svg
+++ b/src/icons/page_find_column.svg
@@ -1,0 +1,518 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   height="16"
+   width="16"
+   version="1.1"
+   id="svg53"
+   sodipodi:docname="page_find_column.svg"
+   inkscape:version="1.4.4 (dcaf3e7d9e, 2026-05-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs53">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#g"
+       id="linearGradient62"
+       x1="-3.72678"
+       y1="0"
+       x2="2.981424"
+       y2="6.7082039"
+       gradientTransform="scale(1.3416408,0.74535599)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#g"
+       id="linearGradient63"
+       x1="-1"
+       y1="0"
+       x2="0"
+       y2="1"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#h"
+       id="linearGradient64"
+       x1="1.2247449"
+       y1="0.81649658"
+       x2="3.6742346"
+       y2="0.81649658"
+       gradientTransform="scale(0.81649658,1.2247449)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#h"
+       id="linearGradient65"
+       x1="-4.8989795"
+       y1="0.81649658"
+       x2="-2.4494897"
+       y2="0.81649658"
+       gradientTransform="scale(0.81649658,1.2247449)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#j"
+       id="linearGradient66"
+       x1="-7.0710678"
+       y1="1.4142136"
+       x2="-5.6568542"
+       y2="1.4142136"
+       gradientTransform="scale(0.70710678,1.4142136)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#j"
+       id="linearGradient67"
+       x1="0"
+       y1="1.4142136"
+       x2="1.4142136"
+       y2="1.4142136"
+       gradientTransform="scale(0.70710678,1.4142136)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#i"
+       id="linearGradient68"
+       x1="-3"
+       y1="2"
+       x2="-1"
+       y2="2"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#i"
+       id="linearGradient69"
+       x1="2"
+       y1="2"
+       x2="4"
+       y2="2"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#n"
+       id="linearGradient70"
+       x1="1.2247449"
+       y1="-2.4494897"
+       x2="3.6742346"
+       y2="0"
+       gradientTransform="scale(0.81649658,1.2247449)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#n"
+       id="linearGradient71"
+       x1="-4.8989795"
+       y1="-2.4494897"
+       x2="-2.4494897"
+       y2="0"
+       gradientTransform="scale(0.81649658,1.2247449)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient72"
+       x1="-1.4142137"
+       x2="1.4142137"
+       y1="14.142136"
+       y2="11.313708"
+       gradientTransform="matrix(2.8284271,0,0,0.35355339,-1,-11)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0"
+         stop-color="#a0d8ff"
+         id="stop10-3" />
+      <stop
+         offset="1"
+         stop-color="#93d4ff"
+         id="stop11-6" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#e"
+       id="linearGradient75"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0,3.5355339,-0.35355339,0,0.9999997,1.1006682e-7)"
+       x1="-1.4142137"
+       y1="14.142136"
+       x2="1.4142137"
+       y2="11.313708" />
+  </defs>
+  <sodipodi:namedview
+     id="namedview53"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showguides="true"
+     inkscape:zoom="45.254834"
+     inkscape:cx="9.5680386"
+     inkscape:cy="7.9991455"
+     inkscape:window-width="1920"
+     inkscape:window-height="995"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg53" />
+  <linearGradient
+     id="a"
+     x1="4.7434165"
+     x2="-4.7434165"
+     y1="-6.3245553"
+     y2="3.1622777"
+     gradientTransform="matrix(1.0540926,0,0,1.2644992,0,1.9973958)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#a0bedc"
+       id="stop1" />
+    <stop
+       offset=".1"
+       stop-color="#b3d2f1"
+       id="stop2" />
+    <stop
+       offset=".5"
+       stop-color="#d5e5fe"
+       id="stop3" />
+  </linearGradient>
+  <linearGradient
+     id="b"
+     x1="2.9512163"
+     x2="6.0008064"
+     y1="-4.0661202"
+     y2="-7.1157103"
+     gradientTransform="scale(1.01653,0.98373875)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#cde6fc"
+       id="stop4" />
+    <stop
+       offset="1"
+       stop-color="#7db2e2"
+       id="stop5" />
+  </linearGradient>
+  <linearGradient
+     id="c"
+     x1="-7.4833148"
+     x2="7.4833148"
+     y1="-7.4833148"
+     y2="7.4833148"
+     gradientTransform="scale(0.93541435,1.069045)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#4f8cc8"
+       id="stop6" />
+    <stop
+       offset="1"
+       stop-color="#2e62b7"
+       id="stop7" />
+  </linearGradient>
+  <linearGradient
+     id="d"
+     x1="-2.7386128"
+     x2="2.7386128"
+     y1="10.954451"
+     y2="5.4772256"
+     gradientTransform="matrix(0.55034242,0,0,2.1901,-3.4928253,-17.99525)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#68bffd"
+       id="stop8" />
+    <stop
+       offset="1"
+       stop-color="#4fb2f7"
+       id="stop9" />
+  </linearGradient>
+  <linearGradient
+     id="e"
+     x1="-1.4142136"
+     x2="1.4142136"
+     y1="14.142136"
+     y2="11.313708"
+     gradientTransform="matrix(2.8284271,0,0,0.35355339,-1,-11)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#a0d8ff"
+       id="stop10" />
+    <stop
+       offset="1"
+       stop-color="#93d4ff"
+       id="stop11" />
+  </linearGradient>
+  <linearGradient
+     id="f"
+     x1="6.4807407"
+     x2="-6.4807407"
+     y1="-6.4807407"
+     y2="6.4807407"
+     gradientTransform="scale(0.9258201,1.0801234)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#fff"
+       id="stop12" />
+    <stop
+       offset="1"
+       stop-color="#eaf1f8"
+       id="stop13" />
+  </linearGradient>
+  <linearGradient
+     id="g"
+     x1="0%"
+     x2="100%"
+     y1="0%"
+     y2="100%">
+    <stop
+       offset="0"
+       stop-color="#767a80"
+       id="stop14" />
+    <stop
+       offset="1"
+       id="stop15" />
+  </linearGradient>
+  <linearGradient
+     id="h"
+     x1="0%"
+     x2="100%"
+     y1="0%"
+     y2="0%">
+    <stop
+       offset="0"
+       stop-color="#86929f"
+       id="stop16" />
+    <stop
+       offset=".33"
+       stop-color="#bac3cc"
+       id="stop17" />
+    <stop
+       offset="1"
+       stop-color="#8b98a6"
+       id="stop18" />
+  </linearGradient>
+  <linearGradient
+     id="i"
+     x1="0%"
+     x2="100%"
+     y1="0%"
+     y2="0%">
+    <stop
+       offset="0"
+       stop-opacity="0"
+       id="stop19" />
+    <stop
+       offset=".2"
+       stop-opacity=".7"
+       id="stop20" />
+    <stop
+       offset="1"
+       id="stop21" />
+  </linearGradient>
+  <linearGradient
+     id="j"
+     x1="0%"
+     x2="100%"
+     y1="0%"
+     y2="0%">
+    <stop
+       offset="0"
+       id="stop22" />
+    <stop
+       offset=".8"
+       stop-opacity=".7"
+       id="stop23" />
+    <stop
+       offset="1"
+       stop-opacity="0"
+       id="stop24" />
+  </linearGradient>
+  <linearGradient
+     id="k"
+     x1="-1.3416408"
+     x2="0.89442719"
+     y1="-2.236068"
+     y2="-2.236068"
+     gradientTransform="scale(2.236068,0.4472136)"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#7b91aa"
+       id="stop25" />
+    <stop
+       offset=".33"
+       stop-color="#94a7ba"
+       id="stop26" />
+    <stop
+       offset="1"
+       stop-color="#7d8d9f"
+       id="stop27" />
+  </linearGradient>
+  <linearGradient
+     id="l"
+     x1="-5"
+     x2="-1"
+     y1="-4"
+     y2="0"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#7d8a96"
+       id="stop28" />
+    <stop
+       offset="1"
+       stop-color="#484f56"
+       id="stop29" />
+  </linearGradient>
+  <linearGradient
+     id="m"
+     x1="0"
+     x2="4"
+     y1="-4"
+     y2="0"
+     gradientUnits="userSpaceOnUse">
+    <stop
+       offset="0"
+       stop-color="#93a0ae"
+       id="stop30" />
+    <stop
+       offset="1"
+       stop-color="#010101"
+       id="stop31" />
+  </linearGradient>
+  <linearGradient
+     id="n"
+     x1="0%"
+     x2="100%"
+     y1="0%"
+     y2="100%">
+    <stop
+       offset="0"
+       stop-color="#9aa0a6"
+       id="stop32" />
+    <stop
+       offset="1"
+       stop-color="#5e6770"
+       id="stop33" />
+  </linearGradient>
+  <g
+     transform="translate(7,8)"
+     id="g39">
+    <path
+       d="m 0,-8 h -6 a 1,1 0 0 0 -1,1 V 7 a 1,1 0 0 0 1,1 H 6 A 1,1 0 0 0 7,7 V -4.5 L 3.5,-8 H -1 Z"
+       fill="url(#c)"
+       id="path33"
+       style="fill:url(#c)" />
+    <path
+       d="M 0,-7 H -6 V 7 H 6 V -4 L 3,-7 Z"
+       fill="url(#f)"
+       id="path34"
+       style="fill:url(#f)" />
+    <path
+       d="M 0,-6 H -5 V 5.9960937 H 5 V -3.3342014 L 3,-6 H 1 Z"
+       fill="url(#a)"
+       id="path35"
+       style="fill:url(#a);stroke-width:1.15451" />
+    <path
+       d="m 2,-7 h 1 l 3,3 v 1 H 2 Z"
+       fill="#ffffff"
+       id="path36" />
+    <path
+       d="m 3,-7 h 0.1 l 3,3 H 3 Z"
+       fill="url(#b)"
+       id="path37"
+       style="fill:url(#b)" />
+    <path
+       d="m -5,-5.9995777 h 3.0143495 V 5.9960937 H -5 Z"
+       fill="url(#d)"
+       id="path38"
+       style="fill:url(#d);stroke-width:1.09787" />
+    <path
+       d="M -3,-5 V 5 H -4 V -5 Z"
+       fill="url(#e)"
+       id="path39-5-1"
+       style="fill:url(#linearGradient75);stroke-width:1.11803" />
+  </g>
+  <g
+     transform="translate(12,9.9960937)"
+     id="g53">
+    <path
+       d="M 0,0 H 4 V 4.5 A 0.5,0.5 0 0 1 3.5,5 h -3 A 0.5,0.5 0 0 1 0,4.5 Z M -1,0 H -5 V 4.5 A 0.5,0.5 0 0 0 -4.5,5 h 3 A 0.5,0.5 0 0 0 -1,4.5 Z"
+       fill="url(#g)"
+       id="path40"
+       style="fill:url(#linearGradient62)" />
+    <path
+       d="M -1,0 H 0 V 1 H -1 Z"
+       fill="url(#g)"
+       id="path41"
+       style="fill:url(#linearGradient63)" />
+    <path
+       d="M 1,1 H 3 V 4 H 1 Z"
+       fill="url(#h)"
+       id="path42"
+       style="fill:url(#linearGradient64)" />
+    <path
+       d="m -4,1 h 2 v 3 h -2 z"
+       fill="url(#h)"
+       id="path43"
+       style="fill:url(#linearGradient65)" />
+    <path
+       d="m -5,2 h 1 v 2 h -1 z"
+       fill="url(#j)"
+       opacity="0.3"
+       id="path44"
+       style="fill:url(#linearGradient66)" />
+    <path
+       d="M 0,2 H 1 V 4 H 0 Z"
+       fill="url(#j)"
+       opacity="0.3"
+       id="path45"
+       style="fill:url(#linearGradient67)" />
+    <path
+       d="m -3,2 h 2 v 2 h -2 z"
+       fill="url(#i)"
+       opacity="0.3"
+       id="path46"
+       style="fill:url(#linearGradient68)" />
+    <path
+       d="M 2,2 H 4 V 4 H 2 Z"
+       fill="url(#i)"
+       opacity="0.3"
+       id="path47"
+       style="fill:url(#linearGradient69)" />
+    <path
+       d="m 0,0 v -4 h 2 v 1 c 0,1 2,1 2,3"
+       fill="url(#m)"
+       id="path48"
+       style="fill:url(#m)" />
+    <path
+       d="M 1,0 V -3 H 1.5 C 1.5,-1.5 3,-2 3,0"
+       fill="url(#n)"
+       id="path49"
+       style="fill:url(#linearGradient70)" />
+    <path
+       d="m -1,0 v -4 h -2 v 1 c 0,1 -2,1 -2,3"
+       fill="url(#l)"
+       id="path50"
+       style="fill:url(#l)" />
+    <path
+       d="m -2,0 v -3 h -0.5 c 0,1.5 -1.5,1 -1.5,3"
+       fill="url(#n)"
+       id="path51"
+       style="fill:url(#linearGradient71)" />
+    <path
+       d="M -3,-1 H 2 V 0 H -3 Z"
+       fill="url(#k)"
+       id="path52"
+       style="fill:url(#k)" />
+    <path
+       d="M -3,-1 H 2 V 0 H -3 Z"
+       fill="none"
+       id="path53" />
+  </g>
+</svg>


### PR DESCRIPTION
This pull request is in regards to: https://github.com/sqlitebrowser/sqlitebrowser/issues/3542.

Added a SearchColumnNames button to the TableBrowser. The button is placed next to the FindReplaceButton.
<img width="602" height="163" alt="image" src="https://github.com/user-attachments/assets/7c5f1523-bf3b-4f87-88ae-0e6cd9b06d67" />
The button icon was created by using Inkscape to modify the page_find.svg, to ensure it would be of the same style as the other buttons.

When the SearchColumnNames button is pressed so will it open a dialog box that is almost the same as the FindDialogBox, so it would not make the UI inconsistent (and its simpler to copy code and just change its text and refrences)
<img width="857" height="465" alt="image" src="https://github.com/user-attachments/assets/8eb6b182-53f8-404f-931b-ed42bc0a3087" />
The search functionality is modeled after how the FindSearch funktions and I think its a 1 to 1 in how it behaves, except that I made it highlight the full column instead of a individual cell.
<img width="744" height="430" alt="image" src="https://github.com/user-attachments/assets/5b8f16a6-a306-4721-8c19-67c8ee3ac76b" />

